### PR TITLE
Initialize average in statistics

### DIFF
--- a/src/sc_statistics.c
+++ b/src/sc_statistics.c
@@ -85,6 +85,7 @@ sc_stats_init (sc_statinfo_t * stats, const char *variable)
   stats->count = 0;
   stats->sum_values = stats->sum_squares = 0.;
   stats->min = stats->max = 0.;
+  stats->average = 0.;
   stats->variable = variable;
 }
 


### PR DESCRIPTION
This avoids calling snprintf with uninitialized average values when
printing statistics that are never filled.