### PR TITLE
Add missing m4 files to be installed w/ libsc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,9 @@ dist_scaclocal_DATA = \
         config/sc_c_version.m4 config/sc_cuda.m4 config/sc_include.m4 \
         config/sc_lapack.m4 config/sc_lint.m4 config/sc_mpi.m4 \
         config/ax_prefix_config_h.m4 config/ax_split_version.m4 \
-        config/sc_package.m4 config/sc_trilinos.m4
+        config/sc_package.m4 config/sc_trilinos.m4 config/sc_pthread.m4 \
+		config/sc_openmp.m4 config/sc_memalign.m4
+
 
 # install example .ini files in a dedicated directory
 scinidir = $(datadir)/ini


### PR DESCRIPTION
Hello, 
in the process of providing packages for p4est in [easybuild](https://easybuild.readthedocs.io/en/latest/) I created two packages: one for `libsc`, and one for `p4est` where the `boostrap.sh` script takes the source dir of `libsc`. 

The problem I encountered is that the install script for `libsc` doesn't install all the macro files in the install prefix `$PREFIX/share/aclocal`. I suppose it is a bug... 

This patch fixes that. 