### PR TITLE
Ref count bypass

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ echo "o---------------------------------------"
 echo "| Checking functions"
 echo "o---------------------------------------"
 
-AC_CHECK_FUNCS([backtrace backtrace_symbols strtol strtoll])
+AC_CHECK_FUNCS([backtrace backtrace_symbols strtol strtoll qsort_r])
 
 echo "o---------------------------------------"
 echo "| Checking libraries"

--- a/src/sc.c
+++ b/src/sc.c
@@ -534,12 +534,16 @@ sc_malloc (int package, size_t size)
 #ifdef SC_ENABLE_PTHREAD
   sc_package_lock (package);
 #endif
+
+#ifndef SC_NOCOUNT_MALLOC
   if (size > 0) {
     ++*malloc_count;
   }
   else {
     *malloc_count += ((ret == NULL) ? 0 : 1);
   }
+#endif
+
 #ifdef SC_ENABLE_PTHREAD
   sc_package_unlock (package);
 #endif
@@ -569,12 +573,16 @@ sc_calloc (int package, size_t nmemb, size_t size)
 #ifdef SC_ENABLE_PTHREAD
   sc_package_lock (package);
 #endif
+
+#ifndef SC_NOCOUNT_MALLOC
   if (nmemb * size > 0) {
     ++*malloc_count;
   }
   else {
     *malloc_count += ((ret == NULL) ? 0 : 1);
   }
+#endif
+
 #ifdef SC_ENABLE_PTHREAD
   sc_package_unlock (package);
 #endif
@@ -637,7 +645,11 @@ sc_free (int package, void *ptr)
 #ifdef SC_ENABLE_PTHREAD
     sc_package_lock (package);
 #endif
+
+#ifndef SC_NOCOUNT_MALLOC
     ++*free_count;
+#endif
+
 #ifdef SC_ENABLE_PTHREAD
     sc_package_unlock (package);
 #endif

--- a/src/sc_sort.h
+++ b/src/sc_sort.h
@@ -28,14 +28,25 @@
 
 SC_EXTERN_C_BEGIN;
 
-/** Sort a distributed set of values in parallel.
+/** Sort a distributed set of fixed-size data items in parallel.
  * This algorithm uses bitonic sort between processors and qsort locally.
+ *
+ * This function is thread-safe if src/sc_config.h #defines SC_HAVE_QSORT_R.
+ * Otherwise, it uses a static read-only variable for the comparison function,
+ * and calling \ref sc_psort concurrently is likely to fail.
+ *
  * The partition of the data can be arbitrary and is not changed.
+ *
  * \param [in] mpicomm          Communicator to use.
- * \param [in] base             Pointer to the local subset of data.
- * \param [in] nmemb            Array of mpisize counts of local data.
- * \param [in] size             Size in bytes of each data value.
- * \param [in] compar           Comparison function to use.
+ * \param [in] base             Pointer to the process-local data items.
+ * \param [in] nmemb            Array of mpisize counts of data items.  For
+ *                              each process, the number of its local items.
+ *                              This array must be identical on all processes.
+ * \param [in] size             Size in bytes of one data item.
+ * \param [in] compar           Comparison function to use; see man (3) qsort.
+ *                              Shall return < 0 if the first argument is less
+ *                              than the second, 0 if both are equal, and > 0
+ *                              if the first is greater than the second.
  */
 void                sc_psort (sc_MPI_Comm mpicomm, void *base,
                               size_t * nmemb, size_t size,


### PR DESCRIPTION
Added ability to skip reference counting in `sc_malloc`, `sc_calloc` and `sc_free` if `DSC_NOCOUNT_MALLOC` is defined. This is useful when multithreading without using `--enable-pthread`, because without using pthreads the aforementioned functions are not thread safe.