### PR TITLE
test/test_dmatrix - Increase tolerance and make test more robust

### DIFF
--- a/test/test_dmatrix.c
+++ b/test/test_dmatrix.c
@@ -73,7 +73,7 @@ test_dmatrix_check_error_identical (const sc_dmatrix_t * mat_chk,
   SC_ASSERT (totalsize == mat_ref->m * mat_ref->n);
 
   for (i = 0; i < totalsize; ++i) {
-    if (DBL_MIN < fabs (mat_chk_data[i] - mat_ref_data[i])) {
+    if (1.e4 * DBL_EPSILON < fabs (mat_chk_data[i] - mat_ref_data[i])) {
       error_count++;
     }
   }


### PR DESCRIPTION
It turns out that on non-amd64 architectures the test test_dmatrix fails
due to differences in the compared matrices larger than floating point
roundoff errors [1]. Changing the limit from DBL_MIN to 1.0e4 *
DBL_EPSILON [2] (assuming that differences are indeed of the order of
eps) fixes the problem .
    
[1] https://launchpad.net/~ginggs/+archive/ubuntu/testing/+sourcepub/10330424/+listing-archive-extra
[2] https://en.cppreference.com/w/c/types/limits
