### PR TITLE
sc_psort issue

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -45,6 +45,10 @@ typedef void        (*sc_sig_t) (int);
 #include <pthread.h>
 #endif
 
+#ifdef SC_HAVE_TIME_H
+#include <time.h>
+#endif
+
 typedef struct sc_package
 {
   int                 is_registered;
@@ -290,6 +294,15 @@ sc_log_handler (FILE * log_stream, const char *filename, int lineno,
     bp = basename (bn);
     fprintf (log_stream, "%s:%d ", bp, lineno);
   }
+
+  #ifdef SC_HAVE_TIME_H
+    time_t t = time(NULL);
+    struct tm tm = *localtime(&t);
+
+    char tst[BUFSIZ];
+    snprintf(tst,BUFSIZ,"[%d-%d-%d %d:%d:%d] ", tm.tm_year + 1900, tm.tm_mon + 1,tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
+    fputs (tst, log_stream);
+  #endif
 
   fputs (msg, log_stream);
   fflush (log_stream);


### PR DESCRIPTION
there are two commits in the new branch:

1) making minor changes and activate test/test_sort.c -->  the changes activate the test and with some minor polish. The test is fine and sc_psort works as expected. 

2) adding time and date to the logger --> this commit adds date and time to the logger. I found it very useful when I run a job in a cluster. This gives a relatively good execution timing and in cases that the job fails may help in finding the cause by tracing back the time. The output would be like the following:
[libsc 7] **[2020-4-4 23:46:43]**     47.9      48    48.1    48.3    48.5    49.3    49.8



