### PR TITLE
mini autotools update for lua53

### DIFF
--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -281,7 +281,7 @@ AC_DEFUN([SC_CHECK_LIBRARIES],
 [
 SC_REQUIRE_LIB([m], [fabs])
 SC_CHECK_LIB([z], [adler32_combine], [ZLIB], [$1])
-SC_CHECK_LIB([lua52 lua5.2 lua51 lua5.1 lua lua5], [lua_createtable],
+SC_CHECK_LIB([lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 lua lua5], [lua_createtable],
 	     [LUA], [$1])
 SC_CHECK_BLAS_LAPACK([$1])
 SC_BUILTIN_ALL_PREFIX([$1])


### PR DESCRIPTION
update AC_CHECK_LIB for lua to check the same lua versions as in AC_CHECK_HEADERS