### PR TITLE
add functions returning the full/major/minor version of libsc

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -1508,4 +1508,22 @@ sc_snprintf (char *str, size_t size, const char *fmt, ...)
   va_end (ap);
 }
 
+const char*
+sc_version (void)
+{
+  return SC_VERSION;
+}
+
+int
+sc_version_major (void)
+{
+  return SC_VERSION_MAJOR;
+}
+
+int
+sc_version_minor (void)
+{
+  return SC_VERSION_MINOR;
+}
+
 #endif

--- a/src/sc.h
+++ b/src/sc.h
@@ -729,6 +729,27 @@ void                sc_snprintf (char *str, size_t size,
                                  const char *format, ...)
   __attribute__((format (printf, 3, 4)));
 
+/** Return the full version of libsc.
+ *
+ * \return          Return the version of libsc using the format
+ *                  `VERSION_MAJOR.VERSION_MINOR.VERSION_POINT`,
+ *                  where `VERSION_POINT` can contain dots and
+ *                  characters, e.g. to indicate the git commit.
+ */
+const char*         sc_version (void);
+
+/** Return the major version of libsc.
+ *
+ * \return          Return the major version of libsc.
+ */
+int                 sc_version_major (void);
+
+/** Return the minor version of libsc.
+ *
+ * \return          Return the minor version of libsc.
+ */
+int                 sc_version_minor (void);
+
 SC_EXTERN_C_END;
 
 #endif /* SC_H */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -14,7 +14,8 @@ sc_test_programs = \
         test/sc_test_reduce \
         test/sc_test_search \
         test/sc_test_sort \
-        test/sc_test_sortb
+        test/sc_test_sortb \
+        test/sc_test_version
 ## Reenable and properly verify pqueue when it is actually used
 ##      test/sc_test_pqueue \
 
@@ -33,6 +34,7 @@ test_sc_test_reduce_SOURCES = test/test_reduce.c
 test_sc_test_search_SOURCES = test/test_search.c
 test_sc_test_sort_SOURCES = test/test_sort.c
 test_sc_test_sortb_SOURCES = test/test_sortb.c
+test_sc_test_version_SOURCES = test/test_version.c
 
 TESTS += $(sc_test_programs)
 
@@ -47,4 +49,5 @@ LINT_CSOURCES += \
         $(test_sc_test_reduce_SOURCES) \
         $(test_sc_test_search_SOURCES) \
         $(test_sc_test_sort_SOURCES) \
-        $(test_sc_test_sortb_SOURCES)
+        $(test_sc_test_sortb_SOURCES) \
+        $(test_sc_test_version_SOURCES)

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -1,0 +1,73 @@
+/*
+  This file is part of the SC Library.
+  The SC Library provides support for parallel scientific applications.
+
+  Copyright (C) 2010 The University of Texas System
+  Additional copyright (C) 2011 individual authors
+
+  The SC Library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  The SC Library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General Public
+  License along with the SC Library; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+*/
+
+#include <sc.h>
+#include <stdio.h>
+#include <string.h>
+
+int
+main (int argc, char **argv)
+{
+  int                 mpiret;
+  sc_MPI_Comm         mpicomm;
+  int                 num_failed_tests;
+  int                 version_major, version_minor;
+  const char         *version;
+  char                version_tmp[32];
+
+  /* standard initialization */
+  mpiret = sc_MPI_Init (&argc, &argv);
+  SC_CHECK_MPI (mpiret);
+  mpicomm = sc_MPI_COMM_WORLD;
+
+  sc_init (mpicomm, 1, 1, NULL, SC_LP_DEFAULT);
+
+  /* check all functions related to version numbers of libsc */
+  num_failed_tests = 0;
+  version = sc_version ();
+  SC_GLOBAL_LDEBUGF ("Full SC version: %s\n", version);
+
+  version_major = sc_version_major ();
+  SC_GLOBAL_LDEBUGF ("Major SC version: %d\n", version_major);
+  snprintf (version_tmp, 32, "%d", version_major);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for major version of SC\n");
+    num_failed_tests++;
+  }
+
+  version_minor = sc_version_minor ();
+  SC_GLOBAL_LDEBUGF ("Minor SC version: %d\n", version_minor);
+  snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for minor version of SC\n");
+    num_failed_tests++;
+  }
+
+  /* clean up and exit */
+  sc_finalize ();
+
+  mpiret = sc_MPI_Finalize ();
+  SC_CHECK_MPI (mpiret);
+
+  return num_failed_tests ? 1 : 0;
+}


### PR DESCRIPTION
I've added three functions `sc_version`, `sc_version_major`, `sc_version_minor` which can be used to get the full/major/minor version of libsc. This can be useful for wrappers of `p4est`/`libsc` when a custom build of the library shall be used and corresponding headers/interfaces need to be determined.

I decided to write three functions and not a single one returning the combined version as an integer, since the point version can contain dots and characters, e.g. to indicate a git commit. Nevertheless, it might be useful to get the full version of `libsc`, which has to be a string. On the other hand, applications checking version numbers will often just check the major (and maybe minor) version numbers. Hence, it's convenient to have direct access to this information, too. 

Since this is my first PR to `p4est`/`libsc`, I would like to get your feedback to improve it. Please, tell me whether the target branch `prev3-develop` is correct or whether I shall switch the target branch. You are also welcome to edit my branch `hr/version_functions` in my fork of `libsc`. I've checked the corresponding GitHub option to give you write access to the branch used for this PR in my fork of the repo.

All tests (including the new ones) pass locally on my computer.
```
PASS: test/sc_test_arrays
PASS: test/sc_test_builtin
PASS: test/sc_test_allgather
PASS: test/sc_test_io_sink
PASS: test/sc_test_keyvalue
PASS: test/sc_test_node_comm
PASS: test/sc_test_notify
PASS: test/sc_test_reduce
PASS: test/sc_test_search
PASS: test/sc_test_sort
PASS: test/sc_test_sortb
PASS: test/sc_test_version
============================================================================
Testsuite summary for libsc 2.8.1.57-a813
============================================================================
# TOTAL: 12
# PASS:  12
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```

If you agree with this approach and code, I can also prepare similar functions for `p4est`.