### PR TITLE
Feature version functions

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -39,9 +39,6 @@ typedef void        (*sc_sig_t) (int);
 #endif
 #endif
 
-#include <errno.h>
-#include <stdlib.h>
-
 #ifdef SC_ENABLE_PTHREAD
 #include <pthread.h>
 #endif
@@ -1469,14 +1466,15 @@ sc_version_minor (void)
 }
 
 /* Define helper macros temporally to convert the point version */
-#define _TOSTRING(x) #x
-#define TOSTRING(x) _TOSTRING(x)
+#define _SC_TOSTRING(x) #x
+#define SC_TOSTRING(x) _SC_TOSTRING(x)
 
 int
 sc_version_point (void)
 {
-  /* SC_VERSION_POINT may contain a dot and/or dash, followed by additional information */
-  return strtol (TOSTRING (SC_VERSION_POINT), NULL, 10);
+  /* SC_VERSION_POINT may contain a dot and/or dash,
+     followed by additional information */
+  return atoi (SC_TOSTRING (SC_VERSION_POINT));
 }
 
 #undef TOSTRING

--- a/src/sc.c
+++ b/src/sc.c
@@ -40,6 +40,7 @@ typedef void        (*sc_sig_t) (int);
 #endif
 
 #include <errno.h>
+#include <stdlib.h>
 
 #ifdef SC_ENABLE_PTHREAD
 #include <pthread.h>
@@ -1466,5 +1467,19 @@ sc_version_minor (void)
 {
   return SC_VERSION_MINOR;
 }
+
+/* Define helper macros temporally to convert the point version */
+#define _TOSTRING(x) #x
+#define TOSTRING(x) _TOSTRING(x)
+
+int
+sc_version_point (void)
+{
+  /* SC_VERSION_POINT may contain a dot and/or dash, followed by additional information */
+  return strtol(TOSTRING(SC_VERSION_POINT), NULL, 10);
+}
+
+#undef TOSTRING
+#undef _TOSTRING
 
 #endif

--- a/src/sc.c
+++ b/src/sc.c
@@ -1476,7 +1476,7 @@ int
 sc_version_point (void)
 {
   /* SC_VERSION_POINT may contain a dot and/or dash, followed by additional information */
-  return strtol(TOSTRING(SC_VERSION_POINT), NULL, 10);
+  return strtol (TOSTRING (SC_VERSION_POINT), NULL, 10);
 }
 
 #undef TOSTRING

--- a/src/sc.h
+++ b/src/sc.h
@@ -709,7 +709,8 @@ void                sc_snprintf (char *str, size_t size,
  * \return          Return the version of libsc using the format
  *                  `VERSION_MAJOR.VERSION_MINOR.VERSION_POINT`,
  *                  where `VERSION_POINT` can contain dots and
- *                  characters, e.g. to indicate the git commit.
+ *                  characters, e.g. to indicate the additional
+ *                  number of commits and a git commit hash.
  */
 const char         *sc_version (void);
 
@@ -724,6 +725,14 @@ int                 sc_version_major (void);
  * \return          Return the minor version of libsc.
  */
 int                 sc_version_minor (void);
+
+/** Return the point version of libsc.
+ *
+ * \return          Return the (first part of the) point version of libsc,
+ *                  without information about the additional number of commits
+ *                  and commit hash.
+ */
+int                 sc_version_point (void);
 
 SC_EXTERN_C_END;
 

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -65,7 +65,8 @@ main (int argc, char **argv)
 
   version_point = sc_version_point ();
   SC_GLOBAL_LDEBUGF ("Point SC version: %d\n", version_point);
-  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor, version_point);
+  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor,
+            version_point);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
     SC_VERBOSE ("Test failure for point version of SC\n");
     num_failed_tests++;

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -31,7 +31,7 @@ main (int argc, char **argv)
   int                 mpiret;
   sc_MPI_Comm         mpicomm;
   int                 num_failed_tests;
-  int                 version_major, version_minor;
+  int                 version_major, version_minor, version_point;
   const char         *version;
   char                version_tmp[32];
 
@@ -60,6 +60,14 @@ main (int argc, char **argv)
   snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
     SC_VERBOSE ("Test failure for minor version of SC\n");
+    num_failed_tests++;
+  }
+
+  version_point = sc_version_point ();
+  SC_GLOBAL_LDEBUGF ("Point SC version: %d\n", version_point);
+  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor, version_point);
+  if (strncmp (version, version_tmp, strlen (version_tmp))) {
+    SC_VERBOSE ("Test failure for point version of SC\n");
     num_failed_tests++;
   }
 


### PR DESCRIPTION
This is a follow-up of #24. I implemented a function `sc_version_point` as discussed earlier today, ran `scindent` (discarding changes to `__attribute__`), and verified that tests pass locally (including the new one).