### PR TITLE
Feature version functions

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -1465,10 +1465,6 @@ sc_version_minor (void)
   return SC_VERSION_MINOR;
 }
 
-/* Define helper macros temporally to convert the point version */
-#define _SC_TOSTRING(x) #x
-#define SC_TOSTRING(x) _SC_TOSTRING(x)
-
 int
 sc_version_point (void)
 {
@@ -1476,8 +1472,5 @@ sc_version_point (void)
      followed by additional information */
   return atoi (SC_TOSTRING (SC_VERSION_POINT));
 }
-
-#undef TOSTRING
-#undef _TOSTRING
 
 #endif

--- a/src/sc.c
+++ b/src/sc.c
@@ -1465,6 +1465,7 @@ sc_version_minor (void)
   return SC_VERSION_MINOR;
 }
 
+#if 0
 int
 sc_version_point (void)
 {
@@ -1472,5 +1473,6 @@ sc_version_point (void)
      followed by additional information */
   return atoi (SC_TOSTRING (SC_VERSION_POINT));
 }
+#endif
 
 #endif

--- a/src/sc.h
+++ b/src/sc.h
@@ -481,6 +481,12 @@ void                SC_LERRORF (const char *fmt, ...)
   SC_LOGF (SC_LP_ERROR, (fmt), __VA_ARGS__)
 #endif
 
+/* Macros used to convert a macro definition such as the point version
+ * to a string
+ */
+#define _SC_TOSTRING(x) #x
+#define SC_TOSTRING(x) _SC_TOSTRING(x)
+
 /* callback typedefs */
 
 typedef void        (*sc_handler_t) (void *data);

--- a/src/sc.h
+++ b/src/sc.h
@@ -732,6 +732,9 @@ int                 sc_version_major (void);
  */
 int                 sc_version_minor (void);
 
+#if 0
+/* Sadly, the point version macro by autoconf doesn't work with vX and vX.Y.
+   The remaining option is to use sc_version and parse its return string. */
 /** Return the point version of libsc.
  *
  * \return          Return the (first part of the) point version of libsc,
@@ -739,6 +742,7 @@ int                 sc_version_minor (void);
  *                  and commit hash.
  */
 int                 sc_version_point (void);
+#endif /* 0 */
 
 SC_EXTERN_C_END;
 

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -2,23 +2,29 @@
   This file is part of the SC Library.
   The SC Library provides support for parallel scientific applications.
 
-  Copyright (C) 2010 The University of Texas System
-  Additional copyright (C) 2011 individual authors
+  Copyright (C) 2020 individual authors
 
-  The SC Library is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation; either
-  version 2.1 of the License, or (at your option) any later version.
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
 
-  The SC Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
+  1. Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
 
-  You should have received a copy of the GNU Lesser General Public
-  License along with the SC Library; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-  02110-1301, USA.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <sc.h>

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -37,7 +37,7 @@ main (int argc, char **argv)
   int                 mpiret;
   sc_MPI_Comm         mpicomm;
   int                 num_failed_tests;
-  int                 version_major, version_minor, version_point;
+  int                 version_major, version_minor;
   const char         *version;
   char                version_tmp[32];
 
@@ -66,15 +66,6 @@ main (int argc, char **argv)
   snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
     SC_VERBOSE ("Test failure for minor version of SC\n");
-    num_failed_tests++;
-  }
-
-  version_point = sc_version_point ();
-  SC_GLOBAL_LDEBUGF ("Point SC version: %d\n", version_point);
-  snprintf (version_tmp, 32, "%d.%d.%d", version_major, version_minor,
-            version_point);
-  if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for point version of SC\n");
     num_failed_tests++;
   }
 

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -51,21 +51,21 @@ main (int argc, char **argv)
   /* check all functions related to version numbers of libsc */
   num_failed_tests = 0;
   version = sc_version ();
-  SC_GLOBAL_LDEBUGF ("Full SC version: %s\n", version);
+  SC_GLOBAL_LDEBUGF ("Full libsc version: %s\n", version);
 
   version_major = sc_version_major ();
-  SC_GLOBAL_LDEBUGF ("Major SC version: %d\n", version_major);
+  SC_GLOBAL_LDEBUGF ("Major libsc version: %d\n", version_major);
   snprintf (version_tmp, 32, "%d", version_major);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for major version of SC\n");
+    SC_GLOBAL_VERBOSE ("Test failure for major version of libsc\n");
     num_failed_tests++;
   }
 
   version_minor = sc_version_minor ();
-  SC_GLOBAL_LDEBUGF ("Minor SC version: %d\n", version_minor);
+  SC_GLOBAL_LDEBUGF ("Minor libsc version: %d\n", version_minor);
   snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
   if (strncmp (version, version_tmp, strlen (version_tmp))) {
-    SC_VERBOSE ("Test failure for minor version of SC\n");
+    SC_GLOBAL_VERBOSE ("Test failure for minor version of libsc\n");
     num_failed_tests++;
   }
 


### PR DESCRIPTION
As discussed in https://github.com/cburstedde/libsc/pull/25, I've
- moved the definition of `SC_TOSTRING` to `sc.h`
- updated the license header of `test/test_version.c`