### PR TITLE
Make SC3_REFCOUNT_MAGIC long as it is used in code

### DIFF
--- a/src/sc3_refcount.c
+++ b/src/sc3_refcount.c
@@ -33,7 +33,7 @@ int
 sc3_refcount_is_valid (const sc3_refcount_t * r, char *reason)
 {
   SC3E_TEST (r != NULL, reason);
-  SC3E_TEST (r->magic == SC3_REFCOUNT_MAGIC, reason);
+  SC3E_TEST (r->magic == (long) SC3_REFCOUNT_MAGIC, reason);
   SC3E_TEST (r->rc >= 1, reason);
   SC3E_YES (reason);
 }

--- a/src/sc3_refcount.c
+++ b/src/sc3_refcount.c
@@ -33,7 +33,7 @@ int
 sc3_refcount_is_valid (const sc3_refcount_t * r, char *reason)
 {
   SC3E_TEST (r != NULL, reason);
-  SC3E_TEST (r->magic == (long) SC3_REFCOUNT_MAGIC, reason);
+  SC3E_TEST (r->magic == SC3_REFCOUNT_MAGIC, reason);
   SC3E_TEST (r->rc >= 1, reason);
   SC3E_YES (reason);
 }

--- a/src/sc3_refcount.h
+++ b/src/sc3_refcount.h
@@ -55,7 +55,7 @@
 #include <sc3_error.h>
 
 /** Arbitrarily chosen number to catch uninitialized objects. */
-#define SC3_REFCOUNT_MAGIC 0x6CA9EFC0
+#define SC3_REFCOUNT_MAGIC 0x6CA9EFC0L
 
 #ifdef __cplusplus
 extern              "C"

--- a/src/sc3_refcount.h
+++ b/src/sc3_refcount.h
@@ -55,7 +55,7 @@
 #include <sc3_error.h>
 
 /** Arbitrarily chosen number to catch uninitialized objects. */
-#define SC3_REFCOUNT_MAGIC 0x6CA9EFC08917AF1C
+#define SC3_REFCOUNT_MAGIC 0x6CA9EFC0
 
 #ifdef __cplusplus
 extern              "C"


### PR DESCRIPTION
Typecast  of SC3_REFCOUNT_MAGIC

GNU 10.2.0 on Windows treated SC3_REFCOUNT_MAGIC as long long type, while the type of sc3_refcount_t::magic is long.
The result of comparison r->magic == SC3_REFCOUNT_MAGIC might have varied depending on compiler / operational system / device.
