### PR TITLE
Add SC_ENABLE_DEBUG in CMake config

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -121,6 +121,10 @@ check_type_size("unsigned long" SC_SIZEOF_UNSIGNED_LONG BUILTIN_TYPES_ONLY)
 check_type_size("unsigned long long" SC_SIZEOF_UNSIGNED_LONG_LONG BUILTIN_TYPES_ONLY)
 set(SC_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+  set(SC_ENABLE_DEBUG 1)
+endif()
+
 configure_file(${CMAKE_CURRENT_LIST_DIR}/sc_config.h.in ${PROJECT_BINARY_DIR}/include/sc_config.h)
 
 # --- sanity check of MPI sc_config.h

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -23,6 +23,9 @@
 
 #cmakedefine SC_ENABLE_PTHREAD
 
+/* Define to 1 if we are using debug build type (assertions and extra checks) */
+#cmakedefine SC_ENABLE_DEBUG @SC_ENABLE_DEBUG@
+
 /* Undefine if: use aligned malloc (optionally use --enable-memalign=<bytes>) */
 #cmakedefine SC_ENABLE_MEMALIGN
 


### PR DESCRIPTION
# SC_ENABLE_DEBUG via CMake

Specifying -DCMAKE_BUILD_TYPE=Debug also defines SC_ENABLE_DEBUG macro to 1.
It's undefined otherwise.
