### PR TITLE
Feature cmake

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -46,7 +46,7 @@ jobs:
       working-directory: build
 
     - name: CMake configure examples
-      run: cmake -B example/build -S example -DSC_ROOT=~/libsc
+      run: cmake -B example/build -S example -Dmpi=yes -Dopenmp=yes -DSC_ROOT=~/libsc
 
     - name: CMake build examples
       run: cmake --build example/build
@@ -95,7 +95,7 @@ jobs:
       working-directory: build
 
     - name: CMake configure examples
-      run: cmake -B example/build -S example -DSC_ROOT=~/libsc
+      run: cmake -B example/build -S example -Dmpi=yes -DSC_ROOT=~/libsc
 
     - name: CMake build examples
       run: cmake --build example/build
@@ -175,11 +175,11 @@ jobs:
 
     - name: CMake configure examples with MPI
       if: steps.check_files.outputs.files_exists == 'true'
-      run: cmake -B example/build -S example -DSC_ROOT=~/libsc
+      run: cmake -B example/build -S example -Dmpi=yes -Dopenmp=yes -DSC_ROOT=~/libsc
 
     - name: CMake configure examples without MPI
       if: steps.check_files.outputs.files_exists == 'false'
-      run: cmake -B example/build -S example -Dmpi=no -DSC_ROOT=~/libsc
+      run: cmake -B example/build -S example -Dopenmp=yes -DSC_ROOT=~/libsc
 
     - name: CMake build examples
       run: cmake --build example/build

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,3 +1,6 @@
+option(mpi "use MPI library" off)
+option(openmp "use OpenMP" off)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 # --- default install directory under build/local

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,7 +1,3 @@
-option(mpi "use MPI library" on)
-option(openmp "use OpenMP" on)
-
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
 # --- default install directory under build/local

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,8 +7,6 @@ include(CheckIncludeFile)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake/Modules)
 
-option(mpi "use MPI" on)
-
 # --- find external libraries
 if(mpi)
   find_package(MPI COMPONENTS C REQUIRED)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,6 +7,8 @@ include(CheckIncludeFile)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../cmake/Modules)
 
+option(mpi "use MPI" off)
+
 # --- find external libraries
 if(mpi)
   find_package(MPI COMPONENTS C REQUIRED)


### PR DESCRIPTION
MPI and OpenMP are disabled by default. Use -Dmpi=yes and -Dopenmp=yes to enable them.
Also, ci runs (for examples) were changed according to new defaults.