### PR TITLE
sc3: array: Add a view option into sc3_array

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -23,8 +23,7 @@
 /** \mainpage The sc auxiliary library
  *
  * \author Carsten Burstedde, Lucas C. Wilcox, Tobin Isaac et.al.
- * \copyright GNU Lesser General Public License version 2.1
- * (or, at your option, any later version)
+ * \copyright GNU Lesser General Public License version 2.1.
  *
  * The sc library provides functions and data types that can be useful
  * in scientific computing.  It is part of the p4est project, which uses

--- a/doc/sc3.dox
+++ b/doc/sc3.dox
@@ -23,10 +23,10 @@
 /** \mainpage The sc auxiliary library
  *
  * \author Carsten Burstedde, Lucas C. Wilcox, Tobin Isaac et.al.
- * \copyright Versions up to 2: GNU Lesser General Public License version 2.1
- *            (or, at your option, any later version)
- * \copyright \ref sc3 "Version 3": FreeBSD License.  The compile currently
- *            includes the version 2 code as well,
+ * \copyright Versions up to 2: GNU Lesser General Public License version 2.1.
+ * \copyright \ref sc3 "Version 3": FreeBSD License.
+              The compile currently
+ *            includes the version 2 code under its old license as well,
  *            which we continue to maintain for backwards compatibility.
  *
  * The sc library provides functions and data types that can be useful

--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -367,37 +367,46 @@ sc3_array_index_noerr (const sc3_array_t * a, int i)
 }
 
 sc3_error_t        *
-sc3_array_subarray (sc3_array_t * a, int idx, sc3_array_t * sa)
+sc3_array_new_view (sc3_array_t * a, int offset, int length,
+                    sc3_array_t ** view)
 {
   SC3A_IS (sc3_array_is_setup, a);
-  SC3A_IS (sc3_array_is_new, sa);
-  SC3A_CHECK (sa->ecount + idx <= a->ecount);
-  SC3A_CHECK (sa->esize == a->esize);
-  SC3A_IS (sc3_array_is_unresizable, sa);
+  SC3A_IS (sc3_array_is_new, *view);
+  SC3A_CHECK (length + offset <= a->ecount);
+  SC3A_IS (sc3_array_is_unresizable, *view);
 
-  sa->view = 1;
-  sa->setup = 1;
-  sa->initzero = a->initzero;
-  sa->tighten = 0;
+  (*view)->view = 1;
+  (*view)->setup = 1;
+  (*view)->initzero = a->initzero;
+  (*view)->tighten = 0;
 
-  sa->ealloc = a->ealloc - idx;
-  sa->mem = a->mem + idx * sa->esize;
+  (*view)->esize = a->esize;
+  (*view)->ealloc = a->ealloc - offset;
+  (*view)->ecount = length;
+  (*view)->mem = a->mem + (*view)->esize * offset;
+
+  SC3A_IS (sc3_array_is_setup, *view);
 
   return NULL;
 }
 
 sc3_error_t        *
-sc3_array_view (char * a, int idx, int n, sc3_array_t * sa)
+sc3_array_new_data (void * data, size_t esize, int offset, int length,
+                    sc3_array_t ** view)
 {
-  SC3A_IS (sc3_array_is_new, sa);
-  SC3A_IS (sc3_array_is_unresizable, sa);
+  SC3A_IS (sc3_array_is_new, *view);
+  SC3A_IS (sc3_array_is_unresizable, *view);
 
-  sa->view = 1;
-  sa->setup = 1;
-  sa->tighten = 0;
+  (*view)->view = 1;
+  (*view)->setup = 1;
+  (*view)->tighten = 0;
 
-  sa->ealloc = n;
-  sa->mem = a + idx * sa->esize;
+  (*view)->esize = esize;
+  (*view)->ealloc = length;
+  (*view)->ecount = length;
+  (*view)->mem = (char *) data + (*view)->esize * offset;
+
+  SC3A_IS (sc3_array_is_setup, *view);
 
   return NULL;
 }

--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -67,6 +67,11 @@ sc3_array_is_valid (const sc3_array_t * a, char *reason)
     SC3E_TEST (a->mem != NULL || a->ecount * a->esize == 0, reason);
     SC3E_TEST (a->ealloc == 0 || SC3_ISPOWOF2 (a->ealloc), reason);
     SC3E_TEST (a->ecount <= a->ealloc, reason);
+
+    /* further check array view */
+    if (a->viewed != NULL && a->viewed != a) {
+      SC3E_IS (sc3_array_is_unresizable, a->viewed, reason);
+    }
   }
   SC3E_YES (reason);
 }
@@ -100,6 +105,14 @@ sc3_array_is_unresizable (const sc3_array_t * a, char *reason)
 {
   SC3E_IS (sc3_array_is_setup, a, reason);
   SC3E_TEST (!a->resizable, reason);
+  SC3E_YES (reason);
+}
+
+int
+sc3_array_is_view (const sc3_array_t * a, char *reason)
+{
+  SC3E_IS (sc3_array_is_unresizable, a, reason);
+  SC3E_TEST (a->viewed != NULL, reason);
   SC3E_YES (reason);
 }
 
@@ -401,7 +414,7 @@ sc3_array_new_view (sc3_allocator_t * alloc, sc3_array_t ** view,
   SC3E (sc3_array_ref (a));
 
   (*view)->setup = 1;
-  SC3A_IS (sc3_array_is_unresizable, *view);
+  SC3A_IS (sc3_array_is_view, *view);
 
   return NULL;
 }
@@ -429,7 +442,7 @@ sc3_array_new_data (sc3_allocator_t * alloc, sc3_array_t ** view,
   (*view)->viewed = *view;
 
   (*view)->setup = 1;
-  SC3A_IS (sc3_array_is_unresizable, *view);
+  SC3A_IS (sc3_array_is_view, *view);
 
   return NULL;
 }

--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -390,7 +390,7 @@ sc3_array_new_view (sc3_allocator_t * alloc, sc3_array_t ** view,
   SC3A_CHECK (offset >= 0 && length >= 0);
   SC3A_CHECK (offset + length <= a->ecount);
 
-  /* create array and adjust for being a view */
+  /* create array and adjust for being an array view */
   SC3E (sc3_array_new (alloc, view));
   (*view)->esize = a->esize;
   (*view)->ealloc = a->ealloc - offset;
@@ -407,22 +407,29 @@ sc3_array_new_view (sc3_allocator_t * alloc, sc3_array_t ** view,
 }
 
 sc3_error_t        *
-sc3_array_new_data (void * data, size_t esize, int offset, int length,
-                    sc3_array_t ** view)
+sc3_array_new_data (sc3_allocator_t * alloc, sc3_array_t ** view,
+                    void *data, size_t esize, int offset, int length)
 {
-  SC3A_IS (sc3_array_is_new, *view);
-  SC3A_IS (sc3_array_is_unresizable, *view);
+  /* default error output */
+  SC3E_RETVAL (view, NULL);
 
-  (*view)->setup = 1;
-  (*view)->tighten = 0;
+  /* verify input parametrs */
+  SC3A_IS (sc3_allocator_is_setup, alloc);
+  SC3A_CHECK (offset >= 0 && length >= 0);
+  SC3A_CHECK (data != NULL || esize * length == 0);
 
+  /* create array and adjust for being a view on data */
+  SC3E (sc3_array_new (alloc, view));
   (*view)->esize = esize;
   (*view)->ealloc = length;
   (*view)->ecount = length;
   (*view)->mem = (char *) data + (*view)->esize * offset;
+
+  /* special setting to indicate view on data */
   (*view)->viewed = *view;
 
-  SC3A_IS (sc3_array_is_setup, *view);
+  (*view)->setup = 1;
+  SC3A_IS (sc3_array_is_unresizable, *view);
 
   return NULL;
 }

--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -65,9 +65,8 @@ sc3_array_is_valid (const sc3_array_t * a, char *reason)
   }
   else {
     SC3E_TEST (a->mem != NULL || a->ecount * a->esize == 0, reason);
-    SC3E_TEST (a->ealloc == 0
-               || SC3_ISPOWOF2 (a->ealloc)
-               || a->viewed != NULL , reason);
+    SC3E_TEST (a->ealloc == 0 || SC3_ISPOWOF2 (a->ealloc) ||
+               a->viewed != NULL, reason);
     SC3E_TEST (a->ecount <= a->ealloc, reason);
 
     /* further check array view */
@@ -420,12 +419,12 @@ sc3_array_new_view (sc3_allocator_t * alloc, sc3_array_t ** view,
   (*view)->ealloc = length;
   (*view)->mem = a->mem + (*view)->esize * offset;
 
+  /* remember and reference the viewed array */
   (*view)->viewed = a;
   SC3E (sc3_array_ref (a));
 
   (*view)->setup = 1;
   SC3A_IS (sc3_array_is_view, *view);
-
   return NULL;
 }
 
@@ -439,7 +438,7 @@ sc3_array_new_data (sc3_allocator_t * alloc, sc3_array_t ** view,
   /* verify input parametrs */
   SC3A_IS (sc3_allocator_is_setup, alloc);
   SC3A_CHECK (offset >= 0 && length >= 0);
-  SC3A_CHECK (data != NULL || esize * length != 0);
+  SC3A_CHECK (data != NULL || esize * length == 0);
 
   /* create array and adjust for being a view on data */
   SC3E (sc3_array_new (alloc, view));
@@ -450,9 +449,9 @@ sc3_array_new_data (sc3_allocator_t * alloc, sc3_array_t ** view,
 
   /* special setting to indicate view on data */
   (*view)->viewed = *view;
+
   (*view)->setup = 1;
   SC3A_IS (sc3_array_is_data, *view);
-
   return NULL;
 }
 
@@ -460,7 +459,7 @@ sc3_error_t        *
 sc3_array_renew_view (sc3_array_t ** view, sc3_array_t * a, int offset,
                       int length)
 {
-  sc3_array_t * old_a = (*view)->viewed;
+  sc3_array_t        *old_a = (*view)->viewed;
 
   /* verify input parametrs */
   SC3A_IS (sc3_array_is_view, *view);

--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -459,29 +459,26 @@ sc3_error_t        *
 sc3_array_renew_view (sc3_array_t ** view, sc3_array_t * a, int offset,
                       int length)
 {
-  sc3_array_t        *old_a = (*view)->viewed;
-
   /* verify input parametrs */
+  SC3A_CHECK (view != NULL);
   SC3A_IS (sc3_array_is_view, *view);
   SC3A_IS (sc3_array_is_unresizable, a);
+  SC3A_CHECK ((*view)->esize == a->esize);
   SC3A_CHECK (offset >= 0 && length >= 0);
   SC3A_CHECK (offset + length <= a->ecount);
 
   /* adjust array for being an array view */
-  (*view)->esize = a->esize;
   (*view)->ecount = length;
   (*view)->ealloc = length;
   (*view)->mem = a->mem + (*view)->esize * offset;
 
-  if (old_a != a) {
-    SC3E (sc3_array_unref (&old_a));
+  if ((*view)->viewed != a) {
+    SC3E (sc3_array_unref (&((*view)->viewed)));
     SC3E (sc3_array_ref (a));
+    (*view)->viewed = a;
   }
-  (*view)->viewed = a;
 
-  (*view)->setup = 1;
   SC3A_IS (sc3_array_is_view, *view);
-
   return NULL;
 }
 
@@ -490,19 +487,18 @@ sc3_array_renew_data (sc3_array_t ** view, void *data, size_t esize,
                       int offset, int length)
 {
   /* verify input parametrs */
+  SC3A_CHECK (view != NULL);
   SC3A_IS (sc3_array_is_data, *view);
+  SC3A_CHECK ((*view)->esize == esize);
   SC3A_CHECK (offset >= 0 && length >= 0);
-  SC3A_CHECK (data != NULL || esize * length != 0);
+  SC3A_CHECK (data != NULL || esize * length == 0);
 
   /* adjust array for being a view on data */
-  (*view)->esize = esize;
   (*view)->ecount = length;
   (*view)->ealloc = length;
   (*view)->mem = (char *) data + (*view)->esize * offset;
 
-  (*view)->setup = 1;
   SC3A_IS (sc3_array_is_data, *view);
-
   return NULL;
 }
 

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -287,37 +287,40 @@ sc3_error_t        *sc3_array_index (sc3_array_t * a, int i, void *ptr);
  */
 void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
-/** Create a subarray sa pointing to the same memory as an array a.
- * \param [in] a        The array must be setup.
- * \param [in] idx      Index of the array a that points to a beginning of
- *                      the subarray sa.
- * \param [in, out] sa  The array must not be setup. Size of elements must
- *                      be equal to elements in a. The number of elements
- *                      must be less of equal than (a->ecount - idx).
- *                      This subarray will contain all the memory of
- *                      the array a corresponding indices
- *                      [idx, sa->ecount + idx).
- * \return              NULL on success, error object otherwise.
+/** Create a new view pointing to the same memory as an array a.
+ * \param [in] a        The array must be setup and must not be resized
+ *                      while view is alive.
+ * \param [in] offset   The offset of the viewed section in element units.
+ *                      This offset cannot be changed until the view is reset.
+ * \param [in] length   The length of the viewed section in element units.
+ *                      The view cannot be resized to exceed this length.
+ * \param [in, out] view Pointer to the array, that must not be setup.
+ *                       This subarray will contain all the memory of
+ *                       the array a corresponding indices
+ *                       [offset, offset + length).
+ * \return               NULL on success, error object otherwise.
  */
-sc3_error_t        *sc3_array_subarray (sc3_array_t * a, int idx,
-                                        sc3_array_t * sa);
+sc3_error_t        *sc3_array_new_view (sc3_array_t * a, int offset,
+                                        int length, sc3_array_t ** view);
 
 /** Create an array view sa pointing to the allocated memory fragment a.
  * Warning! Potentially dangerous function. Make sure, that array's length
  * adjusted for idx shift is covered by the length of the allocated fragment.
- * \param [in] a        The allocated memory fragment.
- * \param [in] idx      Index pointing to allocated memory and is considered
- *                      to be the beginning of the subarray sa.
- * \param [in] n        The number of allocated bits.
- * \param [in, out] sa  The array must not be setup. The number of elements
- *                      as->ecount must be such that
- *                      (as->ecount + idx) * as->esize <= |alloc memory of a|.
- *                      (Sub)array sa will contain all the memory of
- *                      a corresponding indices [idx, sa->ecount + idx).
- * \return              NULL on success, error object otherwise.
+ * \param [in] data     The data must not be moved while view is alive.
+ * \param [in] elem_size Size of one array element in bytes.
+ * \param [in] offset   The offset of the viewed section in element units.
+ *                      This offset cannot be changed until the view is reset.
+ * \param [in] length   The length of the viewed section in element units.
+ *                      The view cannot be resized to exceed this length.
+ * \param [in, out] view The array must not be setup. The number of elements
+ *                       as->ecount must be such that
+ *                       (as->ecount + idx) * as->esize <= |alloc memory of a|.
+ *                       (Sub)array sa will contain all the memory of
+ *                       a corresponding indices [idx, sa->ecount + idx).
+ * \return               NULL on success, error object otherwise.
  */
-sc3_error_t        *sc3_array_view (char * a, int idx, int n,
-                                    sc3_array_t * sa);
+sc3_error_t        *sc3_array_new_data (void *data, size_t esize, int offset,
+                                        int length, sc3_array_t ** view);
 
 /** Return element size of an array that is setup.
  * \param [in] a        Array must be setup.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -287,6 +287,38 @@ sc3_error_t        *sc3_array_index (sc3_array_t * a, int i, void *ptr);
  */
 void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
+/** Create a subarray sa pointing to the same memory as an array a.
+ * \param [in] a        The array must be setup.
+ * \param [in] idx      Index of the array a that points to a beginning of
+ *                      the subarray sa.
+ * \param [in, out] sa  The array must not be setup. Size of elements must
+ *                      be equal to elements in a. The number of elements
+ *                      must be less of equal than (a->ecount - idx).
+ *                      This subarray will contain all the memory of
+ *                      the array a corresponding indices
+ *                      [idx, sa->ecount + idx).
+ * \return              NULL on success, error object otherwise.
+ */
+sc3_error_t        *sc3_array_subarray (sc3_array_t * a, int idx,
+                                        sc3_array_t * sa);
+
+/** Create an array view sa pointing to the allocated memory fragment a.
+ * Warning! Potentially dangerous function. Make sure, that array's length
+ * adjusted for idx shift is covered by the length of the allocated fragment.
+ * \param [in] a        The allocated memory fragment.
+ * \param [in] idx      Index pointing to allocated memory and is considered
+ *                      to be the beginning of the subarray sa.
+ * \param [in] n        The number of allocated bits.
+ * \param [in, out] sa  The array must not be setup. The number of elements
+ *                      as->ecount must be such that
+ *                      (as->ecount + idx) * as->esize <= |alloc memory of a|.
+ *                      (Sub)array sa will contain all the memory of
+ *                      a corresponding indices [idx, sa->ecount + idx).
+ * \return              NULL on success, error object otherwise.
+ */
+sc3_error_t        *sc3_array_view (char * a, int idx, int n,
+                                    sc3_array_t * sa);
+
 /** Return element size of an array that is setup.
  * \param [in] a        Array must be setup.
  * \param [out] esize   Element size of the array in bytes, or 0 on error.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -310,7 +310,7 @@ sc3_error_t        *sc3_array_index (sc3_array_t * a, int i, void *ptr);
  */
 void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
-/** Create a view array pointing to the same memory as a given array.
+/** Create a view array pointing into the same memory as a given array.
  * Inherit the data element size from the given array.  The view refs the
  * viewed array, which must thus not be destroyed before this view.
  * \param [in,out] alloc    An allocator that is setup.
@@ -357,15 +357,16 @@ sc3_error_t        *sc3_array_new_data (sc3_allocator_t * alloc,
                                         void *data, size_t esize,
                                         int offset, int length);
 
-/** Adjust an existed view array for tracking memory of a new array.
- * Inherit the data element size from the given array is. The view must be
- * destroyed BEFORE the target array. An exception will be thrown otherwise.
- * \param [out] view    Pointer to the created view array to be adjusted.
+/** Adjust an existed view array for a different window and/or viewed array.
+ * Inherit the data element size from the given array.  The view refs the
+ * viewed array, which must thus not be destroyed before this view.
+ * \param [out] view    Pointer to existing view array to be adjusted.
  *                      This array will refer to the memory of
  *                      the referenced array \a a corresponding to
  *                      indices [offset, offset + length).
  *                      The view is setup and not resizable.
  * \param [in] a        The array must be setup and not resizable.
+ *                      Its element size must be identical to the view's.
  * \param [in] offset   The offset of the viewed section in element units.
  *                      The offset + length must be within length of \a a.
  * \param [in] length   The length of the viewed section in element units.
@@ -373,25 +374,21 @@ sc3_error_t        *sc3_array_new_data (sc3_allocator_t * alloc,
  * \return              NULL on success, error object otherwise.
  */
 sc3_error_t        *sc3_array_renew_view (sc3_array_t ** view,
-                                          sc3_array_t * a, int offset,
-                                          int length);
+                                          sc3_array_t * a,
+                                          int offset, int length);
 
-/** Adjust an existed view array for tracking some given memory fragment.
- * Warning!  Potentially dangerous function.  Make sure that array's length
+/** Adjust an existing view on data for tracking some given memory fragment.
+ * We have no means to verify that the fragment exists and stays alive.
+ * \note Potentially dangerous function!  Make sure that array's length
  * from start offset is supported by the length of the given fragment.
  * Otherwise the behavior is undefined.
- * The view is setup and never resizable.
- * \param [out] view    Pointer to the created view array to be adjusted.
- *                      The number of elements view->ecount must be such that
- *                      (view->ecount + idx) * view->esize <= |alloc memory of a|.
- *                      (Sub)array view will contain all the memory of
- *                      a corresponding indices [idx, view->ecount + idx).
+ * \param [out] view    Pointer to existing view on data to be adjusted.
+ *                      The element size of the view remains the same.
  * \param [in] data     The data must not be moved while view is alive.
- * \param [in] esize    Size of one array element in bytes.
  * \param [in] offset   The offset of the viewed section in element units.
- *                      This offset cannot be changed until the view is reset.
+ *                      This offset cannot be changed unless the view is renewed.
  * \param [in] length   The length of the viewed section in element units.
- *                      The view cannot be resized to exceed this length.
+ *                      The view cannot be resized resized unless it is renewed.
  * \return              NULL on success, error object otherwise.
  */
 sc3_error_t        *sc3_array_renew_data (sc3_array_t ** view, void *data,

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -299,7 +299,8 @@ sc3_error_t        *sc3_array_index (sc3_array_t * a, int i, void *ptr);
 void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
 /** Create a view array pointing to the same memory as a given array.
- * Inherit the data element size from the given array.
+ * Inherit the data element size from the given array is. The view must be
+ * destroyed BEFORE the target array. An exception will be thrown otherwise.
  * \param [in,out] alloc    An allocator that is setup.
  *                          The allocator is refd and remembered internally
  *                          and will be unrefd on view destruction.
@@ -329,10 +330,10 @@ sc3_error_t        *sc3_array_new_view (sc3_allocator_t * alloc,
  *                          The allocator is refd and remembered internally
  *                          and will be unrefd on view destruction.
  * \param [out] view    The array must not be setup. The number of elements
- *                      as->ecount must be such that
- *                      (as->ecount + idx) * as->esize <= |alloc memory of a|.
- *                      (Sub)array sa will contain all the memory of
- *                      a corresponding indices [idx, sa->ecount + idx).
+ *                      view->ecount must be such that
+ *                      (view->ecount + idx) * view->esize <= |alloc memory of a|.
+ *                      (Sub)array view will contain all the memory of
+ *                      a corresponding indices [idx, view->ecount + idx).
  * \param [in] data     The data must not be moved while view is alive.
  * \param [in] esize    Size of one array element in bytes.
  * \param [in] offset   The offset of the viewed section in element units.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -113,6 +113,14 @@ int                 sc3_array_is_resizable (const sc3_array_t * a,
 int                 sc3_array_is_unresizable (const sc3_array_t * a,
                                               char *reason);
 
+/** Query whether an array is a view.
+ * \param [in] a        Any pointer.
+ * \param [out] reason  If not NULL, existing string of length SC3_BUFSIZE
+ *                      is set to "" if answer is yes or reason if no.
+ * \return              True iff array not NULL, setup, and not resizable.
+ */
+int                 sc3_array_is_view (const sc3_array_t * a, char *reason);
+
 /** Create a new array object in its setup phase.
  * It begins with default parameters that can be overridden explicitly.
  * Setting and modifying parameters is only allowed in the setup phase.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -121,6 +121,14 @@ int                 sc3_array_is_unresizable (const sc3_array_t * a,
  */
 int                 sc3_array_is_view (const sc3_array_t * a, char *reason);
 
+/** Query whether an array is a data.
+ * \param [in] a        Any pointer.
+ * \param [out] reason  If not NULL, existing string of length SC3_BUFSIZE
+ *                      is set to "" if answer is yes or reason if no.
+ * \return              True iff array not NULL, setup, and not resizable.
+ */
+int                 sc3_array_is_data (const sc3_array_t * a, char *reason);
+
 /** Create a new array object in its setup phase.
  * It begins with default parameters that can be overridden explicitly.
  * Setting and modifying parameters is only allowed in the setup phase.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -347,6 +347,47 @@ sc3_error_t        *sc3_array_new_data (sc3_allocator_t * alloc,
                                         void *data, size_t esize,
                                         int offset, int length);
 
+/** Adjust an existed view array for tracking memory of a new array.
+ * Inherit the data element size from the given array is. The view must be
+ * destroyed BEFORE the target array. An exception will be thrown otherwise.
+ * \param [out] view    Pointer to the created view array to be adjusted.
+ *                      This array will refer to the memory of
+ *                      the referenced array \a a corresponding to
+ *                      indices [offset, offset + length).
+ *                      The view is setup and not resisable.
+ * \param [in] a        The array must be setup and not resizable.
+ * \param [in] offset   The offset of the viewed section in element units.
+ *                      The offset + length must be within length of \a a.
+ * \param [in] length   The length of the viewed section in element units.
+ *                      The offset + length must be within length of \a a.
+ * \return              NULL on success, error object otherwise.
+ */
+sc3_error_t        *sc3_array_renew_view (sc3_array_t ** view,
+                                          sc3_array_t * a, int offset,
+                                          int length);
+
+/** Adjust an existed view array for tracking some given memory fragment.
+ * Warning!  Potentially dangerous function.  Make sure that array's length
+ * from start offset is supported by the length of the given fragment.
+ * Otherwise the behavior is undefined.
+ * The view is setup and never resisable.
+ * \param [out] view    Pointer to the created view array to be adjusted.
+ *                      The number of elements view->ecount must be such that
+ *                      (view->ecount + idx) * view->esize <= |alloc memory of a|.
+ *                      (Sub)array view will contain all the memory of
+ *                      a corresponding indices [idx, view->ecount + idx).
+ * \param [in] data     The data must not be moved while view is alive.
+ * \param [in] esize    Size of one array element in bytes.
+ * \param [in] offset   The offset of the viewed section in element units.
+ *                      This offset cannot be changed until the view is reset.
+ * \param [in] length   The length of the viewed section in element units.
+ *                      The view cannot be resized to exceed this length.
+ * \return              NULL on success, error object otherwise.
+ */
+sc3_error_t        *sc3_array_renew_data (sc3_array_t ** view, void *data,
+                                          size_t esize, int offset,
+                                          int length);
+
 /** Return element size of an array that is setup.
  * \param [in] a        Array must be setup.
  * \param [out] esize   Element size of the array in bytes, or 0 on error.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -292,7 +292,7 @@ void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
 /** Create a view array pointing to the same memory as a given array.
  * Inherit the data element size from the given array.
- * \param [in,out] aator    An allocator that is setup.
+ * \param [in,out] alloc    An allocator that is setup.
  *                          The allocator is refd and remembered internally
  *                          and will be unrefd on view destruction.
  * \param [out] view    Pointer to the view array created.
@@ -317,21 +317,26 @@ sc3_error_t        *sc3_array_new_view (sc3_allocator_t * alloc,
  * from start offset is supported by the length of the given fragment.
  * Otherwise the behavior is undefined.
  * The view is setup and never resisable.
+ * \param [in,out] alloc    An allocator that is setup.
+ *                          The allocator is refd and remembered internally
+ *                          and will be unrefd on view destruction.
+ * \param [out] view    The array must not be setup. The number of elements
+ *                      as->ecount must be such that
+ *                      (as->ecount + idx) * as->esize <= |alloc memory of a|.
+ *                      (Sub)array sa will contain all the memory of
+ *                      a corresponding indices [idx, sa->ecount + idx).
  * \param [in] data     The data must not be moved while view is alive.
  * \param [in] esize    Size of one array element in bytes.
  * \param [in] offset   The offset of the viewed section in element units.
  *                      This offset cannot be changed until the view is reset.
  * \param [in] length   The length of the viewed section in element units.
  *                      The view cannot be resized to exceed this length.
- * \param [in, out] view The array must not be setup. The number of elements
- *                       as->ecount must be such that
- *                       (as->ecount + idx) * as->esize <= |alloc memory of a|.
- *                       (Sub)array sa will contain all the memory of
- *                       a corresponding indices [idx, sa->ecount + idx).
- * \return               NULL on success, error object otherwise.
+ * \return              NULL on success, error object otherwise.
  */
-sc3_error_t        *sc3_array_new_data (void *data, size_t esize, int offset,
-                                        int length, sc3_array_t ** view);
+sc3_error_t        *sc3_array_new_data (sc3_allocator_t * alloc,
+                                        sc3_array_t ** view,
+                                        void *data, size_t esize,
+                                        int offset, int length);
 
 /** Return element size of an array that is setup.
  * \param [in] a        Array must be setup.

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -292,21 +292,25 @@ void               *sc3_array_index_noerr (const sc3_array_t * a, int i);
 
 /** Create a view array pointing to the same memory as a given array.
  * Inherit the data element size from the given array.
- * The view is setup and never resisable.
- * \param [in] a        The array must be setup and must not be resized
- *                      while view is alive.
+ * \param [in,out] aator    An allocator that is setup.
+ *                          The allocator is refd and remembered internally
+ *                          and will be unrefd on view destruction.
+ * \param [out] view    Pointer to the view array created.
+ *                      This array will refer to the memory of
+ *                      the referenced array \a a corresponding to
+ *                      indices [offset, offset + length).
+ *                      The view is setup and not resisable.
+ * \param [in] a        The array must be setup and not resizable.
  * \param [in] offset   The offset of the viewed section in element units.
- *                      This offset cannot be changed until the view is reset.
+ *                      The offset + length must be within length of \a a.
  * \param [in] length   The length of the viewed section in element units.
- *                      The view cannot be resized to exceed this length.
- * \param [out] view     Pointer to the view array, that must not be setup.
- *                       This subarray will refer to the memory of
- *                       the referenced array \a a, corresponding to
- *                       indices [offset, offset + length).
- * \return               NULL on success, error object otherwise.
+ *                      The offset + length must be within length of \a a.
+ * \return              NULL on success, error object otherwise.
  */
-sc3_error_t        *sc3_array_new_view (sc3_array_t * a, int offset,
-                                        int length, sc3_array_t ** view);
+sc3_error_t        *sc3_array_new_view (sc3_allocator_t * alloc,
+                                        sc3_array_t ** view,
+                                        sc3_array_t * a,
+                                        int offset, int length);
 
 /** Create a view array pointing to some given memory fragment.
  * Warning!  Potentially dangerous function.  Make sure that array's length

--- a/test/test_containers.c
+++ b/test/test_containers.c
@@ -198,6 +198,8 @@ test_view (void)
     SC3E_DEMAND (data[i + offset / 2] == *(int *) ptr_view,
                  "the view points to the wrong memory");
   }
+  /* renew view with a NULL data */
+  SC3E (sc3_array_renew_data (&view, NULL, isize, offset, 0));
 
   /*destroy the view and free the data */
   SC3E (sc3_allocator_free (alloc, data));

--- a/test/test_containers.c
+++ b/test/test_containers.c
@@ -175,12 +175,8 @@ test_view (void)
                  "the view points to the wrong memory");
   }
 
-  /*destroy both the sc3_array and the view */
-  SC3E (sc3_array_destroy (&view));
-  SC3E (sc3_array_destroy (&a));
-
   /*make a new view of data */
-  SC3E (sc3_array_new_data (alloc, &view, data, isize, offset, length));
+  SC3E (sc3_array_renew_data (&view, data, isize, offset, length));
   for (i = 0; i < length; ++i) {
     SC3E (sc3_array_index (view, i, &ptr_view));
     SC3E_DEMAND (data[i + offset] == *(int *) ptr_view,
@@ -189,6 +185,7 @@ test_view (void)
 
   /*destroy the view and free the data */
   SC3E (sc3_allocator_free (alloc, data));
+  SC3E (sc3_array_destroy (&a));
   SC3E (sc3_array_destroy (&view));
   SC3E (sc3_allocator_destroy (&alloc));
   return NULL;

--- a/test/test_containers.c
+++ b/test/test_containers.c
@@ -174,18 +174,33 @@ test_view (void)
     SC3E_DEMAND (*(int *) ptr == *(int *) ptr_view && ptr == ptr_view,
                  "the view points to the wrong memory");
   }
+  SC3E (sc3_array_renew_view (&view, a, offset / 2, length / 2));
+  for (i = 0; i < length / 2; ++i) {
+    SC3E (sc3_array_index (a, i + offset / 2, &ptr));
+    SC3E (sc3_array_index (view, i, &ptr_view));
+    SC3E_DEMAND (*(int *) ptr == *(int *) ptr_view && ptr == ptr_view,
+                 "the view points to the wrong memory");
+  }
+
+  SC3E (sc3_array_destroy (&view));
+  SC3E (sc3_array_destroy (&a));
 
   /*make a new view of data */
-  SC3E (sc3_array_renew_data (&view, data, isize, offset, length));
+  SC3E (sc3_array_new_data (alloc, &view, data, isize, offset, length));
   for (i = 0; i < length; ++i) {
     SC3E (sc3_array_index (view, i, &ptr_view));
     SC3E_DEMAND (data[i + offset] == *(int *) ptr_view,
                  "the view points to the wrong memory");
   }
+  SC3E (sc3_array_renew_data (&view, data, isize, offset / 2, length / 2));
+  for (i = 0; i < length / 2; ++i) {
+    SC3E (sc3_array_index (view, i, &ptr_view));
+    SC3E_DEMAND (data[i + offset / 2] == *(int *) ptr_view,
+                 "the view points to the wrong memory");
+  }
 
   /*destroy the view and free the data */
   SC3E (sc3_allocator_free (alloc, data));
-  SC3E (sc3_array_destroy (&a));
   SC3E (sc3_array_destroy (&view));
   SC3E (sc3_allocator_destroy (&alloc));
   return NULL;

--- a/test/test_containers.c
+++ b/test/test_containers.c
@@ -29,6 +29,8 @@
 
 #include <sc.h>
 #include <sc3_memstamp.h>
+#include <sc3_array.h>
+#include <sc_random.h>
 
 static sc3_error_t *
 test_allocations (void)
@@ -134,6 +136,65 @@ test_correctness (void)
 }
 
 static sc3_error_t *
+test_view (void)
+{
+  const int           nelems = 7829;
+  const size_t        isize = sizeof (int);
+  const int           offset = nelems / 3 - 1;
+  const int           length = 2 * offset;
+  int                 i;
+  sc3_array_t        *a, *view;
+  int                *iptr, *data;
+  void               *ptr, *ptr_view;
+  sc_rand_state_t     rs = 203, *prs = &rs;
+  sc3_allocator_t    *alloc;
+
+  /* create a toplevel allocator */
+  SC3E (sc3_allocator_new (sc3_allocator_nocount (), &alloc));
+  SC3E (sc3_allocator_setup (alloc));
+
+  /*create and fill a simple sc3_array and c-array */
+  SC3E (sc3_array_new (alloc, &a));
+  SC3E (sc3_array_set_elem_size (a, isize));
+  SC3E (sc3_array_set_elem_count (a, nelems));
+  SC3E (sc3_array_set_resizable (a, 0));
+  SC3E (sc3_array_setup (a));
+  SC3E (sc3_allocator_malloc (alloc, isize * nelems, &data));
+
+  for (i = 0; i < nelems; ++i) {
+    SC3E (sc3_array_index (a, i, &iptr));
+    *iptr = sc_rand_poisson (prs, INT_MAX * 0.5);
+    data[i] = *iptr;
+  }
+  SC3E (sc3_array_new_view (alloc, &view, a, offset, length));
+
+  for (i = 0; i < length; ++i) {
+    SC3E (sc3_array_index (a, i + offset, &ptr));
+    SC3E (sc3_array_index (view, i, &ptr_view));
+    SC3E_DEMAND (*(int *) ptr == *(int *) ptr_view && ptr == ptr_view,
+                 "the view points to the wrong memory");
+  }
+
+  /*destroy both the sc3_array and the view */
+  SC3E (sc3_array_destroy (&view));
+  SC3E (sc3_array_destroy (&a));
+
+  /*make a new view of data */
+  SC3E (sc3_array_new_data (alloc, &view, data, isize, offset, length));
+  for (i = 0; i < length; ++i) {
+    SC3E (sc3_array_index (view, i, &ptr_view));
+    SC3E_DEMAND (data[i + offset] == *(int *) ptr_view,
+                 "the view points to the wrong memory");
+  }
+
+  /*destroy the view and free the data */
+  SC3E (sc3_allocator_free (alloc, data));
+  SC3E (sc3_array_destroy (&view));
+  SC3E (sc3_allocator_destroy (&alloc));
+  return NULL;
+}
+
+static sc3_error_t *
 output_error (sc3_error_t ** pe)
 {
   int                 eline;
@@ -188,6 +249,8 @@ main (int argc, char **argv)
   e = test_allocations ();
   report_error (&e);
   e = test_correctness ();
+  report_error (&e);
+  e = test_view ();
   report_error (&e);
   return 0;
 }


### PR DESCRIPTION
# sc3 array view

I added an opportunity to make subarray/view to sc3_array_t. It's necessary to call sc3_array_split() on p4est3 quadrants array and might be useful for future tasks.