### PR TITLE
Fix for CI warnings

### DIFF
--- a/doc/author_ghosh.txt
+++ b/doc/author_ghosh.txt
@@ -1,0 +1,3 @@
+I place my contributions to libsc under the FreeBSD license. 
+Gautam Ghosh (ghosh@ins.uni-bonn.de)
+

--- a/src/sc_containers.c
+++ b/src/sc_containers.c
@@ -1555,11 +1555,11 @@ sc_hash_array_hash_fn (const void *v, const void *u)
 {
   const sc_hash_array_data_t *internal_data =
     (const sc_hash_array_data_t *) u;
-  long                l = (long) v;
+  ssize_t             l = (ssize_t) v;
   void               *p;
 
   p = (l == -1L) ? internal_data->current_item :
-    sc_array_index_long (internal_data->pa, l);
+    sc_array_index_ssize_t (internal_data->pa, l);
 
   return internal_data->hash_fn (p, internal_data->user_data);
 }
@@ -1569,14 +1569,14 @@ sc_hash_array_equal_fn (const void *v1, const void *v2, const void *u)
 {
   const sc_hash_array_data_t *internal_data =
     (const sc_hash_array_data_t *) u;
-  long                l1 = (long) v1;
-  long                l2 = (long) v2;
+  ssize_t             l1 = (ssize_t) v1;
+  ssize_t             l2 = (ssize_t) v2;
   void               *p1, *p2;
 
   p1 = (l1 == -1L) ? internal_data->current_item :
-    sc_array_index_long (internal_data->pa, l1);
+    sc_array_index_ssize_t (internal_data->pa, l1);
   p2 = (l2 == -1L) ? internal_data->current_item :
-    sc_array_index_long (internal_data->pa, l2);
+    sc_array_index_ssize_t (internal_data->pa, l2);
 
   return internal_data->equal_fn (p1, p2, internal_data->user_data);
 }

--- a/src/sc_notify.c
+++ b/src/sc_notify.c
@@ -2387,7 +2387,7 @@ sc_notify_payload_superset (sc_array_t * receivers, sc_array_t * senders,
                             sc_array_t * in_payload, sc_array_t * out_payload,
                             int sorted, sc_notify_t * notify)
 {
-  int                 num_receivers, num_senders;
+  int                 num_receivers, num_senders = 0;
   int                 num_extra_receivers;
   int                 num_super_senders;
   int                *ireceivers, i, j;


### PR DESCRIPTION
# Title Fix for CMake CI warnings

Following up on issue # .

Proposed changes:
Never type cast void* to long
