### PR TITLE
timeofday

### DIFF
--- a/src/sc_builtin/gettimeofday.c
+++ b/src/sc_builtin/gettimeofday.c
@@ -2,45 +2,48 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-#include <stdint.h> /* portable: uint64_t   MSVC: __int64 */
+#include <stdint.h>             /* portable: uint64_t   MSVC: __int64 */
 
 /* MSVC defines this in winsock2.h!? */
-typedef struct timeval {
-    long tv_sec;
-    long tv_usec;
+typedef struct timeval
+{
+  long                tv_sec;
+  long                tv_usec;
 } timeval;
 
-struct timezone {
-    int tz_minuteswest;
-    int tz_dsttime;
+struct timezone
+{
+  int                 tz_minuteswest;
+  int                 tz_dsttime;
 };
 
-int gettimeofday(struct timeval * tp, struct timezone * tzp)
+int
+gettimeofday (struct timeval *tp, struct timezone *tzp)
 {
-    if(tp){
+  if (tp) {
     /* Note: some broken versions only have 8 trailing zeros,
        the correct epoch has 9 trailing zeros. */
     /* This magic number is the number of 100 nanosecond intervals since
        January 1, 1601 (UTC) until 00:00:00 January 1, 1970 */
     static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
 
-    SYSTEMTIME  system_time;
-    FILETIME    file_time;
-    uint64_t    time;
+    SYSTEMTIME          system_time;
+    FILETIME            file_time;
+    uint64_t            time;
 
-    GetSystemTime( &system_time );
-    SystemTimeToFileTime( &system_time, &file_time );
-    time =  ((uint64_t)file_time.dwLowDateTime )      ;
-    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+    GetSystemTime (&system_time);
+    SystemTimeToFileTime (&system_time, &file_time);
+    time = ((uint64_t) file_time.dwLowDateTime);
+    time += ((uint64_t) file_time.dwHighDateTime) << 32;
 
-    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
+    tp->tv_sec = (long) ((time - EPOCH) / 10000000L);
     tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
-    }
-    if (tzp) {
-        TIME_ZONE_INFORMATION timezone;
-        GetTimeZoneInformation(&timezone);
-        tzp->tz_minuteswest = timezone.Bias;
-        tzp->tz_dsttime = 0;
-    }
-    return 0;
+  }
+  if (tzp) {
+    TIME_ZONE_INFORMATION timezone;
+    GetTimeZoneInformation (&timezone);
+    tzp->tz_minuteswest = timezone.Bias;
+    tzp->tz_dsttime = 0;
+  }
+  return 0;
 }

--- a/src/sc_builtin/gettimeofday.c
+++ b/src/sc_builtin/gettimeofday.c
@@ -10,8 +10,14 @@ typedef struct timeval {
     long tv_usec;
 } timeval;
 
+struct timezone {
+    int tz_minuteswest;
+    int tz_dsttime;
+};
+
 int gettimeofday(struct timeval * tp, struct timezone * tzp)
 {
+    if(tp){
     /* Note: some broken versions only have 8 trailing zeros,
        the correct epoch has 9 trailing zeros. */
     /* This magic number is the number of 100 nanosecond intervals since
@@ -29,5 +35,12 @@ int gettimeofday(struct timeval * tp, struct timezone * tzp)
 
     tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
     tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+    }
+    if (tzp) {
+        TIME_ZONE_INFORMATION timezone;
+        GetTimeZoneInformation(&timezone);
+        tzp->tz_minuteswest = timezone.Bias;
+        tzp->tz_dsttime = 0;
+    }
     return 0;
 }


### PR DESCRIPTION
# Title Fix for getimeofday pointer visibility 

Following up on issue # .

Proposed changes: Define struct timeval and pass it to the function
