### PR TITLE
qsort_r warning fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,7 +41,7 @@ dist_scaclocal_DATA = \
         config/sc_lapack.m4 config/sc_lint.m4 config/sc_mpi.m4 \
         config/ax_prefix_config_h.m4 config/ax_split_version.m4 \
         config/sc_package.m4 config/sc_trilinos.m4 \
-        config/sc_pthread.m4 config/sc_openmp.m4 config/sc_memalign.m4
+        config/sc_pthread.m4 config/sc_openmp.m4 config/sc_memalign.m4 config/sc_qsort.m4
 
 # install example .ini files in a dedicated directory
 scinidir = $(datadir)/ini

--- a/config/sc_qsort.m4
+++ b/config/sc_qsort.m4
@@ -1,0 +1,65 @@
+dnl
+dnl Test script for checking qsort_r
+dnl 
+AC_DEFUN([SC_QSORT_TEST], [
+   AC_MSG_CHECKING([if qsort_r conforms to GNU standard])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM(
+   [[
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include<stdlib.h>
+#ifdef __cplusplus
+#pragma GCC diagnostic ignored "-Wpragmas"
+#endif
+#pragma GCC diagnostic error "-Wimplicit-function-declaration"
+#pragma GCC diagnostic error "-Wincompatible-pointer-types"
+int
+comparator (const void *aa, const void *bb, void *arg)
+{
+  const int          *a = (int *) aa, *b = (int *) bb, *p = (int *) arg;
+  int                 cmp = *a - *b;
+  int                 inv_start = p[0], inv_end = p[1];
+  char                norm = (*a < inv_start || *a > inv_end || *b < inv_start
+                              || *b > inv_end);
+  return norm ? -cmp : cmp;
+}
+   ]],
+   [[
+int                 arr[4] = { 4, 3, 2, 1 };
+int                 p[] = { 0, 5 };
+qsort_r (arr, 4, sizeof (int), comparator, p);
+   ]])],
+   [AC_DEFINE([HAVE_GNU_QSORT_R],[1],[Define to 1 if qsort_r conforms to GNU standard])
+    AC_MSG_RESULT([yes])],
+   [AC_DEFINE([HAVE_GNU_QSORT_R],[0],[Define to 1 if qsort_r conforms to GNU standard])
+    AC_MSG_RESULT([no])])
+
+   AC_MSG_CHECKING([if qsort_r conforms to BSD standard])
+   AC_LINK_IFELSE([AC_LANG_PROGRAM(
+   [[
+#include<stdlib.h>
+#ifndef __cplusplus
+#pragma GCC diagnostic error "-Wimplicit-function-declaration"
+#endif
+int
+comparator (void *arg, const void *aa, const void *bb)
+{
+  const int          *a = (int *) aa, *b = (int *) bb, *p = (int *) arg;
+  int                 cmp = *a - *b;
+  int                 inv_start = p[0], inv_end = p[1];
+  char                norm = (*a < inv_start || *a > inv_end || *b < inv_start
+                              || *b > inv_end);
+  return norm ? -cmp : cmp;
+}
+   ]],
+   [[
+int                 arr[4] = { 4, 3, 2, 1 };
+int                 p[] = { 0, 5 };
+qsort_r (arr, 4, sizeof (int), p, comparator);
+   ]])],
+   [AC_DEFINE([HAVE_BSD_QSORT_R],[1],[Define to 1 if qsort_r conforms to BSD standard])
+    AC_MSG_RESULT([yes])],
+   [AC_DEFINE([HAVE_BSD_QSORT_R],[0],[Define to 1 if qsort_r conforms to BSD standard])
+      AC_MSG_RESULT([no])])
+ ])

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,7 @@ AC_CHECK_FUNCS([backtrace backtrace_symbols])
 AC_CHECK_FUNCS([strtol strtoll])
 AC_CHECK_FUNCS([fsync])
 AC_CHECK_FUNCS([qsort_r])
+SC_QSORT_TEST
 
 echo "o---------------------------------------"
 echo "| Checking libraries"


### PR DESCRIPTION
# Title Macro for selecting the correct qsort_r prototype depending on BSD or GNU system

Following up on issue # .

Proposed changes:
Create a macro which links with the correct prototype -> define and set C macro's SC_HAVE_GNU_QSORT_R and SC_HAVE_BSD_QSORT_R -> Use them in source code to select the the correct prototype and comparators  
