### PR TITLE
CMake: Bugfix: Do not compile and link libb64/b64(dec|enc).c

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,7 @@ target_include_directories(iniparser PRIVATE iniparser src ${PROJECT_BINARY_DIR}
 target_link_libraries(iniparser PRIVATE $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>)
 
 # --- libb64
-add_library(libb64 OBJECT libb64/cencode.c libb64/cdecode.c
-                          libb64/b64dec.c libb64/b64enc.c)
+add_library(libb64 OBJECT libb64/cencode.c libb64/cdecode.c)
 target_include_directories(libb64 PRIVATE libb64)
 
 # --- sc


### PR DESCRIPTION
Both source files only contain a single main() function that adds no
functionality to a shared or static library. Worse, newer linkers
start to reject linking object files with multiply defined global
symbols (in this case "main").

Simply remove both source files from the internal object library.


Ps.: I am not sure against what feature branch / developing branch I am
supposed to make a pull request. I simply chose "feature-cmake".