### PR TITLE
CMake: Bugfix: Build all targets with -fPIC

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -14,6 +14,12 @@ endif()
 find_package(ZLIB)
 find_package(Threads)
 
+# --- set global compile environment
+
+# Build all targets with -fPIC so that libsc itself can be linked as a
+# shared library, or linked into a shared library.
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # --- generate sc_config.h
 
 set(CMAKE_REQUIRED_INCLUDES)


### PR DESCRIPTION
It is simplest to build all libsc code with -fPIC/-fpic to ensure that
libsc itself can be linked as a shared library, or linked into a shared
library.