### PR TITLE
CI:CMake: test across many Clang, GCC versions

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -27,6 +27,13 @@ jobs:
     name: CMake build on Linux
     timeout-minutes: 15
 
+    strategy:
+      matrix:
+        cc: [clang-7, clang-8, clang-9, clang-10, gcc-7, gcc-8, gcc-9, gcc-10, gcc-11]
+
+    env:
+      CC: ${{ matrix.cc }}
+
     steps:
     - uses: actions/checkout@v2
       name: Checkout source code
@@ -35,7 +42,8 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            libopenmpi-dev openmpi-bin ninja-build
+            libopenmpi-dev openmpi-bin ninja-build \
+            ${{ matrix.cc }}
 
     - name: CMake configure
       run: cmake -B build --preset default --install-prefix=$HOME

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13...3.21)
+cmake_minimum_required(VERSION 3.13...3.23)
 
 include(cmake/git.cmake)
 


### PR DESCRIPTION
We had some issues with a specific GCC version. Having many compiler versions in CI helps show it's a system issue vs. libsc issue.