### PR TITLE
CMake: add v4l2 like autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,12 @@ add_library(sc $<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:libb64>)
 target_compile_features(sc PRIVATE c_std_99)
 set_target_properties(sc PROPERTIES EXPORT_NAME SC)
 target_include_directories(sc
-  PRIVATE src src/sc_builtin ${PROJECT_BINARY_DIR}/include iniparser libb64
-  INTERFACE
-  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/sc_builtin>
-  $<INSTALL_INTERFACE:include>
+PRIVATE src src/sc_builtin ${PROJECT_BINARY_DIR}/include iniparser libb64
+INTERFACE
+$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
+$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
+$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/sc_builtin>
+$<INSTALL_INTERFACE:include>
 )
 target_link_libraries(sc PUBLIC
 $<$<BOOL:${MPI_FOUND}>:MPI::MPI_C>

--- a/cmake/check_v4l2.c
+++ b/cmake/check_v4l2.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include <linux/videodev2.h>
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
+#error "Disabling v4l2 code for linux version < 4"
+#endif
+
+int main(void) {
+  struct v4l2_pix_format pf;
+  pf.ycbcr_enc = V4L2_YCBCR_ENC_DEFAULT;
+  pf.quantization = V4L2_QUANTIZATION_DEFAULT;
+  pf.xfer_func = V4L2_XFER_FUNC_DEFAULT;
+
+  open ("/", O_NONBLOCK | O_RDWR);
+  ioctl (0, VIDIOC_QUERYCAP, NULL);
+  ioctl (0, VIDIOC_ENUMOUTPUT, NULL);
+  ioctl (0, VIDIOC_S_OUTPUT, NULL);
+  ioctl (0, VIDIOC_S_FMT, NULL);
+  select (0, NULL, NULL, NULL, NULL);
+  write (0, NULL, 0);
+
+  return 0;
+}

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -2,6 +2,7 @@ include(CheckIncludeFile)
 include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckPrototypeDefinition)
+include(CheckCSourceCompiles)
 
 # --- keep library finds in here so we don't forget to do them first
 
@@ -77,8 +78,8 @@ check_symbol_exists(backtrace_symbols execinfo.h SC_HAVE_BACKTRACE_SYMBOLS)
 # check_include_file(dlfcn.h SC_HAVE_DLFCN_H)
 check_include_file(execinfo.h SC_HAVE_EXECINFO_H)
 check_symbol_exists(fsync unistd.h SC_HAVE_FSYNC)
-# check_include_file(inttypes.h SC_HAVE_INTTYPES_H)
-# check_include_file(memory.h SC_HAVE_MEMORY_H)
+check_include_file(inttypes.h SC_HAVE_INTTYPES_H)
+check_include_file(memory.h SC_HAVE_MEMORY_H)
 
 check_symbol_exists(posix_memalign stdlib.h SC_HAVE_POSIX_MEMALIGN)
 
@@ -127,6 +128,21 @@ if(SC_HAVE_UNISTD_H)
   check_include_file(getopt.h SC_HAVE_GETOPT_H)
 endif()
 
+check_include_file(sys/ioctl.h SC_HAVE_SYS_IOCTL_H)
+check_include_file(sys/select.h SC_HAVE_SYS_SELECT_H)
+check_include_file(sys/stat.h SC_HAVE_SYS_STAT_H)
+check_include_file(fcntl.h SC_HAVE_FCNTL_H)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  check_include_file(linux/videodev2.h SC_HAVE_LINUX_VIDEODEV2_H)
+  check_include_file(linux/version.h SC_HAVE_LINUX_VERSION_H)
+
+  if(SC_HAVE_LINUX_VIDEODEV2_H AND SC_HAVE_LINUX_VERSION_H)
+    file(READ ${CMAKE_CURRENT_LIST_DIR}/check_v4l2.c check_v4l2_src)
+    check_c_source_compiles([=[${check_v4l2_src}]=] SC_ENABLE_V4L2)
+  endif()
+endif()
+
 if(ZLIB_FOUND)
   set(CMAKE_REQUIRED_LIBRARIES ZLIB::ZLIB)
   check_symbol_exists(adler32_combine zlib.h SC_HAVE_ZLIB)
@@ -149,10 +165,10 @@ configure_file(${CMAKE_CURRENT_LIST_DIR}/sc_config.h.in ${PROJECT_BINARY_DIR}/in
 # --- sanity check of MPI sc_config.h
 
 # check if libsc was configured properly
-include(CheckSymbolExists)
 set(CMAKE_REQUIRED_FLAGS)
 set(CMAKE_REQUIRED_INCLUDES)
 set(CMAKE_REQUIRED_LIBRARIES)
+set(CMAKE_REQUIRED_DEFINITIONS)
 
 # libsc and current project must both be compiled with/without MPI
 check_symbol_exists(SC_ENABLE_MPI ${PROJECT_BINARY_DIR}/include/sc_config.h SC_has_mpi)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -3,6 +3,14 @@ option(openmp "use OpenMP" off)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
+# Rpath options necessary for shared library install to work correctly in user projects
+set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+
+# Necessary for shared library with Visual Studio / Windows oneAPI
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
+
 # --- default install directory under build/local
 # users can specify like "cmake -B build --install-prefix=$HOME/mydir"
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -50,6 +50,9 @@
 /* Undefine if: replace array/dmatrix resize with malloc/copy/free */
 #cmakedefine SC_ENABLE_USE_REALLOC
 
+/* Development with V4L2 devices works */
+#cmakedefine SC_ENABLE_V4L2
+
 /* Define to 1 if you have the `aligned_alloc' function. */
 #cmakedefine SC_HAVE_ALIGNED_ALLOC
 
@@ -68,14 +71,23 @@
 /* Define to 1 if you have the <execinfo.h> header file. */
 #cmakedefine SC_HAVE_EXECINFO_H
 
+/* Define to 1 if you have the <fcntl.h> header file. */
+#cmakedefine SC_HAVE_FCNTL_H
+
 /* Define to 1 if you have the `fsync' function. */
 #cmakedefine SC_HAVE_FSYNC
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-// cmakedefine SC_HAVE_INTTYPES_H
+#cmakedefine SC_HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <linux/version.h> header file. */
+#cmakedefine SC_HAVE_LINUX_VERSION_H
+
+/* Define to 1 if you have the <linux/videodev2.h> header file. */
+#cmakedefine SC_HAVE_LINUX_VIDEODEV2_H
 
 /* Define to 1 if you have the <memory.h> header file. */
-//#cmakedefine SC_HAVE_MEMORY_H
+#cmakedefine SC_HAVE_MEMORY_H
 
 /* Define to 1 if you have the `posix_memalign' function. */
 #cmakedefine SC_HAVE_POSIX_MEMALIGN
@@ -103,6 +115,15 @@
 
 /* Define to 1 if you have the `strtoll' function. */
 #cmakedefine SC_HAVE_STRTOLL
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#cmakedefine SC_HAVE_SYS_IOCTL_H
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#cmakedefine SC_HAVE_SYS_SELECT_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine SC_HAVE_SYS_STAT_H
 
 /* Define to 1 if you have the <sys/time.h> header file. */
 #cmakedefine SC_HAVE_SYS_TIME_H

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13...3.21)
+cmake_minimum_required(VERSION 3.13...3.23)
 project(libscExamples LANGUAGES C)
 
 include(CTest)
@@ -23,6 +23,7 @@ find_package(Threads)
 # --- find our library
 
 find_package(SC REQUIRED)
+set(cfg_h ${SC_INCLUDE_DIRS}/sc_config.h)
 
 # --- get system capabilities
 
@@ -32,10 +33,9 @@ if(NOT SC_NONEED_M)
   check_symbol_exists(sqrt math.h SC_NEED_M)
 endif()
 
-check_include_file(unistd.h SC_HAVE_UNISTD_H)
-if(SC_HAVE_UNISTD_H)
-  check_include_file(getopt.h SC_HAVE_GETOPT_H)
-endif()
+check_symbol_exists(SC_HAVE_UNISTD_H ${cfg_h} SC_HAVE_UNISTD_H)
+check_symbol_exists(SC_HAVE_GETOPT_H ${cfg_h} SC_HAVE_GETOPT_H)
+check_symbol_exists(SC_ENABLE_V4L2 ${cfg_h} SC_ENABLE_V4L2)
 
 target_link_libraries(SC::SC INTERFACE
 $<$<BOOL:${MPI_C_FOUND}>:MPI::MPI_C>
@@ -51,12 +51,13 @@ add_executable(sc_${name} ${files})
 
 target_link_libraries(sc_${name} PRIVATE SC::SC)
 
-
 if(MPI_C_FOUND)
   add_test(NAME sc:example:${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:sc_${name}>)
 else()
-  add_test(NAME sc:example:${name} COMMAND $<TARGET_FILE:sc_${name}>)
+  add_test(NAME sc:example:${name} COMMAND sc_${name})
 endif()
+
+set_tests_properties(sc:example:${name} PROPERTIES TIMEOUT 10)
 
 endfunction(test_sc_example)
 
@@ -80,4 +81,8 @@ if(Threads_FOUND)
     test_sc_example(pthread pthread/pthread.c)
     target_link_libraries(sc_pthread PRIVATE Threads::Threads)
   endif()
+endif()
+
+if(SC_ENABLE_V4L2)
+  test_sc_example(v4l2 v4l2/v4l2.c)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ sc_flops.c sc_random.c
 sc_polynom.c
 sc_keyvalue.c sc_refcount.c sc_shmem.c
 sc_allgather.c sc_reduce.c sc_notify.c
-sc_uint128.c
+sc_uint128.c sc_v4l2.c
 )
 
 if(SC_HAVE_GETOPT_H)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,14 @@
-target_sources(sc PRIVATE sc.c sc_mpi.c sc_containers.c sc_avl.c sc_string.c sc_unique_counter.c sc_functions.c sc_statistics.c sc_ranges.c sc_io.c sc_amr.c sc_search.c sc_sort.c sc_flops.c sc_random.c sc_polynom.c sc_keyvalue.c sc_refcount.c sc_shmem.c sc_allgather.c sc_reduce.c sc_notify.c sc_uint128.c)
+target_sources(sc PRIVATE sc.c sc_mpi.c sc_containers.c sc_avl.c
+sc_string.c sc_unique_counter.c
+sc_functions.c sc_statistics.c
+sc_ranges.c sc_io.c
+sc_amr.c sc_search.c sc_sort.c
+sc_flops.c sc_random.c
+sc_polynom.c
+sc_keyvalue.c sc_refcount.c sc_shmem.c
+sc_allgather.c sc_reduce.c sc_notify.c
+sc_uint128.c
+)
 
 if(SC_HAVE_GETOPT_H)
   target_sources(sc PRIVATE sc_options.c sc_getopt.c sc_getopt1.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,24 +1,24 @@
-set(tests allgather arrays keyvalue notify reduce search sortb version)
+set(sc_tests allgather arrays keyvalue notify reduce search sortb version)
 
 if(SC_HAVE_RANDOM AND SC_HAVE_SRANDOM)
-  list(APPEND tests node_comm)
+  list(APPEND sc_tests node_comm)
 endif()
 
 if(SC_SIZEOF_LONG GREATER_EQUAL 8)
-  list(APPEND tests helpers)
+  list(APPEND sc_tests helpers)
 endif()
 
 if(SC_HAVE_UNISTD_H)
-  list(APPEND tests sort)
+  list(APPEND sc_tests sort)
 endif()
 
 if(SC_HAVE_GETOPT_H)
-  list(APPEND tests builtin io_sink)
+  list(APPEND sc_tests builtin io_sink)
 endif()
 
 # ---
 
-foreach(t ${tests})
+foreach(t IN LISTS sc_tests)
 
   add_executable(test_${t} test_${t}.c)
   target_link_libraries(test_${t} PRIVATE SC::SC)
@@ -27,7 +27,7 @@ foreach(t ${tests})
   if(MPIEXEC_EXECUTABLE)
     add_test(NAME sc:${t} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:test_${t}>)
   else()
-    add_test(NAME sc:${t} COMMAND $<TARGET_FILE:test_${t}>)
+    add_test(NAME sc:${t} COMMAND test_${t})
   endif()
   set_tests_properties(sc:${t} PROPERTIES
     TIMEOUT 300


### PR DESCRIPTION
The new v4l2 wasn't in CMake, so this adds it and the v4l2 example.
Relevant symbols are added to sc_config.h.

cmake/options.cmake adds parameters relevant for shared build of libsc--enabling Rpath for Unix-like and on Windows exporting symbols for .lib import library that accompanies .dll.