### PR TITLE
CI:CMake: further compiler tests and improve efficiency

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -3,7 +3,6 @@ name: CI for CMake
 env:
   CMAKE_BUILD_TYPE: Release
   CTEST_PARALLEL_LEVEL: 3
-  CMAKE_GENERATOR: Ninja
 
 on:
   push:
@@ -43,14 +42,14 @@ jobs:
       run: |
         sudo apt-get update -yq
         sudo apt-get install -yq --no-install-recommends \
-            libopenmpi-dev openmpi-bin ninja-build \
+            libopenmpi-dev openmpi-bin \
             ${{ matrix.cc }}
 
     - name: CMake configure
       run: cmake -B build --preset default --install-prefix=${HOME} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build build --parallel
 
     - name: CMake install (for examples)
       run: cmake --install build
@@ -62,7 +61,7 @@ jobs:
       run: cmake -B example/build -S example -Dmpi=yes -DSC_ROOT=${HOME} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build examples
-      run: cmake --build example/build
+      run: cmake --build example/build --parallel
 
     - name: CMake test examples
       run: ctest --test-dir example/build --output-on-failure
@@ -96,13 +95,13 @@ jobs:
       name: Checkout source code
 
     - name: Install system dependencies
-      run: brew install open-mpi ninja
+      run: brew install open-mpi
 
     - name: CMake configure
       run: cmake -B build -Dmpi=yes --install-prefix=${HOME} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build build --parallel
 
     - name: CMake install (for examples)
       run: cmake --install build
@@ -114,7 +113,7 @@ jobs:
       run: cmake -B example/build -S example -Dmpi=yes -DSC_ROOT=${HOME} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build examples
-      run: cmake --build example/build
+      run: cmake --build example/build --parallel
 
     - name: CMake test examples
       run: ctest --test-dir example/build --output-on-failure
@@ -140,20 +139,10 @@ jobs:
       matrix:
         shared: [true, false]
 
+    env:
+      CMAKE_GENERATOR: MinGW Makefiles
+
     steps:
-    - uses: msys2/setup-msys2@v2
-      with:
-        update: true
-        install: >-
-          git
-          mingw-w64-x86_64-cmake
-          mingw-w64-x86_64-ninja
-          mingw-w64-x86_64-msmpi
-
-    - name: Put MSYS2_MinGW64 on PATH
-      # there is not yet an environment variable for this path from msys2/setup-msys2
-      run: echo "D:/a/_temp/msys64/mingw64/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
     - uses: actions/checkout@v2
       name: Checkout source code
 
@@ -161,7 +150,7 @@ jobs:
       run: cmake -B build -Dmpi:BOOL=no -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build
-      run: cmake --build build
+      run: cmake --build build --parallel
 
     - name: CMake install (for examples)
       run: cmake --install build
@@ -173,7 +162,7 @@ jobs:
       run: cmake -B example/build -S example -Dmpi:BOOL=no -DSC_ROOT=build/local -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build examples
-      run: cmake --build example/build
+      run: cmake --build example/build --parallel
 
     - name: CMake test examples
       run: ctest --test-dir example/build --output-on-failure

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -85,10 +85,12 @@ jobs:
 
     strategy:
       matrix:
+        cc: [clang, gcc]
         shared: [true, false]
 
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
+      CC: ${{ matrix.cc }}
 
     steps:
     - uses: actions/checkout@v2
@@ -133,7 +135,7 @@ jobs:
   windows:
     runs-on: windows-latest
     name: CMake build on Windows
-    timeout-minutes: 20
+    timeout-minutes: 15
 
     strategy:
       matrix:

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -156,7 +156,7 @@ check_type_size("unsigned long" SC_SIZEOF_UNSIGNED_LONG BUILTIN_TYPES_ONLY)
 check_type_size("unsigned long long" SC_SIZEOF_UNSIGNED_LONG_LONG BUILTIN_TYPES_ONLY)
 set(SC_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 
-if(CMAKE_BUILD_TYPE MATCHES "Debug")
+if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
   set(SC_ENABLE_DEBUG 1)
 endif()
 


### PR DESCRIPTION
Speed up CI by removing unneeded Ninja install (Make or Ninja works fine).
Speed up Windows CI by using default image GCC
Add Clang test to MacOS

Enable SC debug flags also for CMake RelWithDebInfo builds, which uses flags like `-O2 -g`