### PR TITLE
cmake:findSC: use canonical CMake approach to find/read sc_config.h

### DIFF
--- a/cmake/Modules/FindSC.cmake
+++ b/cmake/Modules/FindSC.cmake
@@ -27,7 +27,15 @@ NAMES sc
 DOC "libsc library"
 )
 
-if(SC_INCLUDE_DIR AND SC_LIBRARY)
+if(SC_LIBRARY AND SC_INCLUDE_DIR)
+  find_file(SC_CONFIG_H
+  NAMES sc_config.h
+  NO_DEFAULT_PATH
+  HINTS ${SC_INCLUDE_DIR}
+  )
+endif()
+
+if(SC_CONFIG_H)
   set(SC_mpi_ok true)
 
   # check if libsc was configured in compatible way
@@ -37,8 +45,8 @@ if(SC_INCLUDE_DIR AND SC_LIBRARY)
   set(CMAKE_REQUIRED_LIBRARIES)
 
   # libsc and current project must both be compiled with/without MPI
-  check_symbol_exists(SC_ENABLE_MPI ${SC_INCLUDE_DIR}/sc_config.h SC_has_mpi)
-  check_symbol_exists(SC_ENABLE_MPIIO ${SC_INCLUDE_DIR}/sc_config.h SC_has_mpi_io)
+  check_symbol_exists(SC_ENABLE_MPI ${SC_CONFIG_H} SC_has_mpi)
+  check_symbol_exists(SC_ENABLE_MPIIO ${SC_CONFIG_H} SC_has_mpi_io)
 
   if(MPI_C_FOUND)
     # a sign the current project is using MPI
@@ -56,7 +64,8 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args (SC
-  REQUIRED_VARS SC_LIBRARY SC_INCLUDE_DIR SC_mpi_ok)
+REQUIRED_VARS SC_LIBRARY SC_INCLUDE_DIR SC_mpi_ok
+)
 
 if(SC_FOUND)
 
@@ -74,4 +83,4 @@ endif()
 
 endif(SC_FOUND)
 
-mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY)
+mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY SC_has_mpi SC_has_mpi_io)


### PR DESCRIPTION
this avoids polluting CMakeError.log with nuisance messages when
SC is not completely found.

(cherry picked from p4est PR)