### PR TITLE
cmake: rpath after default install prefix

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -3,6 +3,13 @@ option(openmp "use OpenMP" off)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS on)
 
+# --- default install directory under build/local
+# users can specify like "cmake -B build --install-prefix=$HOME/mydir"
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  # will not take effect without FORCE
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/local" CACHE PATH "Install top-level directory" FORCE)
+endif()
+
 # Rpath options necessary for shared library install to work correctly in user projects
 set(CMAKE_INSTALL_NAME_DIR ${CMAKE_INSTALL_PREFIX}/lib)
 set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
@@ -10,13 +17,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 
 # Necessary for shared library with Visual Studio / Windows oneAPI
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
-
-# --- default install directory under build/local
-# users can specify like "cmake -B build --install-prefix=$HOME/mydir"
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  # will not take effect without FORCE
-  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/local" CACHE PATH "Install top-level directory" FORCE)
-endif()
 
 # --- auto-ignore build directory
 if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)


### PR DESCRIPTION
Fixes a recent mistake--the Rpath defaults need to come after the default install prefix is set