### PR TITLE
Use autoconf's `ac_c_werror_flag` for compiler-portable qsort_r compatibility check

### DIFF
--- a/config/sc_qsort.m4
+++ b/config/sc_qsort.m4
@@ -10,6 +10,16 @@ dnl The PREFIX argument is currently unused but should be supplied.
 dnl
 AC_DEFUN([SC_CHECK_QSORT_R], [
 
+   AC_LANG_PUSH([C])
+
+   dnl We want any warning about missing declarations or incompatible pointer
+   dnl types to trigger an error: in a belt-and-suspenders approach, we have
+   dnl the `#pragma GCC diagnostic error` statements in the source, but we also
+   dnl uses this compiler's version of "-Werror" that autoconf already knows
+   dnl about for this test
+   sc_check_qsort_r_save_werror_flag=$ac_c_werror_flag
+   ac_c_werror_flag=yes
+
    AC_MSG_CHECKING([whether qsort_r conforms to GNU standard])
    AC_LINK_IFELSE([AC_LANG_PROGRAM(
    [[
@@ -48,6 +58,7 @@ qsort_r (arr, 4, sizeof (int), comparator, p);
 #include <stdlib.h>
 #ifndef __cplusplus
 #pragma GCC diagnostic error "-Wimplicit-function-declaration"
+#pragma GCC diagnostic error "-Wincompatible-pointer-types"
 #endif
 static int
 comparator (void *arg, const void *aa, const void *bb)
@@ -68,4 +79,8 @@ qsort_r (arr, 4, sizeof (int), p, comparator);
    [AC_DEFINE([HAVE_BSD_QSORT_R], [1], [Define to 1 if qsort_r conforms to BSD standard])
     AC_MSG_RESULT([yes])],
    [AC_MSG_RESULT([no])])
+
+   ac_c_werror_flag=$sc_check_qsort_r_save_werror_flag
+
+   AC_LANG_POP([C])
 ])


### PR DESCRIPTION
The `#pragma GCC diagnostic error` approach does not work when using,
for example, the intel compiler.