### PR TITLE
Fix the test in sc_mpi.m4 for whether MPIRUN exists and is a file

### DIFF
--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -97,7 +97,7 @@ $1_MPIRUN=
 $1_MPI_TEST_FLAGS=
 if test "x$HAVE_PKG_MPI" = xyes ; then
 AC_CHECK_PROGS([$1_MPIRUN], [mpiexec mpirun])
-if test "x$MPIRUN" != x -a `which "$MPIRUN"` ; then
+if test "x$MPIRUN" != x && test `which "$MPIRUN" 2> /dev/null` ; then
   $1_MPIRUN="$MPIRUN"
   $1_MPI_TEST_FLAGS="-np 2"
   dnl AC_MSG_NOTICE([Test environment "$$1_MPIRUN" "$$1_MPI_TEST_FLAGS"])


### PR DESCRIPTION
- insert a logical and between the two tests
- silence error output if 2>/dev/null

Without these changes I see the following output when configuring on frontera:

```
which: no  in (/opt/apps/xalt/xalt/bin:/opt/apps/autotools/1.3/bin:/home1/01236/tisaac/bin:/opt/apps/hwloc/1.11.12/bin:/opt/apps/pmix/3.1.4/bin:/opt/apps/cmake/3.20.3/bin:/opt/apps/intel19/python3/3.7.0/bin:/opt/apps/git/2.24.1/bin:/opt/intel/compilers_and_libraries_2020.4.304/linux/mpi/intel64/bin:/opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64:/opt/apps/gcc/8.3.0/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/bin:/usr/bin:/opt/ddn/ime/bin:.)
../configure: line 4595: test: argument expected
```

