### PR TITLE
Prepare array_is_sorted for const qvt

### DIFF
--- a/src/sc3_array.c
+++ b/src/sc3_array.c
@@ -110,8 +110,8 @@ sc3_array_is_unresizable (const sc3_array_t * a, char *reason)
 int
 sc3_array_is_sorted (const sc3_array_t * a,
                      sc3_error_t * (*compar) (const void *, const void *,
-                                              void *, int *),
-                     void *user, char *reason)
+                                              const void *, int *),
+                     const void *user, char *reason)
 {
   int                 i, j;
   const void         *vold, *vnew;

--- a/src/sc3_array.h
+++ b/src/sc3_array.h
@@ -165,8 +165,8 @@ int                 sc3_array_is_data (const sc3_array_t * a, char *reason);
 int                 sc3_array_is_sorted (const sc3_array_t * a, sc3_error_t *
                                          (*compar) (const void *,
                                                     const void *,
-                                                    void *, int *),
-                                         void *user, char *reason);
+                                                    const void *, int *),
+                                         const void *user, char *reason);
 
 /** Create a new array object in its setup phase.
  * It begins with default parameters that can be overridden explicitly.


### PR DESCRIPTION
Make it possible to pass a constant quadrant vtable to the function sc3_array_is_sorted. 