### PR TITLE
lock mpisize for cmake tests to 2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ if(SC_HAVE_GETOPT_H)
 endif()
 
 # ---
-
+set(MPIEXEC_MAX_NUMPROCS 2)
 foreach(t IN LISTS sc_tests)
 
   add_executable(test_${t} test_${t}.c)


### PR DESCRIPTION
Fix mpisize for cmake tests

Proposed changes:
Set MPIEXEC_MAX_NUMPROCS variable to 2