### PR TITLE
use correct directory names for darwin ci

### DIFF
--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -25,8 +25,6 @@ jobs:
 
      - uses: actions/checkout@v2
        name: Checkout source code
-       with:
-          fetch-depth: 0
 
      - name: Install system dependencies
        run: brew install open-mpi ninja automake
@@ -47,7 +45,7 @@ jobs:
      - name: Make check with debug and MPI
        shell: bash
        run: |
-          DIR="checkDebug" && mkdir -p "$DIR" && cd "$DIR"
+          DIR="checkDebugMPI" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug --enable-mpi \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
           make -j V=0
@@ -57,7 +55,7 @@ jobs:
      - name: Make check with debug, MPI and C++ compiler
        shell: bash
        run: |
-          DIR="checkDebug" && mkdir -p "$DIR" && cd "$DIR"
+          DIR="checkDebugMPICXX" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug --enable-mpi CC=mpicxx \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
           make -j V=0
@@ -70,5 +68,5 @@ jobs:
        with:
          name: darwin_log
          path: |
-            ./checkDebug/config.log
-            ./checkDebug/test-suite.log
+            ./**/config.log
+            ./**/test-suite.log


### PR DESCRIPTION
We do not use fetch-depth here because we do not build a tarball.