### PR TITLE
Wrap MPI_Testall

### DIFF
--- a/src/sc_mpi.c
+++ b/src/sc_mpi.c
@@ -511,6 +511,24 @@ sc_MPI_Waitall (int count, sc_MPI_Request * array_of_requests,
 }
 
 int
+sc_MPI_Testall (int count, sc_MPI_Request * array_of_requests, int *flag,
+                sc_MPI_Status * array_of_statuses)
+{
+#ifdef SC_ENABLE_MPI
+  /* we do this to avoid warnings when the prototype uses [] */
+  return MPI_Testall (count, array_of_requests, flag, array_of_statuses);
+#else
+  int                 i;
+
+  for (i = 0; i < count; ++i) {
+    SC_CHECK_ABORT (array_of_requests[i] == sc_MPI_REQUEST_NULL,
+                    "non-MPI MPI_Testall handles NULL requests only");
+  }
+  return sc_MPI_SUCCESS;
+#endif
+}
+
+int
 sc_MPI_Error_class (int errorcode, int *errorclass)
 {
 #ifdef SC_ENABLE_MPIIO

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -262,7 +262,7 @@ sc_MPI_IO_Errorcode_t;
 #define sc_MPI_Get_count           MPI_Get_count
 #define sc_MPI_Wtime               MPI_Wtime
 #define sc_MPI_Wait                MPI_Wait
-/* The MPI_Waitsome and MPI_Waitall functions are wrapped. */
+/* The MPI_Waitsome, MPI_Waitall and MPI_Testall functions are wrapped. */
 #define sc_MPI_Type_size           MPI_Type_size
 
 #else /* !SC_ENABLE_MPI */
@@ -480,6 +480,8 @@ int                 sc_MPI_Wait (sc_MPI_Request *, sc_MPI_Status *);
 int                 sc_MPI_Waitsome (int, sc_MPI_Request *,
                                      int *, int *, sc_MPI_Status *);
 int                 sc_MPI_Waitall (int, sc_MPI_Request *, sc_MPI_Status *);
+int                 sc_MPI_Testall (int, sc_MPI_Request *, int *,
+                                    sc_MPI_Status *);
 
 #if defined SC_ENABLE_MPI && defined SC_ENABLE_MPITHREAD
 

--- a/src/sc_notify.c
+++ b/src/sc_notify.c
@@ -1963,7 +1963,7 @@ sc_notify_payload_nbx (sc_array_t * receivers, sc_array_t * senders,
       int                 sent;
 
       mpiret =
-        MPI_Testall (num_receivers, sendreqs, &sent, MPI_STATUSES_IGNORE);
+        sc_MPI_Testall (num_receivers, sendreqs, &sent, MPI_STATUSES_IGNORE);
       SC_CHECK_MPI (mpiret);
       if (sent) {
         mpiret = MPI_Ibarrier (comm, &barreq);
@@ -2090,7 +2090,7 @@ sc_notify_payloadv_nbx (sc_array_t * receivers, sc_array_t * senders,
       int                 sent;
 
       mpiret =
-        MPI_Testall (num_receivers, sendreqs, &sent, MPI_STATUSES_IGNORE);
+        sc_MPI_Testall (num_receivers, sendreqs, &sent, MPI_STATUSES_IGNORE);
       SC_CHECK_MPI (mpiret);
       if (sent) {
         mpiret = MPI_Ibarrier (comm, &barreq);


### PR DESCRIPTION
# Wrap MPI_Testall

Proposed changes: Wrap MPI_Testall to avoid compiler warnings due to the differentiation between TYPE* abc and TYPE abc[] that is done by some compilers (gcc 11.2).
