### PR TITLE
Initialize output of sc_{strcopy,snprintf}

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -1520,6 +1520,9 @@ sc_snprintf (char *str, size_t size, const char *fmt, ...)
     return;
   }
 
+  /* avoid uninitialized bytes if strlen (src) < size - 1 */
+  memset (str, (int) '\0', size);
+
   /* Writing this function just to catch the return value.
      Avoiding -Wnoformat-truncation gcc option this way */
   va_start (ap, fmt);

--- a/src/sc.c
+++ b/src/sc.c
@@ -1521,7 +1521,7 @@ sc_snprintf (char *str, size_t size, const char *fmt, ...)
   }
 
   /* avoid uninitialized bytes if strlen (src) < size - 1 */
-  memset (str, (int) '\0', size);
+  memset (str, 0, size);
 
   /* Writing this function just to catch the return value.
      Avoiding -Wnoformat-truncation gcc option this way */

--- a/src/sc.h
+++ b/src/sc.h
@@ -763,6 +763,9 @@ int                 sc_is_root (void);
 /** Provide a string copy function.
  * \param [out] dest    Buffer of length at least \a size.
  *                      On output, not touched if NULL or \a size == 0.
+ *                      Otherwise, \a src is copied to \a dest and
+ *                      \a dest is padded with '\0' from the right
+ *                      if strlen (src) < size - 1.
  * \param [in] size     Allocation length of \a dest.
  * \param [in] src      Null-terminated string.
  * \return              Equivalent to \ref
@@ -777,6 +780,9 @@ void                sc_strcopy (char *dest, size_t size, const char *src);
  * \param [out] str     Buffer of length at least \a size.
  *                      On output, not touched if NULL or \a size == 0.
  *                      Otherwise, "" on snprintf error or the proper result.
+ *                      The proper result is padded on the right with '\0'
+ *                      if the allocation length of the string that is
+ *                      defined by \a format is shorter than \a size.
  * \param [in] size     Allocation length of \a str.
  * \param [in] format   Format string as in man (3) snprintf.
  */

--- a/src/sc_containers.c
+++ b/src/sc_containers.c
@@ -181,7 +181,7 @@ sc_array_truncate (sc_array_t * array)
 
 #if SC_ENABLE_DEBUG
   SC_ASSERT (array->byte_alloc >= 0);
-  memset (array->array, (char) -1, array->byte_alloc);
+  memset (array->array, -1, array->byte_alloc);
 #endif
 }
 
@@ -246,7 +246,7 @@ sc_array_resize (sc_array_t * array, size_t new_count)
   else {
 #ifdef SC_ENABLE_DEBUG
     if (newoffs < oldoffs) {
-      memset (array->array + newoffs, (char) -1, oldoffs - newoffs);
+      memset (array->array + newoffs, -1, oldoffs - newoffs);
     }
     for (i = oldoffs; i < newoffs; ++i) {
       SC_ASSERT (array->array[i] == (char) -1);
@@ -274,7 +274,7 @@ sc_array_resize (sc_array_t * array, size_t new_count)
 
 #ifdef SC_ENABLE_DEBUG
   SC_ASSERT (minoffs <= newsize);
-  memset (array->array + minoffs, (char) -1, newsize - minoffs);
+  memset (array->array + minoffs, -1, newsize - minoffs);
 #endif
 }
 


### PR DESCRIPTION
# Initialize output of sc_{strcopy,snprintf}

Proposed changes: We initialize the output string of `sc_{strcopy,snprintf}` with `'\0'`. Therefore, the output of the mentioned function is now initialized even after the first `'\0'`. The initialization is equivalent to padding the output to the right with `'\0'`.
