### PR TITLE
Feature test valgrind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   linux-valgrind:
     runs-on: ubuntu-latest
-    name: Autotools with valgrind on Linux
+    name: Autotools with valgrind
     steps:
 
     - name: Install system dependencies
@@ -115,6 +115,15 @@ jobs:
           CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
         make -j V=0
         make -j check V=0
+
+    - name: Upload log files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux_valgrind_log
+        path: |
+          ./**/test-suite.log
+          ./**/config.log
 
   linux-tarball:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,33 @@ jobs:
           ./**/test-suite.log
           ./**/config.log
 
+  linux-valgrind:
+    runs-on: ubuntu-latest
+    name: Autotools with valgrind on Linux
+    steps:
+
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -yq
+        sudo apt-get install -yq --no-install-recommends \
+            zlib1g-dev libmpich-dev mpich valgrind
+
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
+    - name: Run bootstrap script
+      run: ./bootstrap
+
+    - name: Make check with MPI, debug and valgrind, without shared
+      shell: bash
+      run: |
+        DIR="checkMPIdebug_valgrind" && mkdir -p "$DIR" && cd "$DIR"
+        ../configure --enable-mpi --enable-debug \
+                     --disable-shared --enable-valgrind \
+          CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+        make -j V=0
+        make -j check V=0
+
   linux-tarball:
     runs-on: ubuntu-latest
     name: Pack tarball on Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,9 @@ jobs:
       with:
         name: linux_multi_log
         path: |
-          ./**/test-suite.log
           ./**/config.log
+          ./**/test-suite.log
+          ./**/test/*.log
 
   linux-valgrind:
     runs-on: ubuntu-latest
@@ -122,8 +123,9 @@ jobs:
       with:
         name: linux_valgrind_log
         path: |
-          ./**/test-suite.log
           ./**/config.log
+          ./**/test-suite.log
+          ./**/test/*.log
 
   linux-tarball:
     runs-on: ubuntu-latest
@@ -175,5 +177,6 @@ jobs:
       with:
         name: linux_tarball_log
         path: |
-          ./**/test-suite.log
           ./**/config.log
+          ./**/test-suite.log
+          ./**/test/*.log

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -67,3 +67,4 @@ jobs:
          path: |
             ./**/config.log
             ./**/test-suite.log
+            ./**/test/*.log

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -16,7 +16,6 @@ jobs:
   darwin:
     runs-on: macos-latest
     name: Autotools build on Darwin
-    timeout-minutes: 20
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ DISTCLEANFILES += \
 
 # setup test environment
 LOG_COMPILER = @SC_MPIRUN@
-AM_LOG_FLAGS = @SC_MPI_TEST_FLAGS@
+AM_LOG_FLAGS = @SC_MPI_TEST_FLAGS@ @SC_VALGRIND@
 
 # non-recursive build
 include src/Makefile.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -57,10 +57,8 @@ DISTCLEANFILES += \
 .PHONY: ChangeLog
 
 # setup test environment
-if SC_MPIRUN
 LOG_COMPILER = @SC_MPIRUN@
 AM_LOG_FLAGS = @SC_MPI_TEST_FLAGS@
-endif
 
 # non-recursive build
 include src/Makefile.am

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -118,24 +118,20 @@ dnl Establish the MPI test environment
 $1_MPIRUN=
 $1_MPI_TEST_FLAGS=
 if test "x$HAVE_PKG_MPI" = xyes ; then
-AC_CHECK_PROGS([$1_MPIRUN], [mpiexec mpirun])
-if test "x$MPIRUN" != x && test -x `which "$MPIRUN" 2> /dev/null` ; then
-  $1_MPIRUN="$MPIRUN"
-  $1_MPI_TEST_FLAGS="-np 2"
-  dnl AC_MSG_NOTICE([Test environment "$$1_MPIRUN" "$$1_MPI_TEST_FLAGS"])
-elif test "x$$1_MPIRUN" = xmpiexec ; then
-  # $1_MPIRUN=mpiexec
-  $1_MPI_TEST_FLAGS="-n 2"
-elif test "x$$1_MPIRUN" = xmpirun ; then
-  # $1_MPIRUN=mpirun
-  $1_MPI_TEST_FLAGS="-np 2"
-else
-  $1_MPIRUN=
+  AC_CHECK_PROGS([$1_MPIRUN], [mpirun mpiexec])
+  if test "x$$1_MPIRUN" = xmpirun ; then
+    $1_MPI_TEST_FLAGS="-np 2"
+  elif test "x$$1_MPIRUN" = xmpiexec ; then
+    $1_MPI_TEST_FLAGS="-n 2"
+  else
+    AC_MSG_ERROR([--enable-mpi given but neither mpirun nor mpiexec found])
+  fi
 fi
+dnl We are not using precious variables for simplicity
+dnl AC_ARG_VAR([$1_MPIRUN], [mpirun wrapper to invoke for tests on make check])
 AC_SUBST([$1_MPIRUN])
+dnl AC_ARG_VAR([$1_MPI_TEST_FLAGS], [arguments passed to mpirun wrapper on make check])
 AC_SUBST([$1_MPI_TEST_FLAGS])
-fi
-AM_CONDITIONAL([$1_MPIRUN], [test "x$$1_MPIRUN" != x])
 
 dnl Set compilers if not already set and set define and conditionals
 if test "x$HAVE_PKG_MPI" = xyes ; then

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -114,6 +114,25 @@ elif test "x$enableval" != xno ; then
   AC_MSG_WARN([Ignoring --enable-mpishared with unsupported argument])
 fi
 
+dnl We allow the user to specify the configure option --enable-valgrind.
+dnl If given and valgrind is found, we use it to run tests on make check.
+dnl If given and valgrind is not found, we abort with an error message.
+dnl If not given, we run tests in the default manner (ignoring valgrind).
+$1_VALGRIND=
+AC_ARG_ENABLE([valgrind],
+              [AS_HELP_STRING([--enable-valgrind],
+               [use valgrind with make check to run tests])],,
+              [enableval=no])
+if test "x$enableval" = xyes ; then
+  AC_CHECK_PROG([$1_VALGRIND], [valgrind], [valgrind])
+  if test "x$$1_VALGRIND" != xvalgrind ; then
+    AC_MSG_ERROR([--enable-valgrind given but valgrind not found in PATH])
+  fi
+fi
+dnl We are not making $1_VALGRIND a precious variable for simplicity
+dnl AC_ARG_VAR([$1_VALGRIND], [valgrind wrapper to invoke for tests on make check])
+AC_SUBST([$1_VALGRIND])
+
 dnl Establish the MPI test environment
 $1_MPIRUN=
 $1_MPI_TEST_FLAGS=


### PR DESCRIPTION
## Add configure option to run with valgrind on `make check`

### Proposed changes:

Add `--enable-valgrind` configure option. If given, we check and expect valgrind to be found, and we use it when running tests. With MPI, the effective test command is `mpirun -np 2 valgrind test/sc_test_foo`.

In addition, expand on the uploading of test results on running the CI.
