### PR TITLE
Feature encode

### DIFF
--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -394,8 +394,10 @@ if test "x$$1_HAVE_ZLIB" = x ; then
 AC_MSG_NOTICE([- $1 -------------------------------------------------
 We did not find a recent zlib containing the function adler32_combine.
 This is OK if the following does not matter to you:
-Calling any sc functions that rely on zlib will abort your program.
-These functions include sc_array_checksum and sc_vtk_write_compressed.
+ - Calling some functions that rely on zlib will abort your program.
+   These include sc_array_checksum and sc_vtk_write_compressed.
+ - The data produced by sc_io_encode is not compressed.
+ - The function sc_io_decode is slower than with zlib.
 You can fix this by compiling a recent zlib and pointing LIBS to it.
 ])
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ sc_polynom.c
 sc_keyvalue.c sc_refcount.c sc_shmem.c
 sc_allgather.c sc_reduce.c sc_notify.c
 sc_uint128.c sc_v4l2.c
+sc_puff.c
 )
 
 if(SC_HAVE_GETOPT_H)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,8 @@ libsc_installed_headers = \
         src/sc_getopt.h src/sc_polynom.h \
         src/sc_keyvalue.h src/sc_refcount.h src/sc_shmem.h \
         src/sc_allgather.h src/sc_reduce.h src/sc_notify.h \
-        src/sc_uint128.h src/sc_v4l2.h
+        src/sc_uint128.h src/sc_v4l2.h \
+        src/sc_puff.h
 libsc_internal_headers =
 libsc_compiled_sources = \
         src/sc.c src/sc_mpi.c src/sc_containers.c src/sc_avl.c \
@@ -28,9 +29,11 @@ libsc_compiled_sources = \
         src/sc_getopt.c src/sc_getopt1.c src/sc_polynom.c \
         src/sc_keyvalue.c src/sc_refcount.c src/sc_shmem.c \
         src/sc_allgather.c src/sc_reduce.c src/sc_notify.c \
-        src/sc_uint128.c src/sc_v4l2.c
+        src/sc_uint128.c src/sc_v4l2.c \
+        src/sc_puff.c
 libsc_original_headers = \
-        src/sc_builtin/getopt.h src/sc_builtin/getopt_int.h
+        src/sc_builtin/getopt.h src/sc_builtin/getopt_int.h \
+        src/sc_builtin/puff.h
 
 # this variable is used for headers that are not publicly installed
 LIBSC_CPPFLAGS =

--- a/src/sc_builtin/puff.h
+++ b/src/sc_builtin/puff.h
@@ -1,0 +1,35 @@
+/* puff.h
+  Copyright (C) 2002-2013 Mark Adler, all rights reserved
+  version 2.3, 21 Jan 2013
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler    madler@alumni.caltech.edu
+ */
+
+
+/*
+ * See puff.c for purpose and usage.
+ */
+#ifndef NIL
+#  define NIL ((unsigned char *)0)      /* for no output option */
+#endif
+
+int puff(unsigned char *dest,           /* pointer to destination pointer */
+         unsigned long *destlen,        /* amount of output space */
+         const unsigned char *source,   /* pointer to source data pointer */
+         unsigned long *sourcelen);     /* amount of input available */

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -527,7 +527,7 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
 }
 
 int
-sc_io_decode (sc_array_t *data, sc_array_t *out)
+sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
 {
   int                 i;
 #ifdef SC_HAVE_ZLIB
@@ -637,6 +637,12 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
   }
   if (encoded_size % out->elem_size != 0) {
     SC_LERROR ("encoded size not commensurable\n");
+    goto decode_error;
+  }
+  if (max_original_size > 0 && encoded_size > max_original_size) {
+    SC_LERRORF ("encoded size %llu larger than permitted %llu\n",
+                (unsigned long long) encoded_size,
+                (unsigned long long) max_original_size);
     goto decode_error;
   }
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -583,17 +583,17 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
 
     SC_ASSERT (lein > 0);
     if (lout == 0) {
-      SC_LERROR ("base 64 decode short");
+      SC_LERROR ("base 64 decode short\n");
       goto decode_error;
     }
     if (ipos[lein] != '\n') {
-      SC_LERROR ("base 64 missing newline");
+      SC_LERROR ("base 64 missing newline\n");
       goto decode_error;
     }
     if (zlin < base64_lines - 1) {
       SC_ASSERT (lein == 72);
       if (lout != 54) {
-        SC_LERROR ("base 64 decode mismatch");
+        SC_LERROR ("base 64 decode mismatch\n");
         goto decode_error;
       }
       memcpy (opos, base_out, 54);
@@ -618,7 +618,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
   SC_ASSERT (ocnt <= compressed_size);
   SC_ASSERT (ipos + 1 == data->array + encoded_size);
   if (ocnt < 8) {
-    SC_LERROR ("base 64 decodes to less than 8 bytes");
+    SC_LERROR ("base 64 decodes to less than 8 bytes\n");
     goto decode_error;
   }
 
@@ -635,7 +635,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
     encoded_size |= ((size_t) uc) << (i * 8);
   }
   if (encoded_size % out->elem_size != 0) {
-    SC_LERROR ("encoded size not commensurable");
+    SC_LERROR ("encoded size not commensurable\n");
     goto decode_error;
   }
 
@@ -650,11 +650,11 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
   zrv = uncompress ((Bytef *) out->array, (uLongf *) &encoded_size,
                     (Bytef *) (8 + compressed.array), ocnt - 8);
   if (zrv != Z_OK) {
-    SC_LERRORF ("zlib uncompress error: %d\n", zrv);
+    SC_LERROR ("zlib uncompress error\n");
     goto decode_error;
   }
   if (encoded_size != out->elem_count * out->elem_size) {
-    SC_LERROR ("zlib uncompress short");
+    SC_LERROR ("zlib uncompress short\n");
     goto decode_error;
   }
 #endif /* SC_HAVE_ZLIB */

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -411,14 +411,14 @@ static void
 sc_io_adler32_update (uint32_t *ps1, uint32_t *ps2,
                       const char *buffer, size_t length)
 {
-  int16_t    cn;
-  uint32_t   s1 = *ps1;
-  uint32_t   s2 = *ps2;
-  size_t     iz;
+  int16_t             cn;
+  uint32_t            s1 = *ps1;
+  uint32_t            s2 = *ps2;
+  size_t              iz;
 
   cn = 0;
   for (iz = 0; iz < length; ++iz) {
-    unsigned char uc = (unsigned char) buffer[iz];
+    unsigned char       uc = (unsigned char) buffer[iz];
     if (cn == 5000) {
       s1 = s1 % SC_IO_ADLER32_PRIME;
       s2 = s2 % SC_IO_ADLER32_PRIME;
@@ -583,10 +583,8 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
   /* verify adler32 checksum */
   SC_ASSERT (s1 < SC_IO_ADLER32_PRIME);
   SC_ASSERT (s2 < SC_IO_ADLER32_PRIME);
-  if (src[0] != (char) (s2 >> 8) ||
-      src[1] != (char) (s2 & 0xFF) ||
-      src[2] != (char) (s1 >> 8) ||
-      src[3] != (char) (s1 & 0xFF)) {
+  if (src[0] != (char) (s2 >> 8) || src[1] != (char) (s2 & 0xFF) ||
+      src[2] != (char) (s1 >> 8) || src[3] != (char) (s1 & 0xFF)) {
     SC_LERROR ("uncompress checksum error\n");
   }
   return 0;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -544,12 +544,10 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
     SC_LERROR ("uncompress header not conforming\n");
     return -1;
   }
-#ifndef SC_PUFF_INCLUDED
-  if (ucb & 0xE0) {
-    SC_LERROR ("uncompress cannot handle header\n");
+  if (ucb & 0x20) {
+    SC_LERROR ("uncompress cannot handle dictionary\n");
     return -1;
   }
-#endif
   src += 2;
   src_size -= 2;
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -518,7 +518,7 @@ sc_io_noncompress (char *dest, size_t dest_size,
 
 static int
 sc_io_nonuncompress (char *dest, size_t dest_size,
-                     const char *src, size_t src_size)
+                     const char *src, size_t src_size, void *re)
 {
   int                 final_block;
   uint32_t            adler;
@@ -528,6 +528,9 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
 #else
   unsigned long       destlen, sourcelen;
 #endif
+
+  /* in the future we will add runtime error reporting */
+  SC_ASSERT (re == NULL);
 
   /* check zlib format header */
   if (src_size < 2) {
@@ -794,14 +797,18 @@ sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
 }
 
 int
-sc_io_decode_info (sc_array_t *data,
-                   size_t *original_size, char *format_char)
+sc_io_decode_info (sc_array_t *data, size_t *original_size,
+                   char *format_char, void *re)
 {
   int                 i;
   size_t              osize;
   char                dec[12];
   base64_decodestate  bstate;
 
+  /* in the future we will add runtime error reporting */
+  SC_ASSERT (re == NULL);
+
+  /* basic checks */
   SC_ASSERT (SC_IO_ENCODE_INFO_LEN == 9);
   SC_ASSERT (data != NULL);
   SC_ASSERT (data->elem_size == 1);
@@ -849,7 +856,8 @@ sc_io_decode_info (sc_array_t *data,
 }
 
 int
-sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
+sc_io_decode (sc_array_t *data, sc_array_t *out,
+              size_t max_original_size, void *re)
 {
   int                 i;
   int                 zrv;
@@ -867,6 +875,9 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
 #endif
   sc_array_t          compressed;
   base64_decodestate  bstate;
+
+  /* in the future we will add runtime error reporting */
+  SC_ASSERT (re == NULL);
 
   /* examine input data */
   SC_ASSERT (data != NULL);
@@ -973,7 +984,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
 #ifndef SC_HAVE_ZLIB
   zrv = sc_io_nonuncompress (out->array, encoded_size,
                              compressed.array + SC_IO_ENCODE_INFO_LEN,
-                             ocnt - SC_IO_ENCODE_INFO_LEN);
+                             ocnt - SC_IO_ENCODE_INFO_LEN, re);
   if (zrv) {
     SC_LERROR ("Please consider configuring the build"
                " such that zlib is found.\n");

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -578,6 +578,7 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
   while (!final_block);
   if (src_size != 4 || dest_size != 0) {
     SC_LERROR ("uncompress content error\n");
+    return -1;
   }
 
   /* verify adler32 checksum */
@@ -586,7 +587,10 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
   if (src[0] != (char) (s2 >> 8) || src[1] != (char) (s2 & 0xFF) ||
       src[2] != (char) (s1 >> 8) || src[3] != (char) (s1 & 0xFF)) {
     SC_LERROR ("uncompress checksum error\n");
+    return -1;
   }
+
+  /* task accomplished */
   return 0;
 }
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -558,6 +558,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
   encoded_size = data->elem_count;
   if (encoded_size == 0 ||
       *(char *) sc_array_index (data, encoded_size - 1) != '\0') {
+    SC_LERROR ("input not NUL-terminated\n");
     return -1;
   }
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -419,8 +419,7 @@ sc_io_adler32_init (uint32_t *adler)
 }
 
 static void
-sc_io_adler32_update (uint32_t *adler,
-                      const char *buffer, size_t length)
+sc_io_adler32_update (uint32_t *adler, const char *buffer, size_t length)
 {
   size_t              iz;
   int16_t             cn;
@@ -527,7 +526,7 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
 #ifndef SC_PUFF_INCLUDED
   uint16_t            bsize, nsize;
 #else
-  unsigned  long      destlen, sourcelen;
+  unsigned long       destlen, sourcelen;
 #endif
 
   /* check zlib format header */
@@ -797,14 +796,14 @@ sc_io_decode_length (sc_array_t *data, size_t *original_size)
   osize = base64_decode_block (data->array, 12, dec, &bstate);
   if (osize != 9) {
     SC_LERROR ("sc_io_decode_length base 64 error\n");
-    return - 1;
+    return -1;
   }
 
   /* verify first byte of zlib format */
   uc = (unsigned char) dec[8];
   if ((uc & 0x8F) != 8) {
     SC_LERROR ("sc_io_decode_length data format error\n");
-    return - 1;
+    return -1;
   }
 
   /* decode original length of data */

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -388,20 +388,20 @@ void
 sc_io_encode (sc_array_t *data, sc_array_t *out)
 {
 #ifdef SC_HAVE_ZLIB
-  int zrv;
-  uLong input_compress_bound;
+  int                 zrv;
+  uLong               input_compress_bound;
 #endif
-  char *ipos, *opos;
-  char base_out[2 * 72];
-  size_t input_size;
-  size_t base64_lines;
-  size_t encoded_size;
-  size_t zlin, irem;
+  char               *ipos, *opos;
+  char                base_out[2 * 72];
+  size_t              input_size;
+  size_t              base64_lines;
+  size_t              encoded_size;
+  size_t              zlin, irem;
 #ifdef SC_ENABLE_DEBUG
-  size_t ocnt;
+  size_t              ocnt;
 #endif
-  sc_array_t compressed;
-  base64_encodestate bstate;
+  sc_array_t          compressed;
+  base64_encodestate  bstate;
 
   SC_ASSERT (data != NULL);
   if (out == NULL) {
@@ -458,8 +458,9 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
   SC_ASSERT (ocnt + 1 <= encoded_size);
   opos[0] = '\0';
   for (zlin = 0; zlin < base64_lines; ++zlin) {
-    size_t lein = SC_MIN (irem, 54);
-    size_t lout = base64_encode_block (ipos, lein, base_out, &bstate);
+    size_t              lein = SC_MIN (irem, 54);
+    size_t              lout =
+      base64_encode_block (ipos, lein, base_out, &bstate);
 
 #if 0
     SC_LDEBUGF ("Line %u lein %u lout %u\n", (unsigned) zlin,

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -406,7 +406,7 @@ sc_io_have_zlib (void)
 #define SC_IO_LBD (SC_IO_LBC + 1)
 #define SC_IO_LBE (SC_IO_LBC + 2)
 
-/* see RFC 1950 and RFC 1950 for the uncompressed zlib format */
+/* see RFC 1950 and RFC 1951 for the uncompressed zlib format */
 #ifndef SC_HAVE_ZLIB
 #define SC_IO_NONCOMP_BLOCK 65531       /**< +5 byte header = 64k */
 #define SC_IO_ADLER32_PRIME 65521       /**< defined by RFC 1950 */
@@ -1519,8 +1519,8 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
   *ocount = 0;
 
   if (zcount == 0) {
-    /* This should be not necessary according to the MPI standard but some
-     * MPI impementations trigger valgrind warnigs due to uninitialized
+    /* This should not be necessary according to the MPI standard but some
+     * MPI implementations trigger valgrind warnings due to uninitialized
      * MPI status members.
      */
     mpiret = sc_MPI_SUCCESS;
@@ -1784,8 +1784,8 @@ sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset,
   *ocount = 0;
 
   if (zcount == 0) {
-    /* This should be not necessary according to the MPI standard but some
-     * MPI impementations trigger valgrind warnigs due to uninitialized
+    /* This should not be necessary according to the MPI standard but some
+     * MPI imlementations trigger valgrind warnings due to uninitialized
      * MPI status members.
      */
     mpiret = sc_MPI_SUCCESS;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -641,7 +641,7 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
   input_compress_bound = sc_io_noncompress_bound (input_size);
 #else
   input_compress_bound = compressBound ((uLong) input_size);
-#endif
+#endif /* !SC_HAVE_ZLIB */
   sc_array_init_count (&compressed, 1, 8 + input_compress_bound);
   memcpy (compressed.array, original_size, 8);
 #ifndef SC_HAVE_ZLIB
@@ -655,11 +655,6 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
   SC_CHECK_ABORT (zrv == Z_OK, "Error on zlib compression");
 #endif /* !SC_HAVE_ZLIB */
 
-#if 0
-  SC_LDEBUGF ("Compress %u %u\n",
-              (unsigned) input_size, (unsigned) input_compress_bound);
-#endif
-
   /* prepare output array */
   if (out == NULL) {
     out = data;
@@ -669,11 +664,6 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
   base64_lines = (input_size + 53) / 54;
   encoded_size = 4 * ((input_size + 2) / 3) + base64_lines + 1;
   sc_array_resize (out, encoded_size);
-
-#if 0
-  SC_LDEBUGF ("Lines %u encoded size %u\n",
-              (unsigned) base64_lines, (unsigned) encoded_size);
-#endif
 
   /* run base64 encoder */
   base64_init_encodestate (&bstate);
@@ -689,11 +679,6 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
     size_t              lein = SC_MIN (irem, 54);
     size_t              lout =
       base64_encode_block (ipos, lein, base_out, &bstate);
-
-#if 0
-    SC_LDEBUGF ("Line %u lein %u lout %u\n", (unsigned) zlin,
-                (unsigned) lein, (unsigned) lout);
-#endif
 
     SC_ASSERT (lein > 0);
     if (zlin < base64_lines - 1) {
@@ -795,11 +780,6 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
     size_t              lout =
       base64_decode_block (ipos, lein, base_out, &bstate);
 
-#if 0
-    SC_LDEBUGF ("Line %u lein %u lout %u\n", (unsigned) zlin,
-                (unsigned) lein, (unsigned) lout);
-#endif
-
     SC_ASSERT (lein > 0);
     if (lout == 0) {
       SC_LERROR ("base 64 decode short\n");
@@ -841,11 +821,6 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
     goto decode_error;
   }
 
-#if 0
-  SC_LDEBUGF ("Decoded to %u lines for total %lu\n",
-              (unsigned) base64_lines, (unsigned long) ocnt);
-#endif
-
   /* decompress decoded data */
   encoded_size = 0;
   for (i = 0; i < 8; ++i) {
@@ -863,10 +838,6 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
                 (unsigned long long) max_original_size);
     goto decode_error;
   }
-
-#if 0
-  SC_LDEBUGF ("Original size: %lu\n", (unsigned long) encoded_size);
-#endif
 
   sc_array_resize (out, encoded_size / out->elem_size);
 #ifndef SC_HAVE_ZLIB

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -636,7 +636,7 @@ sc_io_encode (sc_array_t *data, sc_array_t *out)
   input_size = data->elem_count * data->elem_size;
   for (i = 0; i < 8; ++i) {
     /* enforce big endian byte order for original size */
-    original_size[i] = (input_size >> (i * 8)) & 0xFF;
+    original_size[i] = (input_size >> ((7 - i) * 8)) & 0xFF;
   }
 
   /* zlib compress input */
@@ -829,7 +829,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
   for (i = 0; i < 8; ++i) {
     /* enforce big endian byte order for original size */
     unsigned char       uc = (unsigned char) compressed.array[i];
-    encoded_size |= ((size_t) uc) << (i * 8);
+    encoded_size |= ((size_t) uc) << ((7 - i) * 8);
   }
   if (encoded_size % out->elem_size != 0) {
     SC_LERROR ("encoded size not commensurable\n");

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -544,6 +544,12 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
     SC_LERROR ("uncompress header not conforming\n");
     return -1;
   }
+#ifndef SC_PUFF_INCLUDED
+  if (ucb & 0xE0) {
+    SC_LERROR ("uncompress cannot handle header\n");
+    return -1;
+  }
+#endif
   src += 2;
   src_size -= 2;
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -408,8 +408,8 @@ sc_io_have_zlib (void)
 
 /* see RFC 1950 and RFC 1950 for the uncompressed zlib format */
 #ifndef SC_HAVE_ZLIB
-#define SC_IO_NONCOMP_BLOCK 65535
-#define SC_IO_ADLER32_PRIME 65521
+#define SC_IO_NONCOMP_BLOCK 65531       /**< +5 byte header = 64k */
+#define SC_IO_ADLER32_PRIME 65521       /**< defined by RFC 1950 */
 
 static void
 sc_io_adler32_init (uint32_t *adler)

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -531,12 +531,12 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
     return -1;
   }
   uca = (unsigned char) src[0];
-  if ((uca >> 4) > 7 || (uca & 0x0F) != 8) {
+  if ((uca & 0x8F) != 8) {
     SC_LERROR ("uncompress method unsupported\n");
     return -1;
   }
   ucb = (unsigned char) src[1];
-  if ((ucb & (7 << 5)) || ((((unsigned) uca) << 8) + ucb) % 31) {
+  if (((((unsigned) uca) << 8) + ucb) % 31) {
     SC_LERROR ("uncompress header not conforming\n");
     return -1;
   }
@@ -548,11 +548,13 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
 
   /* go through zlib blocks */
   do {
-    /* examine block header */
+    /* verify minimum required size */
     if (src_size < 5) {
       SC_LERROR ("uncompress block header short\n");
       return -1;
     }
+
+    /* examine block header */
     uca = (unsigned char) src[0];
     if (uca > 1) {
       SC_LERROR ("uncompress block header unsupported\n");

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -631,7 +631,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out)
   encoded_size = 0;
   for (i = 0; i < 8; ++i) {
     /* enforce big endian byte order for original size */
-    unsigned char uc = (unsigned char) compressed.array[i];
+    unsigned char       uc = (unsigned char) compressed.array[i];
     encoded_size |= ((size_t) uc) << (i * 8);
   }
   if (encoded_size % out->elem_size != 0) {

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -521,12 +521,12 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
   }
   uca = (unsigned char) src[0];
   if ((uca >> 4) > 7 || (uca & 0x0F) != 8) {
-    SC_LERROR ("uncompress method invalid\n");
+    SC_LERROR ("uncompress method unsupported\n");
     return -1;
   }
   ucb = (unsigned char) src[1];
   if ((ucb & (7 << 5)) || ((((unsigned) uca) << 8) + ucb) % 31) {
-    SC_LERROR ("uncompress header invalid\n");
+    SC_LERROR ("uncompress header not conforming\n");
     return -1;
   }
   src += 2;
@@ -544,7 +544,7 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
     }
     uca = (unsigned char) src[0];
     if (uca > 1) {
-      SC_LERROR ("uncompress block header invalid\n");
+      SC_LERROR ("uncompress block header unsupported\n");
       return -1;
     }
     final_block = (uca == 1);
@@ -555,7 +555,7 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
     ucb = (unsigned char) src[4];
     nsize = (ucb << 8) + uca;
     if ((final_block && bsize < dest_size) || bsize + nsize != 65535) {
-      SC_LERROR ("uncompress block header mismatch\n");
+      SC_LERROR ("uncompress block header invalid\n");
       return -1;
     }
     src += 5;
@@ -846,7 +846,8 @@ sc_io_decode (sc_array_t *data, sc_array_t *out, size_t max_original_size)
   zrv = sc_io_nonuncompress (out->array, encoded_size,
                              compressed.array + 8, ocnt - 8);
   if (zrv) {
-    SC_LERROR ("uncompress attempt error\n");
+    SC_LERROR ("Please consider configuring the build"
+               " such that zlib is found.\n");
     goto decode_error;
   }
 #else

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -345,8 +345,8 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  *                          or if the base 64 input misses the newlines
  *                          expected after every 72 code characters.
  */
-int                sc_io_decode (sc_array_t *data, sc_array_t *out,
-                                 size_t max_original_size);
+int                 sc_io_decode (sc_array_t *data, sc_array_t *out,
+                                  size_t max_original_size);
 
 /** This function writes numeric binary data in VTK base64 encoding.
  * \param vtkfile        Stream opened for writing.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -259,30 +259,32 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
 
 /** Compress and base 64 encode a block of arbitrary data.
  * This is a two-stage process: zlib compress and then encode to base 64.
+ * The output is a NUL-terminated string of printable characters.
  *
  * We first compress the data into the zlib format (RFC 1950).
  * If zlib is detected on configuration, we compress with Z_BEST_COMPRESSION.
- * If zlib is not detected, we write data equivalrent to Z_NO_COMPRESSION.
+ * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * Both ways are readable by a standard zlib uncompress call.
  *
  * Secondly, we run the compressed data through a base 64 encoder.
  * We break lines after 72 characters.  Each line ends in '\n'.
  * The line breaks are considered part of the output data.
- * A final terminating zero is not considered part of it.
+ * A final terminating zero is also considered part of it.
  *
  * This routine can work in place or write to an output array.
  *
  * \param [in,out] data     If \a out is NULL, we work in place.
- *                          In this case, after reading the input
- *                          from this array, it assumes the identity
- *                          of the \a out argument described below.
- *                          In particular, element size resets to 1.
- *                          Otherwise, this is a read-only argument.
+ *                          In this case, the array must on input have
+ *                          an element size of 1 byte, which is preserved.
+ *                          After reading all data from this array, it assumes
+ *                          the identity of the \a out argument below.
+ *                          Otherwise, this is a read-only argument
+ *                          that may have arbitrary element size.
  *                          On input, all data in the array is used.
  * \param [in,out] out      If given, a valid array of element size 1.
  *                          It must be resizable (not a view).
- *                          We resize to the output data size + 1,
- *                          always writing a terminating zero.
+ *                          We resize the array to the output data, which
+ *                          always includes a final terminating zero.
  */
 void                sc_io_encode (sc_array_t *data, sc_array_t *out);
 

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -257,7 +257,7 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
                                               size_t bytes_avail,
                                               size_t *bytes_out);
 
-/** Compress and base 64 encode a block of arbitrary data.
+/** Encode a block of arbitrary data, compressed, into an ASCII string.
  * This is a two-stage process: zlib compress and then encode to base 64.
  * The output is a NUL-terminated string of printable characters.
  *
@@ -266,12 +266,15 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * Both ways are readable by a standard zlib uncompress call.
  *
- * Secondly, we run the compressed data through a base 64 encoder.
- * We break lines after 72 characters.  Each line ends in '\n'.
+ * Secondly, we process the input data size as an 8-byte big-endian number
+ * and then the zlib compressed data, concatenated, with a base 64 encoder.
+ * We break lines after 72 code characters.  Each line ends in '\n'.
  * The line breaks are considered part of the output data.
- * A final terminating zero is also considered part of it.
+ * A final terminating NUL is also considered part of it.
  *
  * This routine can work in place or write to an output array.
+ * The corresponding decoder function is \ref sc_io_decode.
+ * This function cannot crash.
  *
  * \param [in,out] data     If \a out is NULL, we work in place.
  *                          In this case, the array must on input have
@@ -281,7 +284,7 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
  *                          Otherwise, this is a read-only argument
  *                          that may have arbitrary element size.
  *                          On input, all data in the array is used.
- * \param [in,out] out      If given, a valid array of element size 1.
+ * \param [in,out] out      If not NULL, a valid array of element size 1.
  *                          It must be resizable (not a view).
  *                          We resize the array to the output data, which
  *                          always includes a final terminating zero.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -350,11 +350,12 @@ void                sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
  *                      set to the original size as encoded in the data.
  * \param [out] format_char     If not NULL and we do not error out, the
  *                      ninth character of decoded data indicating the format.
+ * \param [in,out] re   Provided for error reporting, presently must be NULL.
  * \return              0 on success, negative value on error.
  */
 int                 sc_io_decode_info (sc_array_t *data,
                                        size_t *original_size,
-                                       char *format_char);
+                                       char *format_char, void *re);
 
 /** Decode a block of base 64 encoded compressed data.
  * The base 64 data must contain a line break after every 72 code
@@ -409,11 +410,12 @@ int                 sc_io_decode_info (sc_array_t *data,
  * \param [in] max_original_size    If nonzero, this is the maximal data
  *                          size that we will accept after uncompression.
  *                          If exceeded, return a negative value.
+ * \param [in,out] re   Provided for error reporting, presently must be NULL.
  * \return                  0 on success, negative on malformed input
  *                          data or insufficient output space.
  */
 int                 sc_io_decode (sc_array_t *data, sc_array_t *out,
-                                  size_t max_original_size);
+                                  size_t max_original_size, void *re);
 
 /** This function writes numeric binary data in VTK base64 encoding.
  * \param vtkfile        Stream opened for writing.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -299,6 +299,27 @@ int                 sc_io_have_zlib (void);
  */
 void                sc_io_encode (sc_array_t *data, sc_array_t *out);
 
+/** Decode length of original input from encoded data.
+ * We expect at least 12 bytes of the format produced by \ref sc_io_encode.
+ * No matter how much data has been encoded by it, this much is available.
+ * We verify the format and if successful decode the original data size.
+ *
+ * Calling this function on any result produced by \ref sc_io_encode
+ * will succeed.  This function cannot crash.
+ *
+ * \param [in] data     This must be an array with element size 1.
+ *                      If it contains less than 12 code bytes we error out.
+ *                      It its first 12 bytes do not base 64 decode to 9 bytes
+ *                      we error out.  We generally ignore the remaining data.
+ *                      If the ninth decoded byte does not conform to the first
+ *                      of the zlib format standard (RFC 1950), we error out.
+ * \param [in,out] original_size    If not NULL and we do not error out,
+ *                      set to the original size as encoded in the data.
+ * \return              0 on success, negative value on error.
+ */
+int                 sc_io_decode_length (sc_array_t *data,
+                                         size_t *original_size);
+
 /** Decode a block of base 64 encoded compressed data.
  * The base 64 data must contain a line break after every 72 code characters.
  *

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -257,6 +257,35 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
                                               size_t bytes_avail,
                                               size_t *bytes_out);
 
+/** Compress and base 64 encode a block of arbitrary data.
+ * This is a two-stage process: zlib compress and then encode to base 64.
+ *
+ * We first compress the data into the zlib format (RFC 1950).
+ * If zlib is detected on configuration, we compress with Z_BEST_COMPRESSION.
+ * If zlib is not detected, we write data equivalrent to Z_NO_COMPRESSION.
+ * Both ways are readable by a standard zlib uncompress call.
+ *
+ * Secondly, we run the compressed data through a base 64 encoder.
+ * We break lines after 72 characters.  Each line ends in '\n'.
+ * The line breaks are considered part of the output data.
+ * A final terminating zero is not considered part of it.
+ *
+ * This routine can work in place or write to an output array.
+ *
+ * \param [in,out] data     If \a out is NULL, we work in place.
+ *                          In this case, after reading the input
+ *                          from this array, it assumes the identity
+ *                          of the \a out argument described below.
+ *                          In particular, element size resets to 1.
+ *                          Otherwise, this is a read-only argument.
+ *                          On input, all data in the array is used.
+ * \param [in,out] out      If given, a valid array of element size 1.
+ *                          It must be resizable (not a view).
+ *                          We resize to the output data size + 1,
+ *                          always writing a terminating zero.
+ */
+void                sc_io_encode (sc_array_t *data, sc_array_t *out);
+
 /** This function writes numeric binary data in VTK base64 encoding.
  * \param vtkfile        Stream opened for writing.
  * \param numeric_data   A pointer to a numeric data array.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -271,6 +271,11 @@ int                 sc_io_have_zlib (void);
  * compression level Z_BEST_COMPRESSION (subject to change).
  * Without zlib configured that function works uncompressed.
  *
+ * The encoding method and input data size can be retrieved, optionally,
+ * from the encoded data by \sc_io_decode_info.  This function decodes
+ * the method as a character, which is 'z' for \ref sc_io_encoded_zlib.
+ * We reserve the characters A-C, d-z indefinitely.
+ *
  * \param [in,out] data     If \a out is NULL, we work in place.
  *                          In this case, the array must on input have
  *                          an element size of 1 byte, which is preserved.
@@ -303,7 +308,6 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * with a base 64 encoder.  We break lines after 72 code characters.
  * The line breaks are considered part of the output data format.
  * The last line is terminated with a line break and then a NUL.
- * The terminating NUL is also considered part of the format.
  *
  * This routine can work in place or write to an output array.
  * The corresponding decoder function is \ref sc_io_decode.
@@ -331,7 +335,8 @@ void                sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
  * We expect at least 12 bytes of the format produced by \ref sc_io_encode.
  * No matter how much data has been encoded by it, this much is available.
  * We decode the original data size and the character indicating the format.
- * This function does not require zlib.
+ *
+ * This function does not require zlib.  It works with any well-defined data.
  *
  * Note that this function is not required before \ref sc_io_decode.
  * Calling this function on any result produced by \ref sc_io_encode
@@ -363,6 +368,7 @@ int                 sc_io_decode_info (sc_array_t *data,
  *
  * If we should add another format in the future, the format character
  * may be something else than 'z', as permitted by our specification.
+ * To this end, we reserve the characters A-C and d-z indefinitely.
  *
  * Any error condition is indicated by a negative return value.
  * Possible causes for error are:

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -257,6 +257,12 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
                                               size_t bytes_avail,
                                               size_t *bytes_out);
 
+/** Return a boolean indicating whether zlib has been configured.
+ * \return          True if zlib has been found on runnning configure,
+ *                  or respectively on calling cmake.
+ */
+int                 sc_io_have_zlib (void);
+
 /** Encode a block of arbitrary data, compressed, into an ASCII string.
  * This is a two-stage process: zlib compress and then encode to base 64.
  * The output is a NUL-terminated string of printable characters.
@@ -264,6 +270,8 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
  * We first compress the data into the zlib format (RFC 1950).
  * If zlib is detected on configuration, we compress with Z_BEST_COMPRESSION.
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
+ * The status of zlib detection can be queried at compile time using
+ * `#ifdef SC_HAVE_ZLIB`, or at run time using \ref sc_io_have_zlib.
  * Both ways are readable by a standard zlib uncompress call.
  *
  * Secondly, we process the input data size as an 8-byte big-endian number

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -268,6 +268,7 @@ int                 sc_io_have_zlib (void);
  * The output is a NUL-terminated string of printable characters.
  *
  * We first compress the data into the zlib format (RFC 1950).
+ * The compressor must use no preset dictionary (this is the default).
  * If zlib is detected on configuration, we compress with Z_BEST_COMPRESSION.
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * The status of zlib detection can be queried at compile time using
@@ -334,12 +335,16 @@ int                 sc_io_decode_length (sc_array_t *data,
  *
  * Any error condition is indicated by a negative return value.
  * Possible causes for error are:
+ *
  *  - the input data string is not NUL-terminated
  *  - the input data is corrupt for decoding or decompression
  *  - the output data array has non-unit element size and the
  *    length of the output data is not divisible by the size
  *  - the output data would exceed the specified threshold
  *  - the output array is a view of insufficient length
+ *
+ * We also error out if the data requires a compression dictionary,
+ * which would be a violation of above encode format specification.
  *
  * The corresponding encode function is \ref sc_io_encode.
  * When passing an array as output, we resize it properly.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -301,16 +301,17 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * if Z_NO_COMPRESSION was used on encoding and errors out otherwise.
  * This function detects malformed input by erroring out.
  *
- * Any error condition is indicated by a nonzero return value.
+ * Any error condition is indicated by a negative return value.
  * Possible causes for error are:
  *  - the input data string is not NUL-terminated
  *  - the input data is compressed and zlib is not configured
  *  - the input data is corrupt for decoding or decompression
  *  - the output data array has non-unit element size and the
  *    length of the decoded data is not divisible by the size
+ *  - the output data would exceed a preset threshold size
  *
  * The corresponding encoder function is \ref sc_io_encode.
- * This function cannot crash.
+ * This function cannot crash unless out of memory.
  *
  * \param [in,out] data     If \a out is NULL, we work in place.
  *                          In that case, output is written into
@@ -324,6 +325,9 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  *                          We resize the array to the output data exactly,
  *                          expecting commensurable element and data size,
  *                          which restores the original input to encoding.
+ * \param [in] max_original_size    If nonzero, this is the maximal data
+ *                          size that we will accept after uncompression.
+ *                          If exceeded, return a negative value.
  * \return                  0 on success, negative if zlib is not configured
  *                          and the data is compressed, as opposed to having
  *                          been created with Z_NO_COMPRESSION, and also if
@@ -333,7 +337,8 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  *                          or if the base 64 input misses the newlines
  *                          expected after every 72 code characters.
  */
-int                sc_io_decode (sc_array_t *data, sc_array_t *out);
+int                sc_io_decode (sc_array_t *data, sc_array_t *out,
+                                 size_t max_original_size);
 
 /** This function writes numeric binary data in VTK base64 encoding.
  * \param vtkfile        Stream opened for writing.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -258,7 +258,7 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
                                               size_t *bytes_out);
 
 /** Return a boolean indicating whether zlib has been configured.
- * \return          True if zlib has been found on runnning configure,
+ * \return          True if zlib has been found on running configure,
  *                  or respectively on calling cmake.
  */
 int                 sc_io_have_zlib (void);

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -304,6 +304,7 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * No matter how much data has been encoded by it, this much is available.
  * We verify the format and if successful decode the original data size.
  *
+ * Note that this function is not required before \ref sc_io_decode.
  * Calling this function on any result produced by \ref sc_io_encode
  * will succeed.  This function cannot crash.
  *
@@ -360,7 +361,7 @@ int                 sc_io_decode_length (sc_array_t *data,
  *                          We expect commensurable element and data size
  *                          and resize the output to it exactly, which
  *                          restores the original input passed to encoding.
- *                          Output data and view of matching size can be
+ *                          An output view array of matching size can be
  *                          constructed using \ref sc_io_decode_length.
  * \param [in] max_original_size    If nonzero, this is the maximal data
  *                          size that we will accept after uncompression.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -274,7 +274,7 @@ int                 sc_io_have_zlib (void);
  * `#ifdef SC_HAVE_ZLIB` or at run time using \ref sc_io_have_zlib.
  * Both approaches are readable by a standard zlib uncompress call.
  *
- * Secondly, we process the input data size as an 8-byte little-endian number
+ * Secondly, we process the input data size as an 8-byte big-endian number
  * and then the zlib compressed data, concatenated, with a base 64 encoder.
  * We break lines after 72 code characters.  Each line ends in '\n'.
  * The line breaks are considered part of the output data format.
@@ -303,7 +303,7 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * The base 64 data must contain a line break after every 72 code characters.
  *
  * This is a two-stage process: we decode the input from base 64
- * and then extract the 8-byte little-endian original data size and
+ * and then extract the 8-byte big-endian original data size and
  * execute a standard zlib decompression on the remaining decoded data.
  * If zlib is not detected on configuration, the function executes ok
  * if Z_NO_COMPRESSION was used on encoding, and errors out otherwise.

--- a/src/sc_puff.c
+++ b/src/sc_puff.c
@@ -1,0 +1,855 @@
+/*
+ * puff.c
+ * Copyright (C) 2002-2013 Mark Adler
+ * For conditions of distribution and use, see copyright notice in puff.h
+ * version 2.3, 21 Jan 2013
+ *
+ * puff.c is a simple inflate written to be an unambiguous way to specify the
+ * deflate format.  It is not written for speed but rather simplicity.  As a
+ * side benefit, this code might actually be useful when small code is more
+ * important than speed, such as bootstrap applications.  For typical deflate
+ * data, zlib's inflate() is about four times as fast as puff().  zlib's
+ * inflate compiles to around 20K on my machine, whereas puff.c compiles to
+ * around 4K on my machine (a PowerPC using GNU cc).  If the faster decode()
+ * function here is used, then puff() is only twice as slow as zlib's
+ * inflate().
+ *
+ * All dynamically allocated memory comes from the stack.  The stack required
+ * is less than 2K bytes.  This code is compatible with 16-bit int's and
+ * assumes that long's are at least 32 bits.  puff.c uses the short data type,
+ * assumed to be 16 bits, for arrays in order to conserve memory.  The code
+ * works whether integers are stored big endian or little endian.
+ *
+ * In the comments below are "Format notes" that describe the inflate process
+ * and document some of the less obvious aspects of the format.  This source
+ * code is meant to supplement RFC 1951, which formally describes the deflate
+ * format:
+ *
+ *    http://www.zlib.org/rfc-deflate.html
+ */
+
+/* CB: we acknowledge that the origin of this software is the zlib library.
+ *     This version is altered by renaming the puff function to sc_puff
+ *     and moving the NIL #define into the .c file,
+ *     as well as adding protection against multiple
+ *     inclusion, an extern "C", and white space.
+ */
+
+#include <sc_puff.h>            /* prototype for sc_puff() */
+#ifndef NIL
+#  define NIL ((unsigned char *)0)      /* for no output option */
+#endif
+#ifdef SLOW
+#undef SLOW
+#endif
+
+/*
+ * Change history:
+ *
+ * 1.0  10 Feb 2002     - First version
+ * 1.1  17 Feb 2002     - Clarifications of some comments and notes
+ *                      - Update puff() dest and source pointers on negative
+ *                        errors to facilitate debugging deflators
+ *                      - Remove longest from struct huffman -- not needed
+ *                      - Simplify offs[] index in construct()
+ *                      - Add input size and checking, using longjmp() to
+ *                        maintain easy readability
+ *                      - Use short data type for large arrays
+ *                      - Use pointers instead of long to specify source and
+ *                        destination sizes to avoid arbitrary 4 GB limits
+ * 1.2  17 Mar 2002     - Add faster version of decode(), doubles speed (!),
+ *                        but leave simple version for readability
+ *                      - Make sure invalid distances detected if pointers
+ *                        are 16 bits
+ *                      - Fix fixed codes table error
+ *                      - Provide a scanning mode for determining size of
+ *                        uncompressed data
+ * 1.3  20 Mar 2002     - Go back to lengths for puff() parameters [Gailly]
+ *                      - Add a puff.h file for the interface
+ *                      - Add braces in puff() for else do [Gailly]
+ *                      - Use indexes instead of pointers for readability
+ * 1.4  31 Mar 2002     - Simplify construct() code set check
+ *                      - Fix some comments
+ *                      - Add FIXLCODES #define
+ * 1.5   6 Apr 2002     - Minor comment fixes
+ * 1.6   7 Aug 2002     - Minor format changes
+ * 1.7   3 Mar 2003     - Added test code for distribution
+ *                      - Added zlib-like license
+ * 1.8   9 Jan 2004     - Added some comments on no distance codes case
+ * 1.9  21 Feb 2008     - Fix bug on 16-bit integer architectures [Pohland]
+ *                      - Catch missing end-of-block symbol error
+ * 2.0  25 Jul 2008     - Add #define to permit distance too far back
+ *                      - Add option in TEST code for puff to write the data
+ *                      - Add option in TEST code to skip input bytes
+ *                      - Allow TEST code to read from piped stdin
+ * 2.1   4 Apr 2010     - Avoid variable initialization for happier compilers
+ *                      - Avoid unsigned comparisons for even happier compilers
+ * 2.2  25 Apr 2010     - Fix bug in variable initializations [Oberhumer]
+ *                      - Add const where appropriate [Oberhumer]
+ *                      - Split if's and ?'s for coverage testing
+ *                      - Break out test code to separate file
+ *                      - Move NIL to puff.h
+ *                      - Allow incomplete code only if single code length is 1
+ *                      - Add full code coverage test to Makefile
+ * 2.3  21 Jan 2013     - Check for invalid code length codes in dynamic blocks
+ */
+
+#include <setjmp.h>             /* for setjmp(), longjmp(), and jmp_buf */
+
+#define local static            /* for local function definitions */
+
+/*
+ * Maximums for allocations and loops.  It is not useful to change these --
+ * they are fixed by the deflate format.
+ */
+#define MAXBITS 15              /* maximum bits in a code */
+#define MAXLCODES 286           /* maximum number of literal/length codes */
+#define MAXDCODES 30            /* maximum number of distance codes */
+#define MAXCODES (MAXLCODES+MAXDCODES)  /* maximum codes lengths to read */
+#define FIXLCODES 288           /* number of fixed literal/length codes */
+
+/* input and output state */
+struct state {
+    /* output state */
+    unsigned char *out;         /* output buffer */
+    unsigned long outlen;       /* available space at out */
+    unsigned long outcnt;       /* bytes written to out so far */
+
+    /* input state */
+    const unsigned char *in;    /* input buffer */
+    unsigned long inlen;        /* available input at in */
+    unsigned long incnt;        /* bytes read so far */
+    int bitbuf;                 /* bit buffer */
+    int bitcnt;                 /* number of bits in bit buffer */
+
+    /* input limit error return state for bits() and decode() */
+    jmp_buf env;
+};
+
+/*
+ * Return need bits from the input stream.  This always leaves less than
+ * eight bits in the buffer.  bits() works properly for need == 0.
+ *
+ * Format notes:
+ *
+ * - Bits are stored in bytes from the least significant bit to the most
+ *   significant bit.  Therefore bits are dropped from the bottom of the bit
+ *   buffer, using shift right, and new bytes are appended to the top of the
+ *   bit buffer, using shift left.
+ */
+local int bits(struct state *s, int need)
+{
+    long val;           /* bit accumulator (can use up to 20 bits) */
+
+    /* load at least need bits into val */
+    val = s->bitbuf;
+    while (s->bitcnt < need) {
+        if (s->incnt == s->inlen)
+            longjmp(s->env, 1);         /* out of input */
+        val |= (long)(s->in[s->incnt++]) << s->bitcnt;  /* load eight bits */
+        s->bitcnt += 8;
+    }
+
+    /* drop need bits and update buffer, always zero to seven bits left */
+    s->bitbuf = (int)(val >> need);
+    s->bitcnt -= need;
+
+    /* return need bits, zeroing the bits above that */
+    return (int)(val & ((1L << need) - 1));
+}
+
+/*
+ * Process a stored block.
+ *
+ * Format notes:
+ *
+ * - After the two-bit stored block type (00), the stored block length and
+ *   stored bytes are byte-aligned for fast copying.  Therefore any leftover
+ *   bits in the byte that has the last bit of the type, as many as seven, are
+ *   discarded.  The value of the discarded bits are not defined and should not
+ *   be checked against any expectation.
+ *
+ * - The second inverted copy of the stored block length does not have to be
+ *   checked, but it's probably a good idea to do so anyway.
+ *
+ * - A stored block can have zero length.  This is sometimes used to byte-align
+ *   subsets of the compressed data for random access or partial recovery.
+ */
+local int stored(struct state *s)
+{
+    unsigned len;       /* length of stored block */
+
+    /* discard leftover bits from current byte (assumes s->bitcnt < 8) */
+    s->bitbuf = 0;
+    s->bitcnt = 0;
+
+    /* get length and check against its one's complement */
+    if (s->incnt + 4 > s->inlen)
+        return 2;                               /* not enough input */
+    len = s->in[s->incnt++];
+    len |= s->in[s->incnt++] << 8;
+    if (s->in[s->incnt++] != (~len & 0xff) ||
+        s->in[s->incnt++] != ((~len >> 8) & 0xff))
+        return -2;                              /* didn't match complement! */
+
+    /* copy len bytes from in to out */
+    if (s->incnt + len > s->inlen)
+        return 2;                               /* not enough input */
+    if (s->out != NIL) {
+        if (s->outcnt + len > s->outlen)
+            return 1;                           /* not enough output space */
+        while (len--)
+            s->out[s->outcnt++] = s->in[s->incnt++];
+    }
+    else {                                      /* just scanning */
+        s->outcnt += len;
+        s->incnt += len;
+    }
+
+    /* done with a valid stored block */
+    return 0;
+}
+
+/*
+ * Huffman code decoding tables.  count[1..MAXBITS] is the number of symbols of
+ * each length, which for a canonical code are stepped through in order.
+ * symbol[] are the symbol values in canonical order, where the number of
+ * entries is the sum of the counts in count[].  The decoding process can be
+ * seen in the function decode() below.
+ */
+struct huffman {
+    short *count;       /* number of symbols of each length */
+    short *symbol;      /* canonically ordered symbols */
+};
+
+/*
+ * Decode a code from the stream s using huffman table h.  Return the symbol or
+ * a negative value if there is an error.  If all of the lengths are zero, i.e.
+ * an empty code, or if the code is incomplete and an invalid code is received,
+ * then -10 is returned after reading MAXBITS bits.
+ *
+ * Format notes:
+ *
+ * - The codes as stored in the compressed data are bit-reversed relative to
+ *   a simple integer ordering of codes of the same lengths.  Hence below the
+ *   bits are pulled from the compressed data one at a time and used to
+ *   build the code value reversed from what is in the stream in order to
+ *   permit simple integer comparisons for decoding.  A table-based decoding
+ *   scheme (as used in zlib) does not need to do this reversal.
+ *
+ * - The first code for the shortest length is all zeros.  Subsequent codes of
+ *   the same length are simply integer increments of the previous code.  When
+ *   moving up a length, a zero bit is appended to the code.  For a complete
+ *   code, the last code of the longest length will be all ones.
+ *
+ * - Incomplete codes are handled by this decoder, since they are permitted
+ *   in the deflate format.  See the format notes for fixed() and dynamic().
+ */
+#ifdef SLOW
+local int decode(struct state *s, const struct huffman *h)
+{
+    int len;            /* current number of bits in code */
+    int code;           /* len bits being decoded */
+    int first;          /* first code of length len */
+    int count;          /* number of codes of length len */
+    int index;          /* index of first code of length len in symbol table */
+
+    code = first = index = 0;
+    for (len = 1; len <= MAXBITS; len++) {
+        code |= bits(s, 1);             /* get next bit */
+        count = h->count[len];
+        if (code - count < first)       /* if length len, return symbol */
+            return h->symbol[index + (code - first)];
+        index += count;                 /* else update for next length */
+        first += count;
+        first <<= 1;
+        code <<= 1;
+    }
+    return -10;                         /* ran out of codes */
+}
+
+/*
+ * A faster version of decode() for real applications of this code.   It's not
+ * as readable, but it makes puff() twice as fast.  And it only makes the code
+ * a few percent larger.
+ */
+#else /* !SLOW */
+local int decode(struct state *s, const struct huffman *h)
+{
+    int len;            /* current number of bits in code */
+    int code;           /* len bits being decoded */
+    int first;          /* first code of length len */
+    int count;          /* number of codes of length len */
+    int index;          /* index of first code of length len in symbol table */
+    int bitbuf;         /* bits from stream */
+    int left;           /* bits left in next or left to process */
+    short *next;        /* next number of codes */
+
+    bitbuf = s->bitbuf;
+    left = s->bitcnt;
+    code = first = index = 0;
+    len = 1;
+    next = h->count + 1;
+    while (1) {
+        while (left--) {
+            code |= bitbuf & 1;
+            bitbuf >>= 1;
+            count = *next++;
+            if (code - count < first) { /* if length len, return symbol */
+                s->bitbuf = bitbuf;
+                s->bitcnt = (s->bitcnt - len) & 7;
+                return h->symbol[index + (code - first)];
+            }
+            index += count;             /* else update for next length */
+            first += count;
+            first <<= 1;
+            code <<= 1;
+            len++;
+        }
+        left = (MAXBITS+1) - len;
+        if (left == 0)
+            break;
+        if (s->incnt == s->inlen)
+            longjmp(s->env, 1);         /* out of input */
+        bitbuf = s->in[s->incnt++];
+        if (left > 8)
+            left = 8;
+    }
+    return -10;                         /* ran out of codes */
+}
+#endif /* SLOW */
+
+/*
+ * Given the list of code lengths length[0..n-1] representing a canonical
+ * Huffman code for n symbols, construct the tables required to decode those
+ * codes.  Those tables are the number of codes of each length, and the symbols
+ * sorted by length, retaining their original order within each length.  The
+ * return value is zero for a complete code set, negative for an over-
+ * subscribed code set, and positive for an incomplete code set.  The tables
+ * can be used if the return value is zero or positive, but they cannot be used
+ * if the return value is negative.  If the return value is zero, it is not
+ * possible for decode() using that table to return an error--any stream of
+ * enough bits will resolve to a symbol.  If the return value is positive, then
+ * it is possible for decode() using that table to return an error for received
+ * codes past the end of the incomplete lengths.
+ *
+ * Not used by decode(), but used for error checking, h->count[0] is the number
+ * of the n symbols not in the code.  So n - h->count[0] is the number of
+ * codes.  This is useful for checking for incomplete codes that have more than
+ * one symbol, which is an error in a dynamic block.
+ *
+ * Assumption: for all i in 0..n-1, 0 <= length[i] <= MAXBITS
+ * This is assured by the construction of the length arrays in dynamic() and
+ * fixed() and is not verified by construct().
+ *
+ * Format notes:
+ *
+ * - Permitted and expected examples of incomplete codes are one of the fixed
+ *   codes and any code with a single symbol which in deflate is coded as one
+ *   bit instead of zero bits.  See the format notes for fixed() and dynamic().
+ *
+ * - Within a given code length, the symbols are kept in ascending order for
+ *   the code bits definition.
+ */
+local int construct(struct huffman *h, const short *length, int n)
+{
+    int symbol;         /* current symbol when stepping through length[] */
+    int len;            /* current length when stepping through h->count[] */
+    int left;           /* number of possible codes left of current length */
+    short offs[MAXBITS+1];      /* offsets in symbol table for each length */
+
+    /* count number of codes of each length */
+    for (len = 0; len <= MAXBITS; len++)
+        h->count[len] = 0;
+    for (symbol = 0; symbol < n; symbol++)
+        (h->count[length[symbol]])++;   /* assumes lengths are within bounds */
+    if (h->count[0] == n)               /* no codes! */
+        return 0;                       /* complete, but decode() will fail */
+
+    /* check for an over-subscribed or incomplete set of lengths */
+    left = 1;                           /* one possible code of zero length */
+    for (len = 1; len <= MAXBITS; len++) {
+        left <<= 1;                     /* one more bit, double codes left */
+        left -= h->count[len];          /* deduct count from possible codes */
+        if (left < 0)
+            return left;                /* over-subscribed--return negative */
+    }                                   /* left > 0 means incomplete */
+
+    /* generate offsets into symbol table for each length for sorting */
+    offs[1] = 0;
+    for (len = 1; len < MAXBITS; len++)
+        offs[len + 1] = offs[len] + h->count[len];
+
+    /*
+     * put symbols in table sorted by length, by symbol order within each
+     * length
+     */
+    for (symbol = 0; symbol < n; symbol++)
+        if (length[symbol] != 0)
+            h->symbol[offs[length[symbol]]++] = symbol;
+
+    /* return zero for complete set, positive for incomplete set */
+    return left;
+}
+
+/*
+ * Decode literal/length and distance codes until an end-of-block code.
+ *
+ * Format notes:
+ *
+ * - Compressed data that is after the block type if fixed or after the code
+ *   description if dynamic is a combination of literals and length/distance
+ *   pairs terminated by and end-of-block code.  Literals are simply Huffman
+ *   coded bytes.  A length/distance pair is a coded length followed by a
+ *   coded distance to represent a string that occurs earlier in the
+ *   uncompressed data that occurs again at the current location.
+ *
+ * - Literals, lengths, and the end-of-block code are combined into a single
+ *   code of up to 286 symbols.  They are 256 literals (0..255), 29 length
+ *   symbols (257..285), and the end-of-block symbol (256).
+ *
+ * - There are 256 possible lengths (3..258), and so 29 symbols are not enough
+ *   to represent all of those.  Lengths 3..10 and 258 are in fact represented
+ *   by just a length symbol.  Lengths 11..257 are represented as a symbol and
+ *   some number of extra bits that are added as an integer to the base length
+ *   of the length symbol.  The number of extra bits is determined by the base
+ *   length symbol.  These are in the static arrays below, lens[] for the base
+ *   lengths and lext[] for the corresponding number of extra bits.
+ *
+ * - The reason that 258 gets its own symbol is that the longest length is used
+ *   often in highly redundant files.  Note that 258 can also be coded as the
+ *   base value 227 plus the maximum extra value of 31.  While a good deflate
+ *   should never do this, it is not an error, and should be decoded properly.
+ *
+ * - If a length is decoded, including its extra bits if any, then it is
+ *   followed a distance code.  There are up to 30 distance symbols.  Again
+ *   there are many more possible distances (1..32768), so extra bits are added
+ *   to a base value represented by the symbol.  The distances 1..4 get their
+ *   own symbol, but the rest require extra bits.  The base distances and
+ *   corresponding number of extra bits are below in the static arrays dist[]
+ *   and dext[].
+ *
+ * - Literal bytes are simply written to the output.  A length/distance pair is
+ *   an instruction to copy previously uncompressed bytes to the output.  The
+ *   copy is from distance bytes back in the output stream, copying for length
+ *   bytes.
+ *
+ * - Distances pointing before the beginning of the output data are not
+ *   permitted.
+ *
+ * - Overlapped copies, where the length is greater than the distance, are
+ *   allowed and common.  For example, a distance of one and a length of 258
+ *   simply copies the last byte 258 times.  A distance of four and a length of
+ *   twelve copies the last four bytes three times.  A simple forward copy
+ *   ignoring whether the length is greater than the distance or not implements
+ *   this correctly.  You should not use memcpy() since its behavior is not
+ *   defined for overlapped arrays.  You should not use memmove() or bcopy()
+ *   since though their behavior -is- defined for overlapping arrays, it is
+ *   defined to do the wrong thing in this case.
+ */
+local int codes(struct state *s,
+                const struct huffman *lencode,
+                const struct huffman *distcode)
+{
+    int symbol;         /* decoded symbol */
+    int len;            /* length for copy */
+    unsigned dist;      /* distance for copy */
+    static const short lens[29] = { /* Size base for length codes 257..285 */
+        3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31,
+        35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258};
+    static const short lext[29] = { /* Extra bits for length codes 257..285 */
+        0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+        3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0};
+    static const short dists[30] = { /* Offset base for distance codes 0..29 */
+        1, 2, 3, 4, 5, 7, 9, 13, 17, 25, 33, 49, 65, 97, 129, 193,
+        257, 385, 513, 769, 1025, 1537, 2049, 3073, 4097, 6145,
+        8193, 12289, 16385, 24577};
+    static const short dext[30] = { /* Extra bits for distance codes 0..29 */
+        0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6,
+        7, 7, 8, 8, 9, 9, 10, 10, 11, 11,
+        12, 12, 13, 13};
+
+    /* decode literals and length/distance pairs */
+    do {
+        symbol = decode(s, lencode);
+        if (symbol < 0)
+            return symbol;              /* invalid symbol */
+        if (symbol < 256) {             /* literal: symbol is the byte */
+            /* write out the literal */
+            if (s->out != NIL) {
+                if (s->outcnt == s->outlen)
+                    return 1;
+                s->out[s->outcnt] = symbol;
+            }
+            s->outcnt++;
+        }
+        else if (symbol > 256) {        /* length */
+            /* get and compute length */
+            symbol -= 257;
+            if (symbol >= 29)
+                return -10;             /* invalid fixed code */
+            len = lens[symbol] + bits(s, lext[symbol]);
+
+            /* get and check distance */
+            symbol = decode(s, distcode);
+            if (symbol < 0)
+                return symbol;          /* invalid symbol */
+            dist = dists[symbol] + bits(s, dext[symbol]);
+#ifndef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+            if (dist > s->outcnt)
+                return -11;     /* distance too far back */
+#endif
+
+            /* copy length bytes from distance bytes back */
+            if (s->out != NIL) {
+                if (s->outcnt + len > s->outlen)
+                    return 1;
+                while (len--) {
+                    s->out[s->outcnt] =
+#ifdef INFLATE_ALLOW_INVALID_DISTANCE_TOOFAR_ARRR
+                        dist > s->outcnt ?
+                            0 :
+#endif
+                            s->out[s->outcnt - dist];
+                    s->outcnt++;
+                }
+            }
+            else
+                s->outcnt += len;
+        }
+    } while (symbol != 256);            /* end of block symbol */
+
+    /* done with a valid fixed or dynamic block */
+    return 0;
+}
+
+/*
+ * Process a fixed codes block.
+ *
+ * Format notes:
+ *
+ * - This block type can be useful for compressing small amounts of data for
+ *   which the size of the code descriptions in a dynamic block exceeds the
+ *   benefit of custom codes for that block.  For fixed codes, no bits are
+ *   spent on code descriptions.  Instead the code lengths for literal/length
+ *   codes and distance codes are fixed.  The specific lengths for each symbol
+ *   can be seen in the "for" loops below.
+ *
+ * - The literal/length code is complete, but has two symbols that are invalid
+ *   and should result in an error if received.  This cannot be implemented
+ *   simply as an incomplete code since those two symbols are in the "middle"
+ *   of the code.  They are eight bits long and the longest literal/length\
+ *   code is nine bits.  Therefore the code must be constructed with those
+ *   symbols, and the invalid symbols must be detected after decoding.
+ *
+ * - The fixed distance codes also have two invalid symbols that should result
+ *   in an error if received.  Since all of the distance codes are the same
+ *   length, this can be implemented as an incomplete code.  Then the invalid
+ *   codes are detected while decoding.
+ */
+local int fixed(struct state *s)
+{
+    static int virgin = 1;
+    static short lencnt[MAXBITS+1], lensym[FIXLCODES];
+    static short distcnt[MAXBITS+1], distsym[MAXDCODES];
+    static struct huffman lencode, distcode;
+
+    /* build fixed huffman tables if first call (may not be thread safe) */
+    if (virgin) {
+        int symbol;
+        short lengths[FIXLCODES];
+
+        /* construct lencode and distcode */
+        lencode.count = lencnt;
+        lencode.symbol = lensym;
+        distcode.count = distcnt;
+        distcode.symbol = distsym;
+
+        /* literal/length table */
+        for (symbol = 0; symbol < 144; symbol++)
+            lengths[symbol] = 8;
+        for (; symbol < 256; symbol++)
+            lengths[symbol] = 9;
+        for (; symbol < 280; symbol++)
+            lengths[symbol] = 7;
+        for (; symbol < FIXLCODES; symbol++)
+            lengths[symbol] = 8;
+        construct(&lencode, lengths, FIXLCODES);
+
+        /* distance table */
+        for (symbol = 0; symbol < MAXDCODES; symbol++)
+            lengths[symbol] = 5;
+        construct(&distcode, lengths, MAXDCODES);
+
+        /* do this just once */
+        virgin = 0;
+    }
+
+    /* decode data until end-of-block code */
+    return codes(s, &lencode, &distcode);
+}
+
+/*
+ * Process a dynamic codes block.
+ *
+ * Format notes:
+ *
+ * - A dynamic block starts with a description of the literal/length and
+ *   distance codes for that block.  New dynamic blocks allow the compressor to
+ *   rapidly adapt to changing data with new codes optimized for that data.
+ *
+ * - The codes used by the deflate format are "canonical", which means that
+ *   the actual bits of the codes are generated in an unambiguous way simply
+ *   from the number of bits in each code.  Therefore the code descriptions
+ *   are simply a list of code lengths for each symbol.
+ *
+ * - The code lengths are stored in order for the symbols, so lengths are
+ *   provided for each of the literal/length symbols, and for each of the
+ *   distance symbols.
+ *
+ * - If a symbol is not used in the block, this is represented by a zero as
+ *   as the code length.  This does not mean a zero-length code, but rather
+ *   that no code should be created for this symbol.  There is no way in the
+ *   deflate format to represent a zero-length code.
+ *
+ * - The maximum number of bits in a code is 15, so the possible lengths for
+ *   any code are 1..15.
+ *
+ * - The fact that a length of zero is not permitted for a code has an
+ *   interesting consequence.  Normally if only one symbol is used for a given
+ *   code, then in fact that code could be represented with zero bits.  However
+ *   in deflate, that code has to be at least one bit.  So for example, if
+ *   only a single distance base symbol appears in a block, then it will be
+ *   represented by a single code of length one, in particular one 0 bit.  This
+ *   is an incomplete code, since if a 1 bit is received, it has no meaning,
+ *   and should result in an error.  So incomplete distance codes of one symbol
+ *   should be permitted, and the receipt of invalid codes should be handled.
+ *
+ * - It is also possible to have a single literal/length code, but that code
+ *   must be the end-of-block code, since every dynamic block has one.  This
+ *   is not the most efficient way to create an empty block (an empty fixed
+ *   block is fewer bits), but it is allowed by the format.  So incomplete
+ *   literal/length codes of one symbol should also be permitted.
+ *
+ * - If there are only literal codes and no lengths, then there are no distance
+ *   codes.  This is represented by one distance code with zero bits.
+ *
+ * - The list of up to 286 length/literal lengths and up to 30 distance lengths
+ *   are themselves compressed using Huffman codes and run-length encoding.  In
+ *   the list of code lengths, a 0 symbol means no code, a 1..15 symbol means
+ *   that length, and the symbols 16, 17, and 18 are run-length instructions.
+ *   Each of 16, 17, and 18 are followed by extra bits to define the length of
+ *   the run.  16 copies the last length 3 to 6 times.  17 represents 3 to 10
+ *   zero lengths, and 18 represents 11 to 138 zero lengths.  Unused symbols
+ *   are common, hence the special coding for zero lengths.
+ *
+ * - The symbols for 0..18 are Huffman coded, and so that code must be
+ *   described first.  This is simply a sequence of up to 19 three-bit values
+ *   representing no code (0) or the code length for that symbol (1..7).
+ *
+ * - A dynamic block starts with three fixed-size counts from which is computed
+ *   the number of literal/length code lengths, the number of distance code
+ *   lengths, and the number of code length code lengths (ok, you come up with
+ *   a better name!) in the code descriptions.  For the literal/length and
+ *   distance codes, lengths after those provided are considered zero, i.e. no
+ *   code.  The code length code lengths are received in a permuted order (see
+ *   the order[] array below) to make a short code length code length list more
+ *   likely.  As it turns out, very short and very long codes are less likely
+ *   to be seen in a dynamic code description, hence what may appear initially
+ *   to be a peculiar ordering.
+ *
+ * - Given the number of literal/length code lengths (nlen) and distance code
+ *   lengths (ndist), then they are treated as one long list of nlen + ndist
+ *   code lengths.  Therefore run-length coding can and often does cross the
+ *   boundary between the two sets of lengths.
+ *
+ * - So to summarize, the code description at the start of a dynamic block is
+ *   three counts for the number of code lengths for the literal/length codes,
+ *   the distance codes, and the code length codes.  This is followed by the
+ *   code length code lengths, three bits each.  This is used to construct the
+ *   code length code which is used to read the remainder of the lengths.  Then
+ *   the literal/length code lengths and distance lengths are read as a single
+ *   set of lengths using the code length codes.  Codes are constructed from
+ *   the resulting two sets of lengths, and then finally you can start
+ *   decoding actual compressed data in the block.
+ *
+ * - For reference, a "typical" size for the code description in a dynamic
+ *   block is around 80 bytes.
+ */
+local int dynamic(struct state *s)
+{
+    int nlen, ndist, ncode;             /* number of lengths in descriptor */
+    int index;                          /* index of lengths[] */
+    int err;                            /* construct() return value */
+    short lengths[MAXCODES];            /* descriptor code lengths */
+    short lencnt[MAXBITS+1], lensym[MAXLCODES];         /* lencode memory */
+    short distcnt[MAXBITS+1], distsym[MAXDCODES];       /* distcode memory */
+    struct huffman lencode, distcode;   /* length and distance codes */
+    static const short order[19] =      /* permutation of code length codes */
+        {16, 17, 18, 0, 8, 7, 9, 6, 10, 5, 11, 4, 12, 3, 13, 2, 14, 1, 15};
+
+    /* construct lencode and distcode */
+    lencode.count = lencnt;
+    lencode.symbol = lensym;
+    distcode.count = distcnt;
+    distcode.symbol = distsym;
+
+    /* get number of lengths in each table, check lengths */
+    nlen = bits(s, 5) + 257;
+    ndist = bits(s, 5) + 1;
+    ncode = bits(s, 4) + 4;
+    if (nlen > MAXLCODES || ndist > MAXDCODES)
+        return -3;                      /* bad counts */
+
+    /* read code length code lengths (really), missing lengths are zero */
+    for (index = 0; index < ncode; index++)
+        lengths[order[index]] = bits(s, 3);
+    for (; index < 19; index++)
+        lengths[order[index]] = 0;
+
+    /* build huffman table for code lengths codes (use lencode temporarily) */
+    err = construct(&lencode, lengths, 19);
+    if (err != 0)               /* require complete code set here */
+        return -4;
+
+    /* read length/literal and distance code length tables */
+    index = 0;
+    while (index < nlen + ndist) {
+        int symbol;             /* decoded value */
+        int len;                /* last length to repeat */
+
+        symbol = decode(s, &lencode);
+        if (symbol < 0)
+            return symbol;          /* invalid symbol */
+        if (symbol < 16)                /* length in 0..15 */
+            lengths[index++] = symbol;
+        else {                          /* repeat instruction */
+            len = 0;                    /* assume repeating zeros */
+            if (symbol == 16) {         /* repeat last length 3..6 times */
+                if (index == 0)
+                    return -5;          /* no last length! */
+                len = lengths[index - 1];       /* last length */
+                symbol = 3 + bits(s, 2);
+            }
+            else if (symbol == 17)      /* repeat zero 3..10 times */
+                symbol = 3 + bits(s, 3);
+            else                        /* == 18, repeat zero 11..138 times */
+                symbol = 11 + bits(s, 7);
+            if (index + symbol > nlen + ndist)
+                return -6;              /* too many lengths! */
+            while (symbol--)            /* repeat last or zero symbol times */
+                lengths[index++] = len;
+        }
+    }
+
+    /* check for end-of-block code -- there better be one! */
+    if (lengths[256] == 0)
+        return -9;
+
+    /* build huffman table for literal/length codes */
+    err = construct(&lencode, lengths, nlen);
+    if (err && (err < 0 || nlen != lencode.count[0] + lencode.count[1]))
+        return -7;      /* incomplete code ok only for single length 1 code */
+
+    /* build huffman table for distance codes */
+    err = construct(&distcode, lengths + nlen, ndist);
+    if (err && (err < 0 || ndist != distcode.count[0] + distcode.count[1]))
+        return -8;      /* incomplete code ok only for single length 1 code */
+
+    /* decode data until end-of-block code */
+    return codes(s, &lencode, &distcode);
+}
+
+/*
+ * Inflate source to dest.  On return, destlen and sourcelen are updated to the
+ * size of the uncompressed data and the size of the deflate data respectively.
+ * On success, the return value of puff() is zero.  If there is an error in the
+ * source data, i.e. it is not in the deflate format, then a negative value is
+ * returned.  If there is not enough input available or there is not enough
+ * output space, then a positive error is returned.  In that case, destlen and
+ * sourcelen are not updated to facilitate retrying from the beginning with the
+ * provision of more input data or more output space.  In the case of invalid
+ * inflate data (a negative error), the dest and source pointers are updated to
+ * facilitate the debugging of deflators.
+ *
+ * puff() also has a mode to determine the size of the uncompressed output with
+ * no output written.  For this dest must be (unsigned char *)0.  In this case,
+ * the input value of *destlen is ignored, and on return *destlen is set to the
+ * size of the uncompressed output.
+ *
+ * The return codes are:
+ *
+ *   2:  available inflate data did not terminate
+ *   1:  output space exhausted before completing inflate
+ *   0:  successful inflate
+ *  -1:  invalid block type (type == 3)
+ *  -2:  stored block length did not match one's complement
+ *  -3:  dynamic block code description: too many length or distance codes
+ *  -4:  dynamic block code description: code lengths codes incomplete
+ *  -5:  dynamic block code description: repeat lengths with no first length
+ *  -6:  dynamic block code description: repeat more than specified lengths
+ *  -7:  dynamic block code description: invalid literal/length code lengths
+ *  -8:  dynamic block code description: invalid distance code lengths
+ *  -9:  dynamic block code description: missing end-of-block code
+ * -10:  invalid literal/length or distance code in fixed or dynamic block
+ * -11:  distance is too far back in fixed or dynamic block
+ *
+ * Format notes:
+ *
+ * - Three bits are read for each block to determine the kind of block and
+ *   whether or not it is the last block.  Then the block is decoded and the
+ *   process repeated if it was not the last block.
+ *
+ * - The leftover bits in the last byte of the deflate data after the last
+ *   block (if it was a fixed or dynamic block) are undefined and have no
+ *   expected values to check.
+ */
+int
+sc_puff (unsigned char *dest,           /* pointer to destination pointer */
+         unsigned long *destlen,        /* amount of output space */
+         const unsigned char *source,   /* pointer to source data pointer */
+         unsigned long *sourcelen)      /* amount of input available */
+{
+    struct state s;             /* input/output state */
+    int last, type;             /* block information */
+    int err;                    /* return value */
+
+    /* initialize output state */
+    s.out = dest;
+    s.outlen = *destlen;                /* ignored if dest is NIL */
+    s.outcnt = 0;
+
+    /* initialize input state */
+    s.in = source;
+    s.inlen = *sourcelen;
+    s.incnt = 0;
+    s.bitbuf = 0;
+    s.bitcnt = 0;
+
+    /* return if bits() or decode() tries to read past available input */
+    if (setjmp(s.env) != 0)             /* if came back here via longjmp() */
+        err = 2;                        /* then skip do-loop, return error */
+    else {
+        /* process blocks until last block or error */
+        do {
+            last = bits(&s, 1);         /* one if last block */
+            type = bits(&s, 2);         /* block type 0..3 */
+            err = type == 0 ?
+                    stored(&s) :
+                    (type == 1 ?
+                        fixed(&s) :
+                        (type == 2 ?
+                            dynamic(&s) :
+                            -1));       /* type == 3, invalid */
+            if (err != 0)
+                break;                  /* return with error */
+        } while (!last);
+    }
+
+    /* update the lengths and return */
+    if (err <= 0) {
+        *destlen = s.outcnt;
+        *sourcelen = s.incnt;
+    }
+    return err;
+}

--- a/src/sc_puff.h
+++ b/src/sc_puff.h
@@ -31,8 +31,10 @@
 #ifndef SC_PUFF_H
 #define SC_PUFF_H
 
+/* every libsc file includes at least sc_config.h */
 #include <sc_config.h>
 
+/* convenient define for code to fallback even further without puff */
 #define SC_PUFF_INCLUDED
 
 #ifdef __cplusplus
@@ -40,12 +42,11 @@ extern "C"
 #endif
 
 /*
- * See puff.c for purpose and usage.
+ * See sc_puff.c for purpose and usage.
  */
 int sc_puff (unsigned char *dest,           /* pointer to destination pointer */
              unsigned long *destlen,        /* amount of output space */
              const unsigned char *source,   /* pointer to source data pointer */
              unsigned long *sourcelen);     /* amount of input available */
-
 
 #endif /* !SC_PUFF_H */

--- a/src/sc_puff.h
+++ b/src/sc_puff.h
@@ -1,0 +1,51 @@
+/* puff.h
+  Copyright (C) 2002-2013 Mark Adler, all rights reserved
+  version 2.3, 21 Jan 2013
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler    madler@alumni.caltech.edu
+ */
+
+/* CB: we acknowledge that the origin of this software is the zlib library.
+ *     This version is altered by renaming the puff function to sc_puff
+ *     and moving the NIL #define into the .c file,
+ *     as well as adding protection against multiple
+ *     inclusion, an extern "C", and white space.
+ */
+
+#ifndef SC_PUFF_H
+#define SC_PUFF_H
+
+#include <sc_config.h>
+
+#define SC_PUFF_INCLUDED
+
+#ifdef __cplusplus
+extern "C"
+#endif
+
+/*
+ * See puff.c for purpose and usage.
+ */
+int sc_puff (unsigned char *dest,           /* pointer to destination pointer */
+             unsigned long *destlen,        /* amount of output space */
+             const unsigned char *source,   /* pointer to source data pointer */
+             unsigned long *sourcelen);     /* amount of input available */
+
+
+#endif /* !SC_PUFF_H */

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -82,6 +82,7 @@ single_inplace_test (sc_array_t *src, int itest)
   int                 i;
   int                 retval;
   int                 num_failed_tests = 0;
+  char                fc;
   size_t              sz, mz;
   size_t              original_size;
   sc_array_t          inp, view, targ;
@@ -147,7 +148,7 @@ single_inplace_test (sc_array_t *src, int itest)
     sc_io_encode (&inp, NULL);
 
     /* decode and verify original data size */
-    if (sc_io_decode_info (&inp, &original_size)) {
+    if (sc_io_decode_info (&inp, &original_size, &fc) || fc != 'z') {
       SC_LERRORF ("decode info error on test %d %d\n", itest, i);
       ++num_failed_tests;
       goto error_inplace_test;
@@ -190,6 +191,7 @@ single_code_test (sc_array_t *src, int itest)
 {
   int                 num_failed_tests = 0;
   int                 retval;
+  char                fc;
   size_t              original_size;
   sc_array_t          dest;
   sc_array_t          comp;
@@ -205,7 +207,7 @@ single_code_test (sc_array_t *src, int itest)
   sc_io_encode (src, &dest);
 
   /* decode and verify original data size */
-  if (sc_io_decode_info (&dest, &original_size)) {
+  if (sc_io_decode_info (&dest, &original_size, &fc) || fc != 'z') {
     SC_LERRORF ("decode info error on test %d\n", itest);
     ++num_failed_tests;
     goto error_code_test;

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -102,7 +102,7 @@ single_inplace_test (sc_array_t *src, int itest)
     sc_io_encode (&inp, NULL);
 
     /* decode in place with array */
-    retval = sc_io_decode (&inp, NULL, 0);
+    retval = sc_io_decode (&inp, NULL, 0, NULL);
     if (retval) {
       SC_LERRORF ("decode array in place error %d %d\n", itest, i);
       ++num_failed_tests;
@@ -126,7 +126,7 @@ single_inplace_test (sc_array_t *src, int itest)
 
       /* decode in place with view */
       sc_array_init_view (&view, &inp, 0, inp.elem_count);
-      retval = sc_io_decode (&view, NULL, 0);
+      retval = sc_io_decode (&view, NULL, 0, NULL);
       if (retval) {
         SC_LERRORF ("decode view in place error %d %d\n", itest, i);
         ++num_failed_tests;
@@ -148,7 +148,7 @@ single_inplace_test (sc_array_t *src, int itest)
     sc_io_encode (&inp, NULL);
 
     /* decode and verify original data size */
-    if (sc_io_decode_info (&inp, &original_size, &fc) || fc != 'z') {
+    if (sc_io_decode_info (&inp, &original_size, &fc, NULL) || fc != 'z') {
       SC_LERRORF ("decode info error on test %d %d\n", itest, i);
       ++num_failed_tests;
       goto error_inplace_test;
@@ -163,7 +163,7 @@ single_inplace_test (sc_array_t *src, int itest)
     mz = SC_MAX (sz, inz[i]);
     sc_array_init_count (&targ, 1, mz);
     sc_array_init_view (&view, &targ, 0, mz);
-    retval = sc_io_decode (&inp, &view, 0);
+    retval = sc_io_decode (&inp, &view, 0, NULL);
     if (retval) {
       SC_LERRORF ("decode view error %d %d\n", itest, i);
       ++num_failed_tests;
@@ -207,7 +207,7 @@ single_code_test (sc_array_t *src, int itest)
   sc_io_encode (src, &dest);
 
   /* decode and verify original data size */
-  if (sc_io_decode_info (&dest, &original_size, &fc) || fc != 'z') {
+  if (sc_io_decode_info (&dest, &original_size, &fc, NULL) || fc != 'z') {
     SC_LERRORF ("decode info error on test %d\n", itest);
     ++num_failed_tests;
     goto error_code_test;
@@ -219,7 +219,7 @@ single_code_test (sc_array_t *src, int itest)
   }
 
   /* decode */
-  retval = sc_io_decode (&dest, &comp, 0);
+  retval = sc_io_decode (&dest, &comp, 0, NULL);
   if (retval) {
     SC_LERRORF ("test %d: sc_io_decode internal error\n", itest);
     ++num_failed_tests;

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -147,8 +147,8 @@ single_inplace_test (sc_array_t *src, int itest)
     sc_io_encode (&inp, NULL);
 
     /* decode and verify original data size */
-    if (sc_io_decode_length (&inp, &original_size)) {
-      SC_LERRORF ("decode length error on test %d %d\n", itest, i);
+    if (sc_io_decode_info (&inp, &original_size)) {
+      SC_LERRORF ("decode info error on test %d %d\n", itest, i);
       ++num_failed_tests;
       goto error_inplace_test;
     }
@@ -205,8 +205,8 @@ single_code_test (sc_array_t *src, int itest)
   sc_io_encode (src, &dest);
 
   /* decode and verify original data size */
-  if (sc_io_decode_length (&dest, &original_size)) {
-    SC_LERRORF ("decode length error on test %d\n", itest);
+  if (sc_io_decode_info (&dest, &original_size)) {
+    SC_LERRORF ("decode info error on test %d\n", itest);
     ++num_failed_tests;
     goto error_code_test;
   }

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -271,11 +271,11 @@ test_encode_decode (void)
   sc_array_init_data (&src, (void *) str2, 1, strlen (str2) + 1);
   single_code_test (&src, -1);
 
-  for (i = 0; i <= 4500; ++i) {
+  for (i = 0; i <= 2000; ++i) {
     if (i % 500 == 0) {
       SC_LDEBUGF ("Code iteration %d\n", i);
     }
-    slen = i <= 4000 ? i : 7 * i;
+    slen = i <= 1800 ? i : 8 * i;
     sc_array_init_count (&src, sizeof (int), slen);
     for (j = 0; j < (int) slen; ++j) {
       *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -120,6 +120,7 @@ test_encode_decode (void)
 {
   int                 num_failed_tests = 0;
   int                 i, j;
+  size_t              slen;
   const char         *str1 = "Hello world.  This is a short text.";
   const char         *str2 =
     "This is a much longer text.  We just paste stuff.\n"
@@ -142,12 +143,13 @@ test_encode_decode (void)
   sc_array_init_data (&src, (void *) str2, 1, strlen (str2) + 1);
   single_code_test (&src, -1);
 
-  for (i = 0; i <= 6000; ++i) {
+  for (i = 0; i <= 4500; ++i) {
     if (i % 1000 == 0) {
       SC_LDEBUGF ("Code iteration %d\n", i);
     }
-    sc_array_init_count (&src, sizeof (int), i);
-    for (j = 0; j < i; ++j) {
+    slen = i <= 4000 ? i : 7 * i;
+    sc_array_init_count (&src, sizeof (int), slen);
+    for (j = 0; j < (int) slen; ++j) {
       *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;
     }
     num_failed_tests += single_code_test (&src, i);

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -27,7 +27,7 @@
   POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <sc.h>
+#include <sc_io.h>
 
 #define SC_TEST_TOOLONG 123456789012345678901234567890123456789
 #define SC_TEST_LONG    1234567890123456789
@@ -75,6 +75,39 @@ test_helpers (const char *str, const char *label, int tint, int tlong)
   return nft;
 }
 
+static int
+test_encode_decode (void)
+{
+  const char *str1 = "Hello world.  This is a short text.";
+  const char *str2 = "This is a much longer text.  We just paste stuff.\n"
+ "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR\
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF\
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS\
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
+ POSSIBILITY OF SUCH DAMAGE.";
+
+  sc_array_t src, dest;
+  sc_array_init (&dest, 1);
+
+  sc_array_init_data (&src, (void *) str1, 1, strlen (str1) + 1);
+  sc_io_encode (&src, &dest);
+  sc_array_reset (&src);
+
+  sc_array_init_data (&src, (void *) str2, 1, strlen (str2) + 1);
+  sc_io_encode (&src, &dest);
+  sc_array_reset (&src);
+
+  sc_array_reset (&dest);
+
+  return 0;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -94,6 +127,9 @@ main (int argc, char **argv)
   num_failed_tests += TH (SC_TEST_TOOLONG, "too long", 0, 0);
   num_failed_tests += TH (SC_TEST_LONG, "long", 0, 1);
   num_failed_tests += TH (SC_TEST_INT, "int", 1, 1);
+
+  /* test encode and decode functions */
+  num_failed_tests += test_encode_decode ();
 
   /* clean up and exit */
   sc_finalize ();

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -75,9 +75,22 @@ test_helpers (const char *str, const char *label, int tint, int tlong)
   return nft;
 }
 
+static void
+single_code_test (sc_array_t *src)
+{
+  sc_array_t dest;
+  sc_array_init (&dest, 1);
+
+  sc_io_encode (src, &dest);
+  sc_array_reset (&dest);
+
+  sc_array_reset (src);
+}
+
 static int
 test_encode_decode (void)
 {
+  int i, j;
   const char *str1 = "Hello world.  This is a short text.";
   const char *str2 = "This is a much longer text.  We just paste stuff.\n"
  "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\
@@ -91,19 +104,24 @@ test_encode_decode (void)
  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
  POSSIBILITY OF SUCH DAMAGE.";
-
-  sc_array_t src, dest;
-  sc_array_init (&dest, 1);
+  sc_array_t src;
 
   sc_array_init_data (&src, (void *) str1, 1, strlen (str1) + 1);
-  sc_io_encode (&src, &dest);
-  sc_array_reset (&src);
+  single_code_test (&src);
 
   sc_array_init_data (&src, (void *) str2, 1, strlen (str2) + 1);
-  sc_io_encode (&src, &dest);
-  sc_array_reset (&src);
+  single_code_test (&src);
 
-  sc_array_reset (&dest);
+  for (i = 0; i <= 6000; ++i) {
+    if (i % 1000 == 0) {
+      SC_LDEBUGF ("Code iteration %d\n", i);
+    }
+    sc_array_init_count (&src, sizeof (int), i);
+    for (j = 0; j < i; ++j) {
+      *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;
+    }
+    single_code_test (&src);
+  }
 
   return 0;
 }

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -78,7 +78,7 @@ test_helpers (const char *str, const char *label, int tint, int tlong)
 static void
 single_code_test (sc_array_t *src)
 {
-  sc_array_t dest;
+  sc_array_t          dest;
   sc_array_init (&dest, 1);
 
   sc_io_encode (src, &dest);
@@ -90,10 +90,11 @@ single_code_test (sc_array_t *src)
 static int
 test_encode_decode (void)
 {
-  int i, j;
-  const char *str1 = "Hello world.  This is a short text.";
-  const char *str2 = "This is a much longer text.  We just paste stuff.\n"
- "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\
+  int                 i, j;
+  const char         *str1 = "Hello world.  This is a short text.";
+  const char         *str2 =
+    "This is a much longer text.  We just paste stuff.\n"
+    "THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\
  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE\
@@ -104,7 +105,7 @@ test_encode_decode (void)
  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
  POSSIBILITY OF SUCH DAMAGE.";
-  sc_array_t src;
+  sc_array_t          src;
 
   sc_array_init_data (&src, (void *) str1, 1, strlen (str1) + 1);
   single_code_test (&src);

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -89,7 +89,7 @@ single_code_test (sc_array_t *src)
 
   /* decode */
   sc_array_init (&comp, src->elem_size);
-  retval = sc_io_decode (&dest, &comp);
+  retval = sc_io_decode (&dest, &comp, 0);
   sc_array_reset (&dest);
   if (retval) {
     SC_LERROR ("sc_io_decode internal error\n");
@@ -151,6 +151,9 @@ test_encode_decode (void)
       *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;
     }
     num_failed_tests += single_code_test (&src);
+    if (num_failed_tests >= 100) {
+      break;
+    }
   }
 
   return num_failed_tests;

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -76,7 +76,7 @@ test_helpers (const char *str, const char *label, int tint, int tlong)
 }
 
 static int
-single_code_test (sc_array_t *src)
+single_code_test (sc_array_t *src, int itest)
 {
   int                 num_failed_tests = 0;
   int                 retval;
@@ -92,19 +92,19 @@ single_code_test (sc_array_t *src)
   retval = sc_io_decode (&dest, &comp, 0);
   sc_array_reset (&dest);
   if (retval) {
-    SC_LERROR ("sc_io_decode internal error\n");
+    SC_LERRORF ("test %d: sc_io_decode internal error\n", itest);
     ++num_failed_tests;
     goto error_code_test;
   }
   if (src->elem_count != comp.elem_count) {
-    SC_LERROR ("sc_io_decode length mismatch\n");
+    SC_LERRORF ("test %d: sc_io_decode length mismatch\n", itest);
     ++num_failed_tests;
     goto error_code_test;
   }
 
   /* compare input and output data */
   if (memcmp (src->array, comp.array, src->elem_size * src->elem_count)) {
-    SC_LERROR ("encode/decode data mismatch\n");
+    SC_LERRORF ("test %d: encode/decode data mismatch\n", itest);
     ++num_failed_tests;
     goto error_code_test;
   }
@@ -137,10 +137,10 @@ test_encode_decode (void)
   sc_array_t          src;
 
   sc_array_init_data (&src, (void *) str1, 1, strlen (str1) + 1);
-  single_code_test (&src);
+  single_code_test (&src, -2);
 
   sc_array_init_data (&src, (void *) str2, 1, strlen (str2) + 1);
-  single_code_test (&src);
+  single_code_test (&src, -1);
 
   for (i = 0; i <= 6000; ++i) {
     if (i % 1000 == 0) {
@@ -150,7 +150,7 @@ test_encode_decode (void)
     for (j = 0; j < i; ++j) {
       *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;
     }
-    num_failed_tests += single_code_test (&src);
+    num_failed_tests += single_code_test (&src, i);
     if (num_failed_tests >= 100) {
       break;
     }

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -144,7 +144,7 @@ test_encode_decode (void)
   single_code_test (&src, -1);
 
   for (i = 0; i <= 4500; ++i) {
-    if (i % 1000 == 0) {
+    if (i % 500 == 0) {
       SC_LDEBUGF ("Code iteration %d\n", i);
     }
     slen = i <= 4000 ? i : 7 * i;
@@ -153,7 +153,7 @@ test_encode_decode (void)
       *(int *) sc_array_index_int (&src, j) = 3 * i + 4 * j + 5;
     }
     num_failed_tests += single_code_test (&src, i);
-    if (num_failed_tests >= 100) {
+    if (num_failed_tests >= 50) {
       break;
     }
   }


### PR DESCRIPTION
# Generic compressed ASCII encode and decode

Proposed changes: Add functions to compress and encode arbitrary data into ASCII.
The proposed implementation relies on zlib for compression and base64 for encoding.
If zlib is not detected by configure, we emulate non-compressed zlib operation.

The test_helpers program has been extended to exercise the new functions.