### PR TITLE
Feature jansson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
         make -j V=0
         make -j check V=0
 
+    - name: Install JSON parser library halfway through CI run
+      run: |
+        sudo apt-get install -yq --no-install-recommends \
+            libjansson-dev
+
     - name: Make check with MPI, debug and C++ compiler
       shell: bash
       run: |

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -414,7 +414,7 @@ fi
 if test "x$$1_HAVE_JSON" = x ; then
 AC_MSG_NOTICE([- $1 ----------------------------------------------------
 We did not find a JSON library containing json_integer and json_real.
-At this point, this is of no consequence to using $1.
-You can fix this by installing the jansson library.])
+This means that loading JSON files for option values will fail.
+You can fix this by installing the jansson development library.])
 fi
 ])

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -172,7 +172,7 @@ for (; sqrt (a) < a; a *= 1.000023) { putc ('1', stdout); }
 dnl SC_CHECK_ZLIB(PREFIX)
 dnl Check whether adler32_combine is found, possibly in -lz, using a link test.
 dnl We AC_DEFINE HAVE_ZLIB to 1 depending on whether it is found.
-dnl We also set PREFIX_HAVE_ZLIB to yes if found.
+dnl We set the shell variable PREFIX_HAVE_ZLIB to yes if found.
 dnl
 AC_DEFUN([SC_CHECK_ZLIB],
 [
@@ -384,12 +384,11 @@ dnl
 AC_DEFUN([SC_FINAL_MESSAGES],
 [
 if test "x$$1_HAVE_ZLIB" = x ; then
-AC_MSG_NOTICE([- $1 -------------------------------------------------
+AC_MSG_NOTICE([- $1 ----------------------------------------------------
 We did not find a recent zlib containing the function adler32_combine.
 This is OK if the following does not matter to you:
 Calling any sc functions that rely on zlib will abort your program.
 These functions include sc_array_checksum and sc_vtk_write_compressed.
-You can fix this by compiling a recent zlib and pointing LIBS to it.
-])
+You can fix this by compiling a recent zlib and pointing LIBS to it.])
 fi
 ])

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -187,6 +187,25 @@ if (a == adler32_combine (a, b, len)) {;}
   [$1_HAVE_ZLIB=])
 ])
 
+dnl SC_CHECK_JSON(PREFIX)
+dnl Check whether json_integer, json_real are found (in -ljansson).
+dnl We AC_DEFINE HAVE_JSON to 1 depending on whether it is found.
+dnl We set the shell variable PREFIX_HAVE_JSON to yes if found.
+dnl
+AC_DEFUN([SC_CHECK_JSON],
+[
+  SC_SEARCH_LIBS([json_integer], [[#include <jansson.h>]],
+[[
+json_t *jint, *jreal;
+if (jint == json_integer ((json_int_t) 15)) { json_decref (jint); }
+if (jreal == json_real (.5)) { json_decref (jreal); }
+]], [jansson],
+  [AC_DEFINE([HAVE_JSON], [1],
+             [Define to 1 if json_integer and json_real link])
+   $1_HAVE_JSON="yes"],
+  [$1_HAVE_JSON=])
+])
+
 dnl SC_CHECK_LIB(LIBRARY LIST, FUNCTION, TOKEN, PREFIX)
 dnl Check for FUNCTION first as is, then in each of the libraries.
 dnl Set shell variable PREFIX_HAVE_TOKEN to nonempty if found.
@@ -359,6 +378,7 @@ AC_DEFUN([SC_CHECK_LIBRARIES],
 AC_DEFINE([USING_AUTOCONF], 1, [Define to 1 if using autoconf build])
 SC_CHECK_MATH([$1])
 SC_CHECK_ZLIB([$1])
+SC_CHECK_JSON([$1])
 dnl SC_CHECK_LIB([lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 lua5 lua],
 dnl              [lua_createtable], [LUA], [$1])
 dnl SC_CHECK_BLAS_LAPACK([$1])
@@ -390,5 +410,11 @@ This is OK if the following does not matter to you:
 Calling any sc functions that rely on zlib will abort your program.
 These functions include sc_array_checksum and sc_vtk_write_compressed.
 You can fix this by compiling a recent zlib and pointing LIBS to it.])
+fi
+if test "x$$1_HAVE_JSON" = x ; then
+AC_MSG_NOTICE([- $1 ----------------------------------------------------
+We did not find a JSON library containing json_integer and json_real.
+At this point, this is of no consequence to using $1.
+You can fix this by installing the jansson library.])
 fi
 ])

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -147,13 +147,6 @@ AS_IF([test "$ac_res" != no],
 AS_VAR_POPDEF([ac_Search])dnl
 ])
 
-dnl SC_REQUIRE_LIB(LIBRARY LIST, FUNCTION)
-dnl Check for FUNCTION in LIBRARY, exit with error if not found
-dnl
-AC_DEFUN([SC_REQUIRE_LIB],
-    [AC_SEARCH_LIBS([$2], [$1],,
-      [AC_MSG_ERROR([cannot find function $2 in $1])])])
-
 dnl SC_CHECK_MATH(PREFIX)
 dnl Check whether sqrt is found, possibly in -lm, using a link test.
 dnl We AC_DEFINE HAVE_MATH to 1 depending on whether it found.

--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,7 @@ echo "o---------------------------------------"
 
 AC_CHECK_HEADERS([fcntl.h sys/ioctl.h sys/select.h sys/stat.h])
 AC_CHECK_HEADERS([execinfo.h signal.h libgen.h time.h sys/time.h])
-AC_CHECK_HEADERS([linux/version.h linux/videodev2.h])
+AC_CHECK_HEADERS([linux/version.h linux/videodev2.h jansson.h])
 
 echo "o---------------------------------------"
 echo "| Checking functions"

--- a/example/options/Makefile.am
+++ b/example/options/Makefile.am
@@ -8,7 +8,8 @@ example_options_sc_options_SOURCES = example/options/options.c
 example_options_sc_logging_SOURCES = example/options/logging.c
 
 dist_scini_DATA += \
+        example/options/sc_options_preload.ini \
         example/options/sc_options_example.ini \
-        example/options/sc_options_preload.ini
+        example/options/sc_options_example.json
 
 LINT_CSOURCES += $(example_options_sc_options_SOURCES)

--- a/example/options/options.c
+++ b/example/options/options.c
@@ -77,7 +77,8 @@ main (int argc, char **argv)
   sc_options_add_callback (opt, 'C', "call2", 0, callback, (void *) cd,
                            "Callback 2");
   sc_options_add_string (opt, 't', NULL, &s2, NULL, "String 2");
-  sc_options_add_inifile (opt, 'f', "inifile", ".ini file");
+  sc_options_add_inifile (opt, 'F', "inifile", ".ini file");
+  sc_options_add_jsonfile (opt, 'J', "jsonfile", "JSON file");
   sc_options_add_int (opt, '\0', "integer2", &i2, 7, "Integer 2");
   sc_options_add_size_t (opt, 'z', "sizet", &z, (size_t) 7000000000ULL,
                          "Size_t");

--- a/example/options/options.c
+++ b/example/options/options.c
@@ -47,13 +47,13 @@ main (int argc, char **argv)
   int                 rank;
   int                 first_arg;
   int                 i1, i2, si1;
-  int                 kvint;
+  int                 kvint, deep;
   size_t              z;
   double              d, sd;
   const char         *s1, *s2, *ss1, *ss2;
   const char         *cd = "Callback example";
   sc_keyvalue_t      *keyvalue;
-  sc_options_t       *opt, *subopt;
+  sc_options_t       *opt, *subopt, *deepopt;
 
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
@@ -92,6 +92,10 @@ main (int argc, char **argv)
   sc_options_add_keyvalue (subopt, 'n', "number", &kvint, "one",
                            keyvalue, "Subset keyvalue number");
 
+  deepopt = sc_options_new (argv[0]);
+  sc_options_add_int (deepopt, '\0', "deep", &deep, 3, "Deep option");
+
+  sc_options_add_suboptions (subopt, deepopt, "Deeper");
   sc_options_add_suboptions (opt, subopt, "Subset");
 
   /* this is just to show off the load function */
@@ -135,6 +139,7 @@ main (int argc, char **argv)
 
   sc_options_destroy (opt);
   sc_options_destroy (subopt);
+  sc_options_destroy (deepopt);
   sc_keyvalue_destroy (keyvalue);
 
   sc_finalize ();

--- a/example/options/sc_options_example.ini
+++ b/example/options/sc_options_example.ini
@@ -1,4 +1,4 @@
-# This file is for playing around with the -f option.
+# This file is for playing around with the -F option.
 
 [Options]
 	-d = 7.55

--- a/example/options/sc_options_example.ini
+++ b/example/options/sc_options_example.ini
@@ -1,11 +1,21 @@
 # This file is for playing around with the -F option.
 
+# The .ini format only goes one level deep.
+
 [Options]
-	-d = 7.55
-	switch = true
-	string = This string is read from the options .ini file!
+  -d = 7.55
+  switch = true
+  string = This string is read from the options .ini file!
+
+  Subset:Deeper:deep = 4
+
 [Subset]
   integer = 23
   double = 3.62
   -s = Subset string 1
   string2 = Subset string 2
+
+  Deeper:deep = 5
+
+[Subset:Deeper]
+  deep = 6

--- a/example/options/sc_options_example.ini
+++ b/example/options/sc_options_example.ini
@@ -6,6 +6,7 @@
   -d = 7.55
   switch = true
   string = This string is read from the options .ini file!
+  sizet = 13428237819423
 
   Subset:Deeper:deep = 4
 

--- a/example/options/sc_options_example.ini
+++ b/example/options/sc_options_example.ini
@@ -3,9 +3,9 @@
 [Options]
 	-d = 7.55
 	switch = true
-	string = This string is read from the options.ini file!
+	string = This string is read from the options .ini file!
 [Subset]
   integer = 23
   double = 3.62
   -s = Subset string 1
-  string2 = subset string 2
+  string2 = Subset string 2

--- a/example/options/sc_options_example.json
+++ b/example/options/sc_options_example.json
@@ -5,6 +5,7 @@
     "-d" : 7.55,
     "switch" : true,
     "string" : "This string is read from the options JSON file!",
+    "sizet" : 13428237819423,
 
     "Subset" : {
       "integer" : 23,

--- a/example/options/sc_options_example.json
+++ b/example/options/sc_options_example.json
@@ -1,5 +1,5 @@
 {
-  "comment" : "This file is for playing around with the -F option.",
+  "comment" : "This file is for playing around with the -J option.",
 
   "Options" : {
     "-d" : 7.55,

--- a/example/options/sc_options_example.json
+++ b/example/options/sc_options_example.json
@@ -1,0 +1,27 @@
+{
+  "comment" : "This file is for playing around with the -F option.",
+
+  "Options" : {
+    "-d" : 7.55,
+    "switch" : true,
+    "string" : "This string is read from the options JSON file!",
+
+    "Subset" : {
+      "integer" : 23,
+       "double" : 3.62,
+      "-s" : "Subset string 1",
+      "string2" : "Subset string 2",
+
+      "Deeper" : {
+        "deep" : 6
+      }
+    },
+
+    "Subset:Deeper" : {
+      "deep" : 5
+    },
+
+    "Subset:Deeper:deep" : 4,
+    "Subset:double" : 5.872
+  }
+}

--- a/src/sc.c
+++ b/src/sc.c
@@ -1564,4 +1564,14 @@ sc_version_point (void)
 }
 #endif
 
+int
+sc_have_json (void)
+{
+#ifndef SC_HAVE_JSON
+  return 0;
+#else
+  return 1;
+#endif
+}
+
 #endif

--- a/src/sc.h
+++ b/src/sc.h
@@ -175,7 +175,7 @@
 #include <unistd.h>
 #elif defined _WIN32
 #include <BaseTsd.h>
-typedef SSIZE_T ssize_t;
+typedef SSIZE_T     ssize_t;
 #endif
 
 /* definitions to allow user code to query the sc library */
@@ -823,6 +823,11 @@ int                 sc_version_minor (void);
  */
 int                 sc_version_point (void);
 #endif /* 0 */
+
+/** Return whether we have found a JSON library at configure time.
+ * \return          True if and only if SC_HAVE_JSON is defined.
+ */
+int                 sc_have_json (void);
 
 SC_EXTERN_C_END;
 

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -252,29 +252,37 @@ sc_options_set_spacing (sc_options_t * opt, int space_type, int space_help)
   opt->space_help = space_help < 0 ? sc_options_space_help : space_help;
 }
 
+static sc_option_item_t *
+sc_options_add_item (sc_options_t * opt, int opt_char, const char *opt_name,
+                     sc_option_type_t otype, const char *help_string)
+{
+  sc_option_item_t   *item;
+
+  SC_ASSERT (opt != NULL);
+  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
+  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
+
+  item = (sc_option_item_t *) sc_array_push (opt->option_items);
+  memset (item, 0, sizeof (sc_option_item_t));
+
+  item->opt_type = otype;
+  item->opt_char = opt_char;
+  item->opt_name = opt_name;
+  item->help_string = help_string;
+
+  return item;
+}
+
 void
 sc_options_add_switch (sc_options_t * opt, int opt_char,
                        const char *opt_name,
                        int *variable, const char *help_string)
 {
-  sc_option_item_t   *item;
+  sc_option_item_t   *item =
+    sc_options_add_item (opt, opt_char, opt_name,
+                         SC_OPTION_SWITCH, help_string);
 
-  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
-  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
-
-  item = (sc_option_item_t *) sc_array_push (opt->option_items);
-
-  item->opt_type = SC_OPTION_SWITCH;
-  item->opt_char = opt_char;
-  item->opt_name = opt_name;
   item->opt_var = variable;
-  item->opt_fn = NULL;
-  item->has_arg = 0;
-  item->called = 0;
-  item->help_string = help_string;
-  item->string_value = NULL;
-  item->user_data = NULL;
-
   *variable = 0;
 }
 
@@ -283,24 +291,12 @@ sc_options_add_bool (sc_options_t * opt, int opt_char,
                      const char *opt_name,
                      int *variable, int init_value, const char *help_string)
 {
-  sc_option_item_t   *item;
+  sc_option_item_t   *item =
+    sc_options_add_item (opt, opt_char, opt_name,
+                         SC_OPTION_BOOL, help_string);
 
-  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
-  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
-
-  item = (sc_option_item_t *) sc_array_push (opt->option_items);
-
-  item->opt_type = SC_OPTION_BOOL;
-  item->opt_char = opt_char;
-  item->opt_name = opt_name;
-  item->opt_var = variable;
-  item->opt_fn = NULL;
   item->has_arg = 2;
-  item->called = 0;
-  item->help_string = help_string;
-  item->string_value = NULL;
-  item->user_data = NULL;
-
+  item->opt_var = variable;
   *variable = init_value;
 }
 
@@ -308,24 +304,12 @@ void
 sc_options_add_int (sc_options_t * opt, int opt_char, const char *opt_name,
                     int *variable, int init_value, const char *help_string)
 {
-  sc_option_item_t   *item;
+  sc_option_item_t   *item =
+    sc_options_add_item (opt, opt_char, opt_name,
+                         SC_OPTION_INT, help_string);
 
-  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
-  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
-
-  item = (sc_option_item_t *) sc_array_push (opt->option_items);
-
-  item->opt_type = SC_OPTION_INT;
-  item->opt_char = opt_char;
-  item->opt_name = opt_name;
-  item->opt_var = variable;
-  item->opt_fn = NULL;
   item->has_arg = 1;
-  item->called = 0;
-  item->help_string = help_string;
-  item->string_value = NULL;
-  item->user_data = NULL;
-
+  item->opt_var = variable;
   *variable = init_value;
 }
 
@@ -334,24 +318,12 @@ sc_options_add_size_t (sc_options_t * opt, int opt_char, const char *opt_name,
                        size_t *variable, size_t init_value,
                        const char *help_string)
 {
-  sc_option_item_t   *item;
+  sc_option_item_t   *item =
+    sc_options_add_item (opt, opt_char, opt_name,
+                         SC_OPTION_SIZE_T, help_string);
 
-  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
-  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
-
-  item = (sc_option_item_t *) sc_array_push (opt->option_items);
-
-  item->opt_type = SC_OPTION_SIZE_T;
-  item->opt_char = opt_char;
-  item->opt_name = opt_name;
-  item->opt_var = variable;
-  item->opt_fn = NULL;
   item->has_arg = 1;
-  item->called = 0;
-  item->help_string = help_string;
-  item->string_value = NULL;
-  item->user_data = NULL;
-
+  item->opt_var = variable;
   *variable = init_value;
 }
 
@@ -361,24 +333,12 @@ sc_options_add_double (sc_options_t * opt, int opt_char,
                        double *variable, double init_value,
                        const char *help_string)
 {
-  sc_option_item_t   *item;
+  sc_option_item_t   *item =
+    sc_options_add_item (opt, opt_char, opt_name,
+                         SC_OPTION_DOUBLE, help_string);
 
-  SC_ASSERT (opt_char != '\0' || opt_name != NULL);
-  SC_ASSERT (opt_name == NULL || opt_name[0] != '-');
-
-  item = (sc_option_item_t *) sc_array_push (opt->option_items);
-
-  item->opt_type = SC_OPTION_DOUBLE;
-  item->opt_char = opt_char;
-  item->opt_name = opt_name;
-  item->opt_var = variable;
-  item->opt_fn = NULL;
   item->has_arg = 1;
-  item->called = 0;
-  item->help_string = help_string;
-  item->string_value = NULL;
-  item->user_data = NULL;
-
+  item->opt_var = variable;
   *variable = init_value;
 }
 

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -1074,6 +1074,7 @@ sc_options_load_json (int package_id, int err_priority,
   json_t             *file;
   json_t             *jopt;
   json_t             *jval, *jv2;
+  json_int_t          jint;
   json_error_t        jerr;
   const char         *s, *key;
   char                skey[BUFSIZ];
@@ -1162,9 +1163,10 @@ sc_options_load_json (int package_id, int err_priority,
       *(int *) item->opt_var = bvalue;
       break;
     case SC_OPTION_INT:
-      if (json_is_integer (jval)) {
-        /* to do: range check */
-        ivalue = (int) json_integer_value (jval);
+      if (json_is_integer (jval) &&
+          (jint = json_integer_value (jval)) >= (json_int_t) INT_MIN &&
+          jint <= (json_int_t) INT_MAX) {
+        ivalue = (int) jint;
       }
       else {
         SC_GEN_LOGF (package_id, SC_LC_GLOBAL, err_priority,
@@ -1174,9 +1176,9 @@ sc_options_load_json (int package_id, int err_priority,
       *(int *) item->opt_var = ivalue;
       break;
     case SC_OPTION_SIZE_T:
-      if (json_is_integer (jval)) {
-        /* to do: range check */
-        zvalue = (size_t) json_integer_value (jval);
+      if (json_is_integer (jval) &&
+          (jint = json_integer_value (jval)) >= 0) {
+        zvalue = (size_t) jint;
       }
       else {
         SC_GEN_LOGF (package_id, SC_LC_GLOBAL, err_priority,
@@ -1188,7 +1190,6 @@ sc_options_load_json (int package_id, int err_priority,
     case SC_OPTION_DOUBLE:
       if (json_is_number (jval)) {
         if (json_is_integer (jval)) {
-          /* to do: range check */
           dvalue = (double) json_integer_value (jval);
         }
         else {

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -971,7 +971,7 @@ sc_options_load_ini (int package_id, int err_priority,
  * We look up each substring between ':'s as key to a sub-object and
  * continue recursively.  If a key is not found, we try the concatenation
  * with the next substring as key, and so forth.
- * Values dound at deeper levels of recursion take precedence.
+ * Values found at deeper levels of recursion take precedence.
  *
  * This allows for both a hierarchical and a flat JSON representation.
  *

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -814,8 +814,8 @@ sc_options_load_ini (int package_id, int err_priority,
 {
   int                 found_short, found_long;
   size_t              iz;
-  sc_array_t         *items = opt->option_items;
-  size_t              count = items->elem_count;
+  size_t              count;
+  sc_array_t         *items;
   sc_option_item_t   *item;
   dictionary         *dict;
   int                 iserror;
@@ -826,6 +826,10 @@ sc_options_load_ini (int package_id, int err_priority,
   const char         *s, *key;
   char                skey[BUFSIZ], lkey[BUFSIZ];
 
+  SC_ASSERT (opt != NULL);
+  SC_ASSERT (inifile != NULL);
+
+  /* read .ini file in one go */
   dict = iniparser_load (inifile);
   if (dict == NULL) {
     SC_GEN_LOG (package_id, SC_LC_GLOBAL, err_priority,
@@ -833,6 +837,9 @@ sc_options_load_ini (int package_id, int err_priority,
     return -1;
   }
 
+  /* loop through option items */
+  items = opt->option_items;
+  count = items->elem_count;
   for (iz = 0; iz < count; ++iz) {
     item = (sc_option_item_t *) sc_array_index (items, iz);
     if (item->opt_type == SC_OPTION_INIFILE ||
@@ -841,6 +848,7 @@ sc_options_load_ini (int package_id, int err_priority,
       continue;
     }
 
+    /* check existence of key */
     key = NULL;
     skey[0] = lkey[0] = '\0';
     found_short = found_long = 0;
@@ -875,6 +883,7 @@ sc_options_load_ini (int package_id, int err_priority,
       continue;
     }
 
+    /* access value by key */
     ++item->called;
     switch (item->opt_type) {
     case SC_OPTION_SWITCH:

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -792,12 +792,12 @@ int
 sc_options_load (int package_id, int err_priority,
                  sc_options_t * opt, const char *file)
 {
-  return sc_options_load_ini (package_id, err_priority, opt, file);
+  return sc_options_load_ini (package_id, err_priority, opt, file, NULL);
 }
 
 int
 sc_options_load_ini (int package_id, int err_priority,
-                     sc_options_t * opt, const char *inifile)
+                     sc_options_t * opt, const char *inifile, void *re)
 {
   int                 found_short, found_long;
   size_t              iz;
@@ -815,6 +815,9 @@ sc_options_load_ini (int package_id, int err_priority,
 
   SC_ASSERT (opt != NULL);
   SC_ASSERT (inifile != NULL);
+
+  /* prepare for runtime error checking implementation */
+  SC_ASSERT (re == NULL);
 
   /* read .ini file in one go */
   dict = iniparser_load (inifile);
@@ -1061,7 +1064,7 @@ sc_options_json_lookup (json_t *object, const char *keystring)
 
 int
 sc_options_load_json (int package_id, int err_priority,
-                      sc_options_t *opt, const char *jsonfile)
+                      sc_options_t *opt, const char *jsonfile, void *re)
 {
   int                 retval = -1;
 #ifndef SC_HAVE_JSON
@@ -1085,6 +1088,9 @@ sc_options_load_json (int package_id, int err_priority,
 
   SC_ASSERT (opt != NULL);
   SC_ASSERT (jsonfile != NULL);
+
+  /* prepare for runtime error checking implementation */
+  SC_ASSERT (re == NULL);
 
   /* read JSON file in one go */
   file = NULL;
@@ -1585,14 +1591,16 @@ sc_options_parse (int package_id, int err_priority, sc_options_t * opt,
       sc_options_string_set ((sc_option_string_t *) item->opt_var, optarg);
       break;
     case SC_OPTION_INIFILE:
-      if (sc_options_load_ini (package_id, err_priority, opt, optarg)) {
+      if (sc_options_load_ini (package_id, err_priority,
+                               opt, optarg, NULL)) {
         SC_GEN_LOGF (package_id, SC_LC_GLOBAL, err_priority,
                      "Error loading .ini file: %s\n", optarg);
         retval = -1;            /* this ends option processing */
       }
       break;
     case SC_OPTION_JSONFILE:
-      if (sc_options_load_json (package_id, err_priority, opt, optarg)) {
+      if (sc_options_load_json (package_id, err_priority,
+                                opt, optarg, NULL)) {
         SC_GEN_LOGF (package_id, SC_LC_GLOBAL, err_priority,
                      "Error loading JSON file: %s\n", optarg);
         retval = -1;            /* this ends option processing */

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -961,6 +961,8 @@ sc_options_load_ini (int package_id, int err_priority,
   return 0;
 }
 
+#ifdef SC_HAVE_JSON
+
 /** Look up a key, possibly with ':' hierarchy markers, in a JSON object.
  *
  * We look up each substring between ':'s as key to a sub-object and
@@ -1054,6 +1056,8 @@ sc_options_json_lookup (json_t *object, const char *keystring)
     }
   }
 }
+
+#endif /* SC_HAVE_JSON */
 
 int
 sc_options_load_json (int package_id, int err_priority,

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -800,7 +800,14 @@ sc_options_print_summary (int package_id, int log_priority,
 
 int
 sc_options_load (int package_id, int err_priority,
-                 sc_options_t * opt, const char *inifile)
+                 sc_options_t * opt, const char *file)
+{
+  return sc_options_load_ini (package_id, err_priority, opt, file);
+}
+
+int
+sc_options_load_ini (int package_id, int err_priority,
+                     sc_options_t * opt, const char *inifile)
 {
   int                 found_short, found_long;
   size_t              iz;
@@ -819,7 +826,7 @@ sc_options_load (int package_id, int err_priority,
   dict = iniparser_load (inifile);
   if (dict == NULL) {
     SC_GEN_LOG (package_id, SC_LC_GLOBAL, err_priority,
-                "Could not load or parse inifile\n");
+                "Could not load or parse .ini file\n");
     return -1;
   }
 
@@ -1311,7 +1318,7 @@ sc_options_parse (int package_id, int err_priority, sc_options_t * opt,
         SC_STRDUP (optarg);
       break;
     case SC_OPTION_INIFILE:
-      if (sc_options_load (package_id, err_priority, opt, optarg)) {
+      if (sc_options_load_ini (package_id, err_priority, opt, optarg)) {
         SC_GEN_LOGF (package_id, SC_LC_GLOBAL, err_priority,
                      "Error loading .ini file: %s\n", optarg);
         retval = -1;            /* this ends option processing */

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -320,11 +320,13 @@ int                 sc_options_load (int package_id, int err_priority,
  * \param [in] err_priority     Error log priority according to sc.h.
  * \param [in] opt              The option structure.
  * \param [in] inifile          Filename of the ini file to load.
+ * \param [in,out] re           Provisioned for runtime error checking
+ *                              implementation; currently must be NULL.
  * \return                      Returns 0 on success, -1 on failure.
  */
 int                 sc_options_load_ini (int package_id, int err_priority,
                                          sc_options_t * opt,
-                                         const char *inifile);
+                                         const char *inifile, void *re);
 
 /** Load a file in JSON format and update entries from object Options.
  * An option whose name contains a colon such as "prefix:basename" will be
@@ -333,11 +335,13 @@ int                 sc_options_load_ini (int package_id, int err_priority,
  * \param [in] err_priority     Error log priority according to sc.h.
  * \param [in] opt              The option structure.
  * \param [in] jsonfile         Filename of the JSON file to load.
+ * \param [in,out] re           Provisioned for runtime error checking
+ *                              implementation; currently must be NULL.
  * \return                      Returns 0 on success, -1 on failure.
  */
 int                 sc_options_load_json (int package_id, int err_priority,
                                           sc_options_t * opt,
-                                          const char *jsonfile);
+                                          const char *jsonfile, void *re);
 
 /** Save all options and arguments to a file in .ini format.
  * This function must only be called after successful option parsing.

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -325,6 +325,19 @@ int                 sc_options_load_ini (int package_id, int err_priority,
                                          sc_options_t * opt,
                                          const char *inifile);
 
+/** Load a file in JSON format and update entries from object Options.
+ * An option whose name contains a colon such as "prefix:basename" will be
+ * updated by a "basename =" entry in a prefix nested object.
+ * \param [in] package_id       Registered package id or -1.
+ * \param [in] err_priority     Error log priority according to sc.h.
+ * \param [in] opt              The option structure.
+ * \param [in] inifile          Filename of the JSON file to load.
+ * \return                      Returns 0 on success, -1 on failure.
+ */
+int                 sc_options_load_json (int package_id, int err_priority,
+                                          sc_options_t * opt,
+                                          const char *jsonfile);
+
 /** Save all options and arguments to a file in .ini format.
  * This function must only be called after successful option parsing.
  * This function should only be called on rank 0.

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -190,6 +190,24 @@ void                sc_options_add_inifile (sc_options_t * opt,
                                             const char *opt_name,
                                             const char *help_string);
 
+/** Add an option to read in a file in JSON format.
+ * The argument to this option must be a filename.
+ * On parsing the specified file is read to set known option variables.
+ * It does not have an associated option variable itself.
+ *
+ * This functionality is only active when \ref sc_have_json returns true,
+ * equivalent to the #define SC_HAVE_JSON existing, and ignored otherwise.
+ *
+ * \param [in,out] opt       A valid options structure.
+ * \param [in] opt_char      Short option character, may be '\0'.
+ * \param [in] opt_name      Long option name without initial dashes, may be NULL.
+ * \param [in] help_string   Help string for usage message, may be NULL.
+ */
+void                sc_options_add_jsonfile (sc_options_t * opt,
+                                             int opt_char,
+                                             const char *opt_name,
+                                             const char *help_string);
+
 /** Add an option that calls a user-defined function when parsed.
  * The callback function should be implemented to allow multiple calls.
  * The option does not have an associated variable.

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -327,11 +327,11 @@ int                 sc_options_load_ini (int package_id, int err_priority,
 
 /** Load a file in JSON format and update entries from object Options.
  * An option whose name contains a colon such as "prefix:basename" will be
- * updated by a "basename =" entry in a prefix nested object.
+ * updated by a "basename =" entry in a "prefix" nested object.
  * \param [in] package_id       Registered package id or -1.
  * \param [in] err_priority     Error log priority according to sc.h.
  * \param [in] opt              The option structure.
- * \param [in] inifile          Filename of the JSON file to load.
+ * \param [in] jsonfile         Filename of the JSON file to load.
  * \return                      Returns 0 on success, -1 on failure.
  */
 int                 sc_options_load_json (int package_id, int err_priority,

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -38,13 +38,15 @@ typedef struct sc_options sc_options_t;
 
 /** This callback can be invoked during sc_options_parse.
  * \param [in] opt      Valid options data structure.
- *                      This is passed in case a file should be loaded.
- * \param [in] optarg   The option argument or NULL if there is none.
+ *                      This is passed as a matter of principle.
+ * \param [in] opt_arg  The option argument or NULL if there is none.
+ *                      This variable is internal.  Do not store pointer.
  * \param [in] data     User-defined data passed to sc_options_add_callback.
- * \return              Return 0 if successful, -1 on error.
+ * \return              Return 0 if successful, -1 to indicate a parse error.
  */
 typedef int         (*sc_options_callback_t) (sc_options_t * opt,
-                                              const char *optarg, void *data);
+                                              const char *opt_arg,
+                                              void *data);
 
 /** Create an empty options structure.
  * \param [in] program_path   Name or path name of the program to display.
@@ -196,7 +198,7 @@ void                sc_options_add_inifile (sc_options_t * opt,
  * It does not have an associated option variable itself.
  *
  * This functionality is only active when \ref sc_have_json returns true,
- * equivalent to the #define SC_HAVE_JSON existing, and ignored otherwise.
+ * equivalent to the define SC_HAVE_JSON existing, and ignored otherwise.
  *
  * \param [in,out] opt       A valid options structure.
  * \param [in] opt_char      Short option character, may be '\0'.
@@ -210,17 +212,15 @@ void                sc_options_add_jsonfile (sc_options_t * opt,
 
 /** Add an option that calls a user-defined function when parsed.
  * The callback function should be implemented to allow multiple calls.
- * The option does not have an associated variable.
- * The callback can be used to set multiple option variables in bulk that would
- * otherwise require an inconvenient number of individual options.
- * This is, however, currently not possible for options with
- * string values or key-value pairs due to the way the API is set up.
- * This function should not have non-option related side effects.
+ * The callback may be used to set multiple option variables in bulk that
+ * would otherwise require an inconvenient number of individual options.
  * This option is not loaded from or saved to files.
  * \param [in,out] opt      A valid options structure.
  * \param [in] opt_char     Short option character, may be '\0'.
  * \param [in] opt_name     Long option name without initial dashes, may be NULL.
- * \param [in] has_arg      Specify if the option needs an option argument.
+ * \param [in] has_arg      Specify whether the option needs an option argument.
+ *                          This can be 0 for none, 1 for a required argument,
+ *                          and 2 for an optional argument; see getopt_long (3).
  * \param [in] fn           Function to call when this option is encountered.
  * \param [in] data         User-defined data passed to the callback.
  * \param [in] help_string  Help string for usage message, may be NULL.

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -258,6 +258,7 @@ void                sc_options_add_keyvalue (sc_options_t * opt,
                                              const char *help_string);
 
 /** Copy one set of options to another as a subset, with a prefix.
+ * The variables referenced by the options and the suboptions are the same.
  * \param [in,out] opt  A set of options.
  * \param [in]  subopt  Another set of options to be copied.
  * \param [in]  prefix  The prefix to add to option names as they are copied.

--- a/src/sc_options.h
+++ b/src/sc_options.h
@@ -301,7 +301,18 @@ void                sc_options_print_summary (int package_id,
                                               int log_priority,
                                               sc_options_t * opt);
 
-/** Load a file in .ini format and updates entries found under [Options].
+/** Load a file in the default format and update option values.
+ * The default is a file in the .ini format; see \ref sc_options_load_ini.
+ * \param [in] package_id       Registered package id or -1.
+ * \param [in] err_priority     Error log priority according to sc.h.
+ * \param [in] opt              The option structure.
+ * \param [in] file             Filename of the file to load.
+ * \return                      Returns 0 on success, -1 on failure.
+ */
+int                 sc_options_load (int package_id, int err_priority,
+                                     sc_options_t * opt, const char *file);
+
+/** Load a file in .ini format and update entries found under [Options].
  * An option whose name contains a colon such as "prefix:basename" will be
  * updated by a "basename =" entry in a [prefix] section.
  * \param [in] package_id       Registered package id or -1.
@@ -310,8 +321,9 @@ void                sc_options_print_summary (int package_id,
  * \param [in] inifile          Filename of the ini file to load.
  * \return                      Returns 0 on success, -1 on failure.
  */
-int                 sc_options_load (int package_id, int err_priority,
-                                     sc_options_t * opt, const char *inifile);
+int                 sc_options_load_ini (int package_id, int err_priority,
+                                         sc_options_t * opt,
+                                         const char *inifile);
 
 /** Save all options and arguments to a file in .ini format.
  * This function must only be called after successful option parsing.
@@ -341,7 +353,7 @@ int                 sc_options_parse (int package_id, int err_priority,
                                       sc_options_t * opt, int argc,
                                       char **argv);
 
-/** Load a file in .ini format and updates entries found under [Arguments].
+/** Load a file in .ini format and update entries found under [Arguments].
  * There needs to be a key Arguments.count specifying the number.
  * Then as many integer keys starting with 0 need to be present.
  * \param [in] package_id       Registered package id or -1.

--- a/test/test_version.c
+++ b/test/test_version.c
@@ -29,6 +29,26 @@
 
 #include <sc.h>
 
+static int
+test_config_libraries (void)
+{
+  int                 num_failed_tests = 0;
+
+#ifndef SC_HAVE_JSON
+  if (sc_have_json ()) {
+    SC_GLOBAL_LERROR ("Negative JSON presence mismatch\n");
+    ++num_failed_tests;
+  }
+#else
+  if (!sc_have_json ()) {
+    SC_GLOBAL_LERROR ("Positive JSON presence mismatch\n");
+    ++num_failed_tests;
+  }
+#endif
+
+  return num_failed_tests;
+}
+
 int
 main (int argc, char **argv)
 {
@@ -50,34 +70,37 @@ main (int argc, char **argv)
   /* check all functions related to version numbers of libsc */
   num_failed_tests = 0;
   version = sc_version ();
-  SC_GLOBAL_LDEBUGF ("Full libsc version: %s\n", version);
+  SC_GLOBAL_INFOF ("Full libsc version: %s\n", version);
 
   if (!strncmp (version, unknown, strlen (unknown))) {
-    SC_GLOBAL_VERBOSE ("Version is unknown\n");
+    SC_GLOBAL_INFO ("Version is unknown\n");
     version_major = sc_version_major ();
     version_minor = sc_version_minor ();
     if (version_major != 0 || version_minor != 0) {
-      SC_GLOBAL_VERBOSE ("Unknown version of libsc not zero\n");
+      SC_GLOBAL_LERROR ("Unknown version of libsc not zero\n");
       num_failed_tests++;
     }
   }
   else {
     version_major = sc_version_major ();
-    SC_GLOBAL_LDEBUGF ("Major libsc version: %d\n", version_major);
+    SC_GLOBAL_INFOF ("Major libsc version: %d\n", version_major);
     snprintf (version_tmp, 32, "%d", version_major);
     if (strncmp (version, version_tmp, strlen (version_tmp))) {
-      SC_GLOBAL_VERBOSE ("Test failure for major version of libsc\n");
+      SC_GLOBAL_LERROR ("Test failure for major version of libsc\n");
       num_failed_tests++;
     }
 
     version_minor = sc_version_minor ();
-    SC_GLOBAL_LDEBUGF ("Minor libsc version: %d\n", version_minor);
+    SC_GLOBAL_INFOF ("Minor libsc version: %d\n", version_minor);
     snprintf (version_tmp, 32, "%d.%d", version_major, version_minor);
     if (strncmp (version, version_tmp, strlen (version_tmp))) {
-      SC_GLOBAL_VERBOSE ("Test failure for minor version of libsc\n");
+      SC_GLOBAL_LERROR ("Test failure for minor version of libsc\n");
       num_failed_tests++;
     }
   }
+
+  /* further tests */
+  num_failed_tests += test_config_libraries ();
 
   /* clean up and exit */
   sc_finalize ();


### PR DESCRIPTION
# Enable JSON file parsing for option variables

Proposed changes: Provide `sc_options_load_json` to parse a JSON file.
To this end, implement a configure check for the jansson library.

Along the way, conduct a slight renovation of the source in `sc_options.c`.
The API of all pre-existing functions as well as their semantics are unchanged.

Planning separately to write to the JSON format and load/save command line arguments.