### PR TITLE
Improve documentation of sc_io

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: CMake build on Linux
     timeout-minutes: 15
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1683,7 +1683,7 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
       if (errval != 0) {
         /* it occurred an error */
         SC_ASSERT (errval > 0);
-        SC_ABORT ("sc_mpi_read_at_all: rank 0 open failed");
+        SC_ABORT ("sc_io_read_at_all: rank 0 open failed");
       }
     }
     else {

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1456,12 +1456,11 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
 #endif
 }
 
-#ifdef SC_ENABLE_MPIIO
-
 void
 sc_io_read (sc_MPI_File mpifile, void *ptr, size_t zcount,
             sc_MPI_Datatype t, const char *errmsg)
 {
+#ifdef SC_ENABLE_MPIIO
 #ifdef SC_ENABLE_DEBUG
   int                 icount;
 #endif
@@ -1476,9 +1475,11 @@ sc_io_read (sc_MPI_File mpifile, void *ptr, size_t zcount,
   SC_CHECK_MPI (mpiret);
   SC_CHECK_ABORT (icount == (int) zcount, errmsg);
 #endif
-}
-
+#else
+  /* we do not provide a non-MPI I/O implementation of sc_io_read */
+  SC_ABORT ("no non-MPI I/O implementation of sc_io_read/sc_mpi_read");
 #endif
+}
 
 int
 sc_io_read_at (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
@@ -1710,12 +1711,11 @@ sc_io_read_all (sc_MPI_File mpifile, void *ptr, int zcount, sc_MPI_Datatype t,
   return sc_io_read_at_all (mpifile, 0, ptr, zcount, t, ocount);
 }
 
-#ifdef SC_ENABLE_MPIIO
-
 void
 sc_io_write (sc_MPI_File mpifile, const void *ptr, size_t zcount,
              sc_MPI_Datatype t, const char *errmsg)
 {
+#ifdef SC_ENABLE_MPIIO
 #ifdef SC_ENABLE_DEBUG
   int                 icount;
 #endif
@@ -1731,9 +1731,11 @@ sc_io_write (sc_MPI_File mpifile, const void *ptr, size_t zcount,
   SC_CHECK_MPI (mpiret);
   SC_CHECK_ABORT (icount == (int) zcount, errmsg);
 #endif
-}
-
+#else
+  /* we do not provide a non-MPI I/O implementation of sc_io_write */
+  SC_ABORT ("no non-MPI I/O implementation of sc_io_write/sc_mpi_write");
 #endif
+}
 
 int
 sc_io_write_at (sc_MPI_File mpifile, sc_MPI_Offset offset,

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -312,7 +312,7 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * If zlib is detected on configuration, we compress with given level.
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * The status of zlib detection can be queried at compile time using
- * <tt>\#ifdef SC_HAVE_ZLIB</tt> or at run time using \ref sc_io_have_zlib.
+ * \#ifdef \a SC_HAVE_ZLIB or at run time using \ref sc_io_have_zlib.
  * Both approaches are readable by a standard zlib uncompress call.
  *
  * Secondly, we process the input data size as an 8-byte big-endian number,
@@ -503,7 +503,6 @@ int                 sc_io_open (sc_MPI_Comm mpicomm,
 #define sc_mpi_read         sc_io_read   /**< For backwards compatibility. */
 
 /** Read MPI file content into memory.
- * This function aborts if MPI I/O is not enabled.
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [out] ptr     Data array to read in from disk.
  * \param [in] zcount   Number of array members.
@@ -513,6 +512,7 @@ int                 sc_io_open (sc_MPI_Comm mpicomm,
  *                      This function does not use the calling convention
  *                      and error handling as the other sc_io MPI file
  *                      functions to ensure backwards compatibility.
+ * \note                This function aborts if MPI I/O is not enabled.
  */
 void                sc_io_read (sc_MPI_File mpifile, void *ptr,
                                 size_t zcount, sc_MPI_Datatype t,
@@ -575,7 +575,6 @@ int                 sc_io_read_all (sc_MPI_File mpifile, void *ptr,
 #define sc_mpi_write        sc_io_write  /**< For backwards compatibility. */
 
 /** Write memory content to an MPI file.
- * This function aborts if MPI I/O is not enabled.
  * \param [in,out] mpifile      MPI file object opened for writing.
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
@@ -585,6 +584,7 @@ int                 sc_io_read_all (sc_MPI_File mpifile, void *ptr,
  *                      This function does not use the calling convention
  *                      and error handling as the other sc_io MPI file
  *                      functions to ensure backwards compatibility.
+ * \note                This function aborts if MPI I/O is not enabled.
  */
 void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
                                  size_t zcount, sc_MPI_Datatype t,

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -113,11 +113,14 @@ typedef struct sc_io_source
 }
 sc_io_source_t;
 
+/** Open modes for \ref sc_io_open */
 typedef enum
 {
-  SC_IO_READ,
-  SC_IO_WRITE_CREATE,
-  SC_IO_WRITE_APPEND
+  SC_IO_READ,                         /**< open a file in read-only mode */
+  SC_IO_WRITE_CREATE,                 /**< open a file in write-only mode;
+                                           if the file exists, the file will
+                                           be overwritten */
+  SC_IO_WRITE_APPEND                  /**< append to an already existing file */
 }
 sc_io_open_mode_t;
 

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -486,11 +486,10 @@ int                 sc_io_open (sc_MPI_Comm mpicomm,
                                 const char *filename, sc_io_open_mode_t amode,
                                 sc_MPI_Info mpiinfo, sc_MPI_File * mpifile);
 
-#ifdef SC_ENABLE_MPIIO
-
 #define sc_mpi_read         sc_io_read   /**< For backwards compatibility. */
 
 /** Read MPI file content into memory.
+ * This function aborts if MPI I/O is not enabled.
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [out] ptr     Data array to read in from disk.
  * \param [in] zcount   Number of array members.
@@ -504,8 +503,6 @@ int                 sc_io_open (sc_MPI_Comm mpicomm,
 void                sc_io_read (sc_MPI_File mpifile, void *ptr,
                                 size_t zcount, sc_MPI_Datatype t,
                                 const char *errmsg);
-
-#endif
 
 /** Read MPI file content into memory for an explicit offset.
  * This function does not update the file pointer of the MPI file.
@@ -558,11 +555,10 @@ int                 sc_io_read_all (sc_MPI_File mpifile, void *ptr,
                                     int zcount, sc_MPI_Datatype t,
                                     int *ocount);
 
-#ifdef SC_ENABLE_MPIIO
-
 #define sc_mpi_write        sc_io_write  /**< For backwards compatibility. */
 
 /** Write memory content to an MPI file.
+ * This function aborts if MPI I/O is not enabled.
  * \param [in,out] mpifile      MPI file object opened for writing.
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
@@ -576,8 +572,6 @@ int                 sc_io_read_all (sc_MPI_File mpifile, void *ptr,
 void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
                                  size_t zcount, sc_MPI_Datatype t,
                                  const char *errmsg);
-
-#endif
 
 /** Write MPI file content into memory for an explicit offset.
  * This function does not update the file pointer that is part of mpifile.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -281,8 +281,8 @@ int                 sc_io_have_zlib (void);
  * Without zlib configured that function works uncompressed.
  *
  * The encoding method and input data size can be retrieved, optionally,
- * from the encoded data by \sc_io_decode_info.  This function decodes
- * the method as a character, which is 'z' for \ref sc_io_encoded_zlib.
+ * from the encoded data by \ref sc_io_decode_info.  This function decodes
+ * the method as a character, which is 'z' for \ref sc_io_encode_zlib.
  * We reserve the characters A-C, d-z indefinitely.
  *
  * \param [in,out] data     If \a out is NULL, we work in place.
@@ -309,7 +309,7 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * If zlib is detected on configuration, we compress with given level.
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * The status of zlib detection can be queried at compile time using
- * `#ifdef SC_HAVE_ZLIB` or at run time using \ref sc_io_have_zlib.
+ * <tt>\#ifdef SC_HAVE_ZLIB</tt> or at run time using \ref sc_io_have_zlib.
  * Both approaches are readable by a standard zlib uncompress call.
  *
  * Secondly, we process the input data size as an 8-byte big-endian number,

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -542,6 +542,9 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
                                        int *ocount);
 
 /** Read memory content collectively from an MPI file.
+ * A call of this function is equivalent to call \ref sc_io_read_at_all
+ * with offset = 0 but the call of this function is not equivalent
+ * to a call of MPI_File_read_all.
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
@@ -615,6 +618,9 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
                                         sc_MPI_Datatype t, int *ocount);
 
 /** Write memory content collectively to an MPI file.
+ * A call of this function is equivalent to call \ref sc_io_write_at_all
+ * with offset = 0 but the call of this function is not equivalent
+ * to a call of MPI_File_write_all.
  * \param [in,out] mpifile      MPI file object opened for writing.
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -32,7 +32,6 @@
  * in parallel if at least MPI is enabled.
  * Furthermore, there are functions to encode and decode
  * based on zlib.
- *
  */
 
 #include <sc_containers.h>

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -24,6 +24,17 @@
 #ifndef SC_IO_H
 #define SC_IO_H
 
+/** \file sc_io.h
+ *
+ * The I/O functionalities provide functions to
+ * read and write data based on C-standard functions
+ * and also an other set of functions to read and write
+ * in parallel if at least MPI is enabled.
+ * Furthermore, there are functions to encode and decode
+ * based on zlib.
+ *
+ */
+
 #include <sc_containers.h>
 
 /** Examine the MPI return value and print an error if there is one.


### PR DESCRIPTION
# Improve documentation of `sc_io`

Proposed changes:
- Fix some syntax warnings of doxygen.
- Clarify and add documentation in `sc_io.h`.
- Give an implementation of `sc_mpi_{read,write}` (aka `sc_io_{read,write}`) without MPI I/O and abort in this case.
- Fix the Ubuntu version in CI to 20.4 to be able to install older compiler version.
