### PR TITLE
Feature sc3 cut

### DIFF
--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -23,7 +23,7 @@ dnl If MPI is enabled, set AC_DEFINE and AC_CONDITIONAL for PREFIX_ENABLE_MPI.
 dnl If MPI I/O is not disabled, set these for PREFIX_ENABLE_MPIIO.
 dnl If MPI_Init_thread is not disabled, set these for PREFIX_ENABLE_MPITHREAD.
 dnl If MPI shared nodes are supported, set these for PREFIX_ENABLE_MPISHARED.
-dnl If MPI shared memory is continious, set these for PREFIX_ENABLE_MPISOCKET.
+dnl If MPI split by socket is supported, set these for PREFIX_ENABLE_MPISOCKET.
 dnl
 dnl SC_MPI_ENGAGE(PREFIX)
 dnl

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -431,6 +431,28 @@ MPI_Finalize ();
  $2])
 ])
 
+dnl SC_OMPICOMMSOCKET_C_COMPILE_AND_LINK([action-if-successful], [action-if-failed])
+dnl Compile and link an OMPI_COMM_TYPE_SOCKET test program
+dnl
+AC_DEFUN([SC_OMPICOMMSOCKET_C_COMPILE_AND_LINK],
+[
+AC_MSG_CHECKING([compile/link for OMPI_COMM_TYPE_SOCKET C program])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+#undef MPI
+#include <mpi.h>
+]], [[
+MPI_Comm subcomm;
+MPI_Init ((int *) 0, (char ***) 0);
+MPI_Comm_split_type(MPI_COMM_WORLD,OMPI_COMM_TYPE_SOCKET,0,MPI_INFO_NULL,&subcomm);
+MPI_Finalize ();
+]])],
+[AC_MSG_RESULT([successful])
+ $1],
+[AC_MSG_RESULT([failed])
+ $2])
+])
+
 dnl This was only used for our lint code, which needs to be replaced.
 dnl
 dnl dnl SC_MPI_INCLUDES
@@ -533,6 +555,13 @@ dnl  ])
   if test "x$$1_ENABLE_MPICOMMSHARED" = xyes ; then
     AC_DEFINE([ENABLE_MPICOMMSHARED], 1,
               [Define to 1 if we can use MPI_COMM_TYPE_SHARED])
+  fi
+  dnl Run test to check availability of MPI split socket communicator
+  $1_ENABLE_MPICOMMSOCKET=yes
+  SC_MPICOMMSOCKET_C_COMPILE_AND_LINK(,[$1_ENABLE_MPICOMMSOCKET=no])
+  if test "x$$1_ENABLE_MPICOMMSOCKET" = xyes ; then
+    AC_DEFINE([ENABLE_MPICOMMSOCKET], 1,
+              [Define to 1 if we can use OMPI_COMM_TYPE_SOCKET])
   fi
   dnl Deactivate overall MPI 3 code when not available or not configured
   AC_MSG_CHECKING([whether we are using MPI 3 node shared memory])

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -23,6 +23,7 @@ dnl If MPI is enabled, set AC_DEFINE and AC_CONDITIONAL for PREFIX_ENABLE_MPI.
 dnl If MPI I/O is not disabled, set these for PREFIX_ENABLE_MPIIO.
 dnl If MPI_Init_thread is not disabled, set these for PREFIX_ENABLE_MPITHREAD.
 dnl If MPI shared nodes are supported, set these for PREFIX_ENABLE_MPISHARED.
+dnl If MPI shared memory is continious, set these for PREFIX_ENABLE_MPISOCKET.
 dnl
 dnl SC_MPI_ENGAGE(PREFIX)
 dnl
@@ -558,7 +559,7 @@ dnl  ])
   fi
   dnl Run test to check availability of MPI split socket communicator
   $1_ENABLE_MPICOMMSOCKET=yes
-  SC_MPICOMMSOCKET_C_COMPILE_AND_LINK(,[$1_ENABLE_MPICOMMSOCKET=no])
+  SC_OMPICOMMSOCKET_C_COMPILE_AND_LINK(,[$1_ENABLE_MPICOMMSOCKET=no])
   if test "x$$1_ENABLE_MPICOMMSOCKET" = xyes ; then
     AC_DEFINE([ENABLE_MPICOMMSOCKET], 1,
               [Define to 1 if we can use OMPI_COMM_TYPE_SOCKET])

--- a/src/sc3_base.c
+++ b/src/sc3_base.c
@@ -173,6 +173,15 @@ sc3_ulongcut (unsigned long N, int P, int p)
   return p < P ? (N * p) / P : N;
 }
 
+uint64_t
+sc3_uint64cut (uint64_t N, int P, int p)
+{
+  if (N <= 0 || P <= 0 || p <= 0) {
+    return 0;
+  }
+  return p < P ? (N * p) / P : N;
+}
+
 char               *
 sc3_basename (char *path)
 {

--- a/src/sc3_base.h
+++ b/src/sc3_base.h
@@ -324,6 +324,17 @@ long                sc3_longcut (long N, int P, int p);
  */
 unsigned long       sc3_ulongcut (unsigned long N, int P, int p);
 
+/** Compute a cumulative partition cut by floor (Np / P).
+ * The product NP must fit into a long integer.
+ * For p <= 0 we return 0 and for p >= P we return N.
+ * \param [in] N       Non-negative integer to divide between P slots.
+ * \param [in] P       The total number of slots, a positive integer.
+ * \param [in] p       Slot number is trimmed to satisfy 0 <= p <= P.
+ * \return             floor (Np / P) in long integer arithmetic or
+ *                     0 if any argument is invalid.
+ */
+uint64_t            sc3_uint64cut (uint64_t N, int P, int p);
+
 /** Extract the basename of a path.
  * This function uses the system's `basename` function if available
  * and falls back to returning the input string otherwise.

--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -269,7 +269,16 @@ sc3_MPI_Comm_type_t;
 #else
 /* We know that MPI is generally available. */
 
+#ifdef SC3_ENABLE_MPISOCKET
+/* We can split by socket */
+
+#define SC3_MPI_COMM_TYPE_SHARED OMPI_COMM_TYPE_SOCKET
+
+#else
+
 #define SC3_MPI_COMM_TYPE_SHARED MPI_COMM_TYPE_SHARED
+
+#endif /* SC3_ENABLE_MPISOCKET */
 
 #endif /* SC_ENABLE_MPICOMMSHARED */
 

--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -271,13 +271,9 @@ sc3_MPI_Comm_type_t;
 
 #ifdef SC3_ENABLE_MPISOCKET
 /* We can split by socket */
-
 #define SC3_MPI_COMM_TYPE_SHARED OMPI_COMM_TYPE_SOCKET
-
 #else
-
 #define SC3_MPI_COMM_TYPE_SHARED MPI_COMM_TYPE_SHARED
-
 #endif /* SC3_ENABLE_MPISOCKET */
 
 #endif /* SC_ENABLE_MPICOMMSHARED */

--- a/src/sc3_mpienv.c
+++ b/src/sc3_mpienv.c
@@ -129,6 +129,7 @@ sc3_mpienv_new (sc3_allocator_t * mator, sc3_mpienv_t ** mp)
   m->nodecomm = SC3_MPI_COMM_NULL;
 #ifdef SC3_ENABLE_MPI3
   m->shared = 1;
+  m->contiguous = 0;
 #endif
 
   SC3A_IS (sc3_mpienv_is_new, m);

--- a/src/sc3_mpienv.c
+++ b/src/sc3_mpienv.c
@@ -129,7 +129,6 @@ sc3_mpienv_new (sc3_allocator_t * mator, sc3_mpienv_t ** mp)
   m->nodecomm = SC3_MPI_COMM_NULL;
 #ifdef SC3_ENABLE_MPI3
   m->shared = 1;
-  m->contiguous = 0;
 #endif
 
   SC3A_IS (sc3_mpienv_is_new, m);

--- a/test/test_mpienv.c
+++ b/test/test_mpienv.c
@@ -121,8 +121,8 @@ main (int argc, char **argv)
   /* Valgrind might indicate false-positiv errors
      with some MPI shared memory implementations */
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 0));
-  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 1));
 #endif /* SC_ENABLE_VALGRIND */
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 1));
   num_failed_tests += CHECKE (reset_alloc (mainalloc, &alloc));
   if (num_failed_tests > 0) {
     fprintf (stderr, "Number failed tests: %d\n", num_failed_tests);

--- a/test/test_mpienv.c
+++ b/test/test_mpienv.c
@@ -117,10 +117,10 @@ main (int argc, char **argv)
   num_failed_tests += CHECKE (init_alloc (mainalloc, &alloc));
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_SELF, 0, 0));
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 0, 0));
-  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 0));
 #ifndef SC_ENABLE_VALGRIND
   /* Valgrind might indicate false-positiv errors
      with some MPI shared memory implementations */
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 0));
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 1));
 #endif /* SC_ENABLE_VALGRIND */
   num_failed_tests += CHECKE (reset_alloc (mainalloc, &alloc));

--- a/test/test_mpienv.c
+++ b/test/test_mpienv.c
@@ -30,7 +30,7 @@
 #include <sc3_mpienv.h>
 
 static sc3_error_t *
-test_mpienv (sc3_allocator_t * alloc, sc3_MPI_Comm_t mpicomm, int shared)
+test_mpienv (sc3_allocator_t * alloc, sc3_MPI_Comm_t mpicomm, int shared, int contig)
 {
   int                 i;
   int                 get_shared;
@@ -41,6 +41,7 @@ test_mpienv (sc3_allocator_t * alloc, sc3_MPI_Comm_t mpicomm, int shared)
   SC3E (sc3_mpienv_new (alloc, &m));
   SC3E (sc3_mpienv_set_comm (m, mpicomm, 1));
   SC3E (sc3_mpienv_set_shared (m, shared));
+  SC3E (sc3_mpienv_set_contiguous (m, contig));
   SC3E (sc3_mpienv_setup (m));
 
   /* fun tests */
@@ -114,9 +115,12 @@ main (int argc, char **argv)
 
   /* Sophisticated error checking */
   num_failed_tests += CHECKE (init_alloc (mainalloc, &alloc));
-  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_SELF, 0));
-  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 0));
-  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1));
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_SELF, 0, 0));
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 0, 0));
+#ifndef SC_ENABLE_VALGRIND
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 0));
+#endif /* SC_ENABLE_VALGRIND */
+  num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 1));
   num_failed_tests += CHECKE (reset_alloc (mainalloc, &alloc));
   if (num_failed_tests > 0) {
     fprintf (stderr, "Number failed tests: %d\n", num_failed_tests);

--- a/test/test_mpienv.c
+++ b/test/test_mpienv.c
@@ -117,10 +117,12 @@ main (int argc, char **argv)
   num_failed_tests += CHECKE (init_alloc (mainalloc, &alloc));
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_SELF, 0, 0));
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 0, 0));
-#ifndef SC_ENABLE_VALGRIND
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 0));
-#endif /* SC_ENABLE_VALGRIND */
+#ifndef SC_ENABLE_VALGRIND
+  /* Valgrind might indicate false-positiv errors
+     with some MPI shared memory implementations */
   num_failed_tests += CHECKE (test_mpienv (alloc, SC3_MPI_COMM_WORLD, 1, 1));
+#endif /* SC_ENABLE_VALGRIND */
   num_failed_tests += CHECKE (reset_alloc (mainalloc, &alloc));
   if (num_failed_tests > 0) {
     fprintf (stderr, "Number failed tests: %d\n", num_failed_tests);


### PR DESCRIPTION
A small update of lib-sc3:

1. Add a 64-bit integer cut function.
2. Add an assembling check on availability of socket communicator split for MPI3 shared memory. If so, split comm by socket always.  