### PR TITLE
sc3:mpienv: fix `shared` mismatch at p3 and sc3

### DIFF
--- a/src/sc3_mpienv.c
+++ b/src/sc3_mpienv.c
@@ -127,9 +127,7 @@ sc3_mpienv_new (sc3_allocator_t * mator, sc3_mpienv_t ** mp)
   m->nodesizewin = SC3_MPI_WIN_NULL;
   m->headcomm = SC3_MPI_COMM_NULL;
   m->nodecomm = SC3_MPI_COMM_NULL;
-#ifdef SC3_ENABLE_MPI3
   m->shared = 1;
-#endif
 
   SC3A_IS (sc3_mpienv_is_new, m);
   *mp = m;
@@ -163,9 +161,7 @@ sc3_error_t        *
 sc3_mpienv_set_shared (sc3_mpienv_t * m, int shared)
 {
   SC3A_IS (sc3_mpienv_is_new, m);
-#ifdef SC3_ENABLE_MPI3
   m->shared = shared;
-#endif
   return NULL;
 }
 


### PR DESCRIPTION
Fix an error with availability shared memory flag without MPI library. Previously, it led to mismatching between p4est3's and sc3's `shared` flags in case of disabling MPI, that caused unexpected behavior. 