### PR TITLE
Add mpienv files to cmake assembling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,7 @@ sc_allgather.c sc_reduce.c sc_notify.c
 sc_uint128.c sc_v4l2.c
 sc_puff.c
 sc3_base.c sc3_alloc.c sc3_error.c sc3_refcount.c sc3_omp.c sc3_mpi.c
-sc3_array.c sc3_log.c sc3_trace.c sc3_memstamp.c
+sc3_array.c sc3_log.c sc3_trace.c sc3_memstamp.c sc3_mpienv.c
 )
 
 if(SC_HAVE_GETOPT_H)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(sc_tests allgather arrays keyvalue notify reduce search sortb version)
+set(sc_tests allgather arrays keyvalue notify reduce search sortb version mpienv containers)
 
 if(SC_HAVE_RANDOM AND SC_HAVE_SRANDOM)
   list(APPEND sc_tests node_comm)


### PR DESCRIPTION
Added missing sc3_mpienv files to cmake. Additionally added  sc3_containers to the cmake tests.