### PR TITLE
Fix sc3 warnings

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -58,13 +58,29 @@ set(SC_ENABLE_MEMALIGN 1)
 
 if(MPI_FOUND)
   set(SC_ENABLE_MPI ${MPI_FOUND})
-  check_symbol_exists(MPI_COMM_TYPE_SHARED mpi.h SC_ENABLE_MPICOMMSHARED)
+  check_c_source_compiles("
+  #include <mpi.h>
+  int main (void) {
+    MPI_Comm subcomm;
+    MPI_Init ((int *) 0, (char ***) 0);
+    MPI_Comm_split_type(MPI_COMM_WORLD,MPI_COMM_TYPE_SHARED,0,MPI_INFO_NULL,&subcomm);
+    MPI_Finalize ();
+    return 0;
+  }" SC_ENABLE_MPICOMMSHARED)
   set(SC_ENABLE_MPIIO 1)
   check_symbol_exists(MPI_Init_thread mpi.h SC_ENABLE_MPITHREAD)
   check_symbol_exists(MPI_Win_allocate_shared mpi.h SC_ENABLE_MPIWINSHARED)
 endif(MPI_FOUND)
 
-
+  check_c_source_compiles("
+  #include <mpi.h>
+  int main (void) {
+    MPI_Comm subcomm;
+    MPI_Init ((int *) 0, (char ***) 0);
+    MPI_Comm_split_type(MPI_COMM_WORLD,OMPI_COMM_TYPE_SOCKET,0,MPI_INFO_NULL,&subcomm);
+    MPI_Finalize ();
+    return 0;
+  }" SC_ENABLE_OMPICOMMSOCKET)
 check_symbol_exists(realloc stdlib.h SC_ENABLE_USE_REALLOC)
 
 check_symbol_exists(aligned_alloc stdlib.h SC_HAVE_ALIGNED_ALLOC)

--- a/src/sc3_alloc.c
+++ b/src/sc3_alloc.c
@@ -65,7 +65,7 @@ sc3_allocator_is_valid (const sc3_allocator_t * a, char *reason)
 {
   SC3E_TEST (a != NULL, reason);
   SC3E_IS (sc3_refcount_is_valid, &a->rc, reason);
-  SC3E_TEST (!a->alloced == (a->oa == NULL), reason);
+  SC3E_TEST ((!a->alloced) == (a->oa == NULL), reason);
   if (a->oa != NULL) {
     /* this goes into a recursion up the allocator tree */
     SC3E_IS (sc3_allocator_is_setup, a->oa, reason);

--- a/src/sc3_error.c
+++ b/src/sc3_error.c
@@ -88,7 +88,7 @@ sc3_error_is_valid (const sc3_error_t * e, char *reason)
 {
   SC3E_TEST (e != NULL, reason);
   SC3E_IS (sc3_refcount_is_valid, &e->rc, reason);
-  SC3E_TEST (!e->alloced == (e->eator == NULL), reason);
+  SC3E_TEST ((!e->alloced) == (e->eator == NULL), reason);
   if (e->eator != NULL) {
     SC3E_IS (sc3_allocator_is_setup, e->eator, reason);
   }

--- a/src/sc3_log.c
+++ b/src/sc3_log.c
@@ -65,7 +65,7 @@ sc3_log_is_valid (const sc3_log_t * log, char *reason)
 {
   SC3E_TEST (log != NULL, reason);
   SC3E_IS (sc3_refcount_is_valid, &log->rc, reason);
-  SC3E_TEST (!log->alloced == (log->lator == NULL), reason);
+  SC3E_TEST ((!log->alloced) == (log->lator == NULL), reason);
   if (log->lator != NULL) {
     SC3E_IS (sc3_allocator_is_setup, log->lator, reason);
   }


### PR DESCRIPTION
1. Fixed some warnings appeared with the older versions of gcc.
2. Check availability of shared memory and socket split properly for cmake build case.