### PR TITLE
CMake: correct pkgconf generation

### DIFF
--- a/cmake/pkgconf.cmake
+++ b/cmake/pkgconf.cmake
@@ -1,5 +1,10 @@
 # --- generate pkg-config .pc
-set(pc_req_private "ompi ompi-c orte zlib")
+set(pc_req_private "")
+if(mpi)
+  string(APPEND pc_req_private " ompi ompi-c zlib")
+elseif(zlib)
+  string(APPEND pc_req_private " zlib")
+endif()
 
 set(pc_filename libsc-${git_version}.pc)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/pkgconf.pc.in ${pc_filename} @ONLY)


### PR DESCRIPTION
# CMake:pkgconf: only specify used requirements

Following up on issue #107 .

