### PR TITLE
Cmake soversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ target_include_directories(libb64 PRIVATE libb64)
 add_library(sc $<TARGET_OBJECTS:iniparser> $<TARGET_OBJECTS:libb64>)
 target_compile_features(sc PRIVATE c_std_99)
 set_property(TARGET sc PROPERTY EXPORT_NAME SC)
+set_property(TARGET sc PROPERTY VERSION ${PROJECT_VERSION})
 target_include_directories(sc
 PRIVATE iniparser libb64
 PUBLIC
@@ -84,5 +85,6 @@ include(FeatureSummary)
 add_feature_info(MPI mpi "MPI features of libsc")
 add_feature_info(OpenMP openmp "OpenMP features of libsc")
 add_feature_info(ZLIB zlib "ZLIB features of libsc")
+add_feature_info(shared BUILD_SHARED_LIBS "shared libsc library")
 
 feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES)

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -2,6 +2,7 @@ option(mpi "use MPI library" off)
 option(openmp "use OpenMP" off)
 option(zlib "use ZLIB" on)
 option(BUILD_TESTING "build libsc self-tests" on)
+option(BUILD_SHARED_LIBS "build shared libsc")
 
 # --- default install directory under build/local
 # users can specify like "cmake -B build -DCMAKE_INSTALL_PREFIX=~/mydir"


### PR DESCRIPTION
# CMake build with SOVERSION

Following up on issue https://github.com/cburstedde/p4est/issues/174

This populates target libsc VERSION, that also populates shared library SOVERSION. This allows for a future integer SOVERSION if ever desired.

fixes https://github.com/cburstedde/p4est/issues/174

example: `cmake -DBUILD_SHARED_LIBS=on` on Linux results in binaries:
   libsc.so   libsc.so.2.8.3.999