### PR TITLE
sc3: shared: fix a socket split macro name

### DIFF
--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -269,12 +269,12 @@ sc3_MPI_Comm_type_t;
 #else
 /* We know that MPI is generally available. */
 
-#ifdef SC3_ENABLE_MPISOCKET
+#ifdef SC_ENABLE_MPICOMMSOCKET
 /* We can split by socket */
 #define SC3_MPI_COMM_TYPE_SHARED OMPI_COMM_TYPE_SOCKET
 #else
 #define SC3_MPI_COMM_TYPE_SHARED MPI_COMM_TYPE_SHARED
-#endif /* SC3_ENABLE_MPISOCKET */
+#endif /* SC_ENABLE_MPICOMMSOCKET */
 
 #endif /* SC_ENABLE_MPICOMMSHARED */
 


### PR DESCRIPTION
A small fix in the name of the macro responsible for splitting the communicator across socket.
