### PR TITLE
CI: handle CMake 3.26 logs, add GCC-12

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -83,8 +83,7 @@ jobs:
       with:
         name: linux_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log
 
   mac:
@@ -146,8 +145,7 @@ jobs:
       with:
         name: mac_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log
 
   windows:
@@ -202,6 +200,5 @@ jobs:
       with:
         name: windows_cmake_log
         path: |
-          ./build/CMakeFiles/CMakeOutput.log
-          ./build/CMakeFiles/CMakeError.log
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -14,6 +14,9 @@ on:
   release:
     types: [published]
 
+env:
+  CTEST_NO_TESTS_ACTION: "error"
+
 jobs:
 
   linux:
@@ -23,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        cc: [gcc-9, gcc-10, gcc-11]
+        cc: [gcc-9, gcc-10, gcc-11, gcc-12]
         shared: [false]
         mpi: [true]
         include:
@@ -93,7 +96,7 @@ jobs:
 
     strategy:
       matrix:
-        cc: [clang, gcc-11]
+        cc: [clang, gcc-12]
         shared: [false]
         include:
         - shared: true


### PR DESCRIPTION
For GitHub Actions CI:

* GCC 12 is now also available
* CMake 3.26 is now used, which does not have CMake{Error,Output}.log anymore, replaced by CMakeConfigureLog.yaml
* CTEST_NO_TESTS_ACTION: "error" is in case something is amiss in the CMakeLists.txt that accidentally disabled all tests, this environment variable fails CTest if no tests are enabled.