### PR TITLE
Do not require compile-time MPI constants for configure

### DIFF
--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -149,7 +149,7 @@ if test "x$HAVE_PKG_MPI" = xyes ; then
   elif test "x$$1_MPIRUN" = xmpiexec ; then
     $1_MPI_TEST_FLAGS="-n 2"
   else
-    AC_MSG_ERROR([--enable-mpi given but neither mpirun nor mpiexec found])
+    $1_MPIRUN=
   fi
 fi
 dnl We are not using precious variables for simplicity

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -281,7 +281,7 @@ if (mpiret == MPI_ERR_ARG ||
     mpiret == MPI_ERR_UNKNOWN ||
     mpiret == MPI_ERR_OTHER ||
     mpiret == MPI_ERR_NO_MEM) {
-  mpiret = MPI_SUCESS;
+  mpiret = MPI_SUCCESS;
 }
 MPI_Finalize ();
 ]])],

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -277,13 +277,11 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM(
 ]], [[
 int mpiret =
 MPI_Init ((int *) 0, (char ***) 0);
-switch (mpiret) {
-  case MPI_ERR_ARG:
-  case MPI_ERR_UNKNOWN:
-  case MPI_ERR_OTHER:
-  case MPI_ERR_NO_MEM:
-    mpiret = MPI_SUCCESS;
-    break;
+if (mpiret == MPI_ERR_ARG ||
+    mpiret == MPI_ERR_UNKNOWN ||
+    mpiret == MPI_ERR_OTHER ||
+    mpiret == MPI_ERR_NO_MEM) {
+  mpiret = MPI_SUCESS;
 }
 MPI_Finalize ();
 ]])],
@@ -333,25 +331,23 @@ mpiret =
 MPI_File_open (MPI_COMM_WORLD, "filename",
                MPI_MODE_WRONLY | MPI_MODE_APPEND,
                MPI_INFO_NULL, &fh);
-switch (mpiret) {
-  case MPI_ERR_FILE:
-  case MPI_ERR_NOT_SAME:
-  case MPI_ERR_AMODE:
-  case MPI_ERR_UNSUPPORTED_DATAREP:
-  case MPI_ERR_UNSUPPORTED_OPERATION:
-  case MPI_ERR_NO_SUCH_FILE:
-  case MPI_ERR_FILE_EXISTS:
-  case MPI_ERR_BAD_FILE:
-  case MPI_ERR_ACCESS:
-  case MPI_ERR_NO_SPACE:
-  case MPI_ERR_QUOTA:
-  case MPI_ERR_READ_ONLY:
-  case MPI_ERR_FILE_IN_USE:
-  case MPI_ERR_DUP_DATAREP:
-  case MPI_ERR_CONVERSION:
-  case MPI_ERR_IO:
-    mpiret = MPI_SUCCESS;
-    break;
+if (mpiret == MPI_ERR_FILE ||
+    mpiret == MPI_ERR_NOT_SAME ||
+    mpiret == MPI_ERR_AMODE ||
+    mpiret == MPI_ERR_UNSUPPORTED_DATAREP ||
+    mpiret == MPI_ERR_UNSUPPORTED_OPERATION ||
+    mpiret == MPI_ERR_NO_SUCH_FILE ||
+    mpiret == MPI_ERR_FILE_EXISTS ||
+    mpiret == MPI_ERR_BAD_FILE ||
+    mpiret == MPI_ERR_ACCESS ||
+    mpiret == MPI_ERR_NO_SPACE ||
+    mpiret == MPI_ERR_QUOTA ||
+    mpiret == MPI_ERR_READ_ONLY ||
+    mpiret == MPI_ERR_FILE_IN_USE ||
+    mpiret == MPI_ERR_DUP_DATAREP ||
+    mpiret == MPI_ERR_CONVERSION ||
+    mpiret == MPI_ERR_IO) {
+  mpiret = MPI_SUCCESS;
 }
 MPI_File_close (&fh);
 MPI_Finalize ();

--- a/doc/author_markert.txt
+++ b/doc/author_markert.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. Johannes Markert <johannes.markert@jmark.de>

--- a/doc/author_schlottke-lakemper.txt
+++ b/doc/author_schlottke-lakemper.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. Michael Schlottke-Lakemper


### PR DESCRIPTION
The MPI standard does not mandate constants to be compile-time constants, but only to be link-time constants. In the current setup for configure, however, MPI constants are used in a C `switch` statement, for which they need to be compile-time constants.

This PR tries to remedy this by using `if` statements instead of switches.

@jmark Can you please check if this patch fixes your issue in  https://github.com/cburstedde/p4est/issues/197?