### PR TITLE
Update sc_io.c

### DIFF
--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -26,6 +26,11 @@
 #include <libb64.h>
 #ifdef SC_HAVE_ZLIB
 #include <zlib.h>
+#else
+/* when SC_HAVE_ZLIB is undefined, we need to define Z_BEST_COMPRESSION (zlib.h compatibility) */
+#ifndef Z_BEST_COMPRESSION
+#define Z_BEST_COMPRESSION 9
+#endif
 #endif
 
 #ifndef SC_ENABLE_MPIIO


### PR DESCRIPTION
Fix build when using cmake build, using cmake option zlib=OFF. 
See  recent p4est issue : https://github.com/cburstedde/p4est/issues/198 where the problem was noticed

