### PR TITLE
Feature/cmake/build zlib archive

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -9,12 +9,26 @@ include(CheckCSourceCompiles)
 if(mpi)
   find_package(MPI COMPONENTS C REQUIRED)
 endif()
+
 if(openmp)
   find_package(OpenMP COMPONENTS C REQUIRED)
 endif()
+
 if(zlib)
+  message(STATUS "Using builtin zlib")
   include(${CMAKE_CURRENT_LIST_DIR}/zlib.cmake)
+  set(SC_HAVE_ZLIB true)
+else()
+  find_package(ZLIB)
+  if(ZLIB_FOUND)
+    message(STATUS "Using system zlib : ${ZLIB_VERSION_STRING}")
+    set(SC_HAVE_ZLIB true)
+  else()
+    message(STATUS "Zlib disabled (not found). Consider using cmake \"-Dzlib=ON\" to turn on builtin zlib.")
+    set(SC_HAVE_ZLIB false)
+  endif()
 endif()
+
 find_package(Threads)
 
 # --- set global compile environment

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,8 +1,9 @@
+
 include(GNUInstallDirs)
 
 option(mpi "use MPI library" off)
 option(openmp "use OpenMP" off)
-option(zlib "use ZLIB" on)
+option(zlib "build ZLIB" on)
 option(BUILD_TESTING "build libsc self-tests" on)
 option(BUILD_SHARED_LIBS "build shared libsc")
 

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -3,6 +3,19 @@
 include(GNUInstallDirs)
 include(ExternalProject)
 
+# option to chose if we want to download zlib sources, or use a local archive file
+option(LIBSC_USE_ZLIB_ARCHIVE "Turn ON if you want to use a local archive of zlib sources (default: OFF)." OFF)
+
+# select which version of zlib will be build
+if (NOT DEFINED LIBS_BUILD_ZLIB_VERSION)
+  set(LIBSC_BUILD_ZLIB_VERSION 2.0.6)
+endif()
+
+# default zlib source archive
+if (NOT DEFINED LIBSC_BUILD_ZLIB_ARCHIVE_FILE)
+  set(LIBSC_BUILD_ZLIB_ARCHIVE_FILE https://github.com/zlib-ng/zlib-ng/archive/refs/tags/${LIBSC_BUILD_ZLIB_VERSION}.tar.gz CACHE STRING "zlib source archive (URL or local filepath).")
+endif()
+
 set(ZLIB_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/include)
 
 if(BUILD_SHARED_LIBS)
@@ -29,16 +42,27 @@ set(zlib_cmake_args
 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 )
 
-ExternalProject_Add(ZLIB
-GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng.git
-GIT_TAG 2.0.6
-GIT_SHALLOW true
-CMAKE_ARGS ${zlib_cmake_args}
-BUILD_BYPRODUCTS ${ZLIB_LIBRARIES}
-TLS_VERIFY true
-CONFIGURE_HANDLED_BY_BUILD ON
-INACTIVITY_TIMEOUT 60
-)
+if(LIBSC_USE_ZLIB_ARCHIVE)
+  ExternalProject_Add(ZLIB
+    URL ${LIBSC_BUILD_ZLIB_ARCHIVE_FILE}
+    CMAKE_ARGS ${zlib_cmake_args}
+    BUILD_BYPRODUCTS ${ZLIB_LIBRARIES}
+    TLS_VERIFY true
+    CONFIGURE_HANDLED_BY_BUILD ON
+    INACTIVITY_TIMEOUT 60
+    )
+else()
+  ExternalProject_Add(ZLIB
+    GIT_REPOSITORY https://github.com/zlib-ng/zlib-ng.git
+    GIT_TAG ${LIBSC_BUILD_ZLIB_VERSION}
+    GIT_SHALLOW true
+    CMAKE_ARGS ${zlib_cmake_args}
+    BUILD_BYPRODUCTS ${ZLIB_LIBRARIES}
+    TLS_VERIFY true
+    CONFIGURE_HANDLED_BY_BUILD ON
+    INACTIVITY_TIMEOUT 60
+    )
+endif()
 
 # --- imported target
 


### PR DESCRIPTION
# Add control over building zlib inside libsc

this MR proposes ideas to fix https://github.com/cburstedde/p4est/issues/198 and to issue #96 

we try to fix 2 items:
- slightly change the meaning of cmake option `mpi`; now `mpi=ON` means libsc builds zlib, and `mpi=OFF` means libsc tries to detect zlib from the system. So the user is free to chose if he/she wants to build zlib
-  the second item is more secondary, it adds a cmake option to specifiy a zlib archive on the cmake configure line (to avoid having to download zlib sources). This was motived by the fact a user may want to build p4est with using the website archive (which does not contains zlib sources). The cmake option `zlib`must also exist in p4est to make that possible.

to be discussed further.
