### PR TITLE
Add SC_PROVIDE_GETOPT to sc_config.h for a cmake build.

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -140,6 +140,10 @@ if(SC_HAVE_UNISTD_H)
   check_include_file(getopt.h SC_HAVE_GETOPT_H)
 endif()
 
+if(NOT SC_HAVE_GETOPT_H)
+  set(SC_PROVIDE_GETOPT True)
+endif()
+
 check_include_file(sys/ioctl.h SC_HAVE_SYS_IOCTL_H)
 check_include_file(sys/select.h SC_HAVE_SYS_SELECT_H)
 check_include_file(sys/stat.h SC_HAVE_SYS_STAT_H)

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -153,6 +153,9 @@
 /* Define to 1 if you have a working zlib installation. */
 #cmakedefine SC_HAVE_ZLIB 1
 
+/* Use builtin getopt */
+#cmakedefine SC_PROVIDE_GETOPT 1
+
 /* Linker flags */
 #ifndef SC_LDFLAGS
 #define SC_LDFLAGS @SC_LDFLAGS@

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -59,12 +59,10 @@ test_sc_example(function function/function.c)
 test_sc_example(logging logging/logging.c)
 test_sc_example(test_shmem testing/sc_test_shmem.c)
 
-if(SC_HAVE_GETOPT_H)
-  configure_file(options/sc_options_example.ini sc_options_example.ini COPYONLY)
-  configure_file(options/sc_options_example.json sc_options_example.json COPYONLY)
-  configure_file(options/sc_options_preload.ini sc_options_preload.ini COPYONLY)
-  test_sc_example(options options/options.c)
-endif()
+configure_file(options/sc_options_example.ini sc_options_example.ini COPYONLY)
+configure_file(options/sc_options_example.json sc_options_example.json COPYONLY)
+configure_file(options/sc_options_preload.ini sc_options_preload.ini COPYONLY)
+test_sc_example(options options/options.c)
 
 # The OpenMP example is disabled
 # We are likely removing the OpenMP configuration entirely

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,11 +9,8 @@ sc_keyvalue.c sc_refcount.c sc_shmem.c
 sc_allgather.c sc_reduce.c sc_notify.c
 sc_uint128.c sc_v4l2.c
 sc_puff.c
+sc_options.c sc_getopt.c sc_getopt1.c
 )
-
-if(SC_HAVE_GETOPT_H)
-  target_sources(sc PRIVATE sc_options.c sc_getopt.c sc_getopt1.c)
-endif()
 
 if(SC_HAVE_WINSOCK2_H)
   target_sources(sc PRIVATE sc_builtin/gettimeofday.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,9 +12,7 @@ if(SC_HAVE_UNISTD_H)
   list(APPEND sc_tests sort)
 endif()
 
-if(SC_HAVE_GETOPT_H)
-  list(APPEND sc_tests builtin io_sink)
-endif()
+list(APPEND sc_tests builtin io_sink)
 
 # ---
 set(MPIEXEC_MAX_NUMPROCS 2)


### PR DESCRIPTION
When header getopt.h is not available, just use built-in getopt (cmake was behaving differently from autotools).
Align with the autotools build system.

This fixes an issue raised while discussing in https://github.com/cburstedde/libsc/pull/119