### PR TITLE
update generated pkgconfig (cmake and autotools)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,13 @@ VERSION ${PROJECT_VERSION})
 
 enable_testing()
 
+include(cmake/init_build_type.cmake)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(debug_build ON)
+else()
+  set(debug_build OFF)
+endif()
+
 include(cmake/options.cmake)
 message(STATUS "libsc ${PROJECT_VERSION} "
                "install prefix: ${CMAKE_INSTALL_PREFIX}")

--- a/cmake/FindSC.cmake
+++ b/cmake/FindSC.cmake
@@ -45,8 +45,9 @@ if(SC_CONFIG_H)
   set(CMAKE_REQUIRED_LIBRARIES)
 
   # libsc and current project must both be compiled with/without MPI
-  check_symbol_exists(SC_ENABLE_MPI ${SC_CONFIG_H} SC_has_mpi)
+  check_symbol_exists(SC_ENABLE_MPI   ${SC_CONFIG_H} SC_has_mpi)
   check_symbol_exists(SC_ENABLE_MPIIO ${SC_CONFIG_H} SC_has_mpi_io)
+  check_symbol_exists(SC_HAVE_JSON    ${SC_CONFIG_H} SC_have_json)
   check_symbol_exists(SC_ENABLE_DEBUG ${SC_CONFIG_H} SC_debug_build)
 
   if(MPI_C_FOUND)
@@ -82,4 +83,4 @@ endif()
 
 endif(SC_FOUND)
 
-mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY SC_has_mpi SC_has_mpi_io SC_debug_build)
+mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY SC_has_mpi SC_has_mpi_io SC_debug_build SC_have_json)

--- a/cmake/FindSC.cmake
+++ b/cmake/FindSC.cmake
@@ -47,6 +47,7 @@ if(SC_CONFIG_H)
   # libsc and current project must both be compiled with/without MPI
   check_symbol_exists(SC_ENABLE_MPI ${SC_CONFIG_H} SC_has_mpi)
   check_symbol_exists(SC_ENABLE_MPIIO ${SC_CONFIG_H} SC_has_mpi_io)
+  check_symbol_exists(SC_ENABLE_DEBUG ${SC_CONFIG_H} SC_debug_build)
 
   if(MPI_C_FOUND)
     # a sign the current project is using MPI
@@ -81,4 +82,4 @@ endif()
 
 endif(SC_FOUND)
 
-mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY SC_has_mpi SC_has_mpi_io)
+mark_as_advanced(SC_INCLUDE_DIR SC_LIBRARY SC_has_mpi SC_has_mpi_io SC_debug_build)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -188,6 +188,8 @@ set(SC_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
 
 if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
   set(SC_ENABLE_DEBUG 1)
+else()
+  set(SC_ENABLE_DEBUG 0)
 endif()
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/sc_config.h.in ${PROJECT_BINARY_DIR}/include/sc_config.h)

--- a/cmake/init_build_type.cmake
+++ b/cmake/init_build_type.cmake
@@ -1,0 +1,10 @@
+# set default build type to "RelWithDebInfo"
+set(default_build_type "RelWithDebInfo")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()

--- a/cmake/pkgconf.cmake
+++ b/cmake/pkgconf.cmake
@@ -10,7 +10,7 @@ include(cmake/utils.cmake)
 convert_yn(mpi mpi_pc)
 convert_yn(openmp openmp_pc)
 convert_yn(zlib zlib_pc)
-convert_yn(debug_build debug_build_pc)
+convert_yn(SC_ENABLE_DEBUG debug_build_pc)
 
 set(pc_filename libsc-${git_version}.pc)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/pkgconf.pc.in ${pc_filename} @ONLY)

--- a/cmake/pkgconf.cmake
+++ b/cmake/pkgconf.cmake
@@ -9,6 +9,7 @@ endif()
 include(cmake/utils.cmake)
 convert_yn(mpi mpi_pc)
 convert_yn(openmp openmp_pc)
+convert_yn(SC_HAVE_JSON sc_have_json_pc)
 convert_yn(zlib zlib_pc)
 convert_yn(SC_ENABLE_DEBUG debug_build_pc)
 

--- a/cmake/pkgconf.cmake
+++ b/cmake/pkgconf.cmake
@@ -6,6 +6,12 @@ elseif(zlib)
   string(APPEND pc_req_private " zlib")
 endif()
 
+include(cmake/utils.cmake)
+convert_yn(mpi mpi_pc)
+convert_yn(openmp openmp_pc)
+convert_yn(zlib zlib_pc)
+convert_yn(debug_build debug_build_pc)
+
 set(pc_filename libsc-${git_version}.pc)
 configure_file(${CMAKE_CURRENT_LIST_DIR}/pkgconf.pc.in ${pc_filename} @ONLY)
 

--- a/cmake/pkgconf.pc.in
+++ b/cmake/pkgconf.pc.in
@@ -7,7 +7,8 @@ includedir=${prefix}/include
 libsc_CC=@SC_CC@
 libsc_CFLAGS=@SC_CPPFLAGS@ @SC_CFLAGS@
 
-enable_mpi=@mpi_pc@
+have_mpi=@mpi_pc@
+have_json=@sc_have_json_pc@
 build_zlib=@zlib_pc@
 debug_build=@debug_build_pc@
 

--- a/cmake/pkgconf.pc.in
+++ b/cmake/pkgconf.pc.in
@@ -7,6 +7,10 @@ includedir=${prefix}/include
 libsc_CC=@SC_CC@
 libsc_CFLAGS=@SC_CPPFLAGS@ @SC_CFLAGS@
 
+enable_mpi=@mpi_pc@
+build_zlib=@zlib_pc@
+debug_build=@debug_build_pc@
+
 Name: libsc
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @git_version@

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -5,20 +5,32 @@
 # macro to convert a boolean variable (ON/OFF) to 0/1.
 #
 macro(convert_01 varin varout)
+
+  if(NOT DEFINED ${varin})
+    message(FATAL_ERROR "variable ${varin} not defined")
+  endif()
+
   if(${varin})
     set(${varout} 1)
   else()
     set(${varout} 0)
   endif()
+
 endmacro()
 
 #
 # macro to convert a boolean variable (ON/OFF) to yes/no.
 #
 macro(convert_yn varin varout)
+
+  if(NOT DEFINED ${varin})
+    message(FATAL_ERROR "variable ${varin} not defined")
+  endif()
+
   if(${varin})
     set(${varout} yes)
   else()
     set(${varout} no)
   endif()
+
 endmacro()

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,0 +1,24 @@
+# Define simple macro to ease interoperability with autotools.
+# These macro are used to write variable values in pgk-config files.
+
+#
+# macro to convert a boolean variable (ON/OFF) to 0/1.
+#
+macro(convert_01 varin varout)
+  if(${varin})
+    set(${varout} 1)
+  else()
+    set(${varout} 0)
+  endif()
+endmacro()
+
+#
+# macro to convert a boolean variable (ON/OFF) to yes/no.
+#
+macro(convert_yn varin varout)
+  if(${varin})
+    set(${varout} yes)
+  else()
+    set(${varout} no)
+  endif()
+endmacro()

--- a/config/sc_autotools.pc.in
+++ b/config/sc_autotools.pc.in
@@ -7,7 +7,8 @@ includedir=@includedir@
 libsc_CC=@CC@
 libsc_CFLAGS=@CPPFLAGS@ @CFLAGS@
 
-enable_mpi=@HAVE_PKG_MPI@
+have_mpi=@HAVE_PKG_MPI@
+have_json=@SC_HAVE_JSON@
 build_zlib=no
 debug_build=@SC_ENABLE_DEBUG@
 

--- a/config/sc_autotools.pc.in
+++ b/config/sc_autotools.pc.in
@@ -7,6 +7,10 @@ includedir=@includedir@
 libsc_CC=@CC@
 libsc_CFLAGS=@CPPFLAGS@ @CFLAGS@
 
+enable_mpi=@HAVE_PKG_MPI@
+build_zlib=no
+debug_build=@SC_ENABLE_DEBUG@
+
 Name: libsc
 Description: The SC library supports parallel scientific applications.
 Version: @VERSION@

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -380,6 +380,7 @@ AC_CHECK_PROG([$1_HAVE_DOT], [dot], [YES], [NO])
 SC_CHECK_MATH([$1])
 SC_CHECK_ZLIB([$1])
 SC_CHECK_JSON([$1])
+AC_SUBST([SC_HAVE_JSON])
 dnl SC_CHECK_LIB([lua53 lua5.3 lua52 lua5.2 lua51 lua5.1 lua5 lua],
 dnl              [lua_createtable], [LUA], [$1])
 dnl SC_CHECK_BLAS_LAPACK([$1])

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -65,6 +65,7 @@ elif test "x$enableval" != xno ; then
 fi
 AC_MSG_CHECKING([whether we are using MPI])
 AC_MSG_RESULT([$HAVE_PKG_MPI])
+AC_SUBST([HAVE_PKG_MPI])
 
 dnl The shell variable SC_ENABLE_MPIIO is set if --disable-mpiio is not given.
 dnl If not disabled, MPI I/O will be verified by a compile/link test below.

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ See sc.h for possible log priorities in --enable-logging=PRIO])
                esac])
 SC_ARG_ENABLE([debug], [enable debug mode (assertions and extra checks)],
               [DEBUG])
+AC_SUBST(SC_ENABLE_DEBUG)
 SC_ARG_DISABLE([realloc], [replace array/dmatrix resize with malloc/copy/free],
                [USE_REALLOC])
 SC_ARG_DISABLE([counters], [disable non-thread-safe internal debug counters],

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ See sc.h for possible log priorities in --enable-logging=PRIO])
                esac])
 SC_ARG_ENABLE([debug], [enable debug mode (assertions and extra checks)],
               [DEBUG])
-AC_SUBST(SC_ENABLE_DEBUG)
+AC_SUBST([SC_ENABLE_DEBUG])
 SC_ARG_DISABLE([realloc], [replace array/dmatrix resize with malloc/copy/free],
                [USE_REALLOC])
 SC_ARG_DISABLE([counters], [disable non-thread-safe internal debug counters],


### PR DESCRIPTION
# Update generated pkgconfig (cmake and autotools)

This is a minor change, we just expose 3 variables in pkg-config (autotools and cmake):
- enable_mpi
- build_zlib
- debug_build

these are boolean variables (yes/no) to help a downstream project to quickly get information about how libsc was built.

Another change in the cmake build: we set default value for CMAKE_BUILD_TYPE to RelWithDebInfo for compatibility with autotools defaults.