### PR TITLE
Feature io

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -1417,8 +1417,6 @@ sc_is_root (void)
 #undef SC_LERRORF
 #endif
 
-#ifndef SC_SPLINT
-
 void
 SC_ABORTF (const char *fmt, ...)
 {
@@ -1565,6 +1563,16 @@ sc_version_point (void)
 #endif
 
 int
+sc_have_zlib (void)
+{
+#ifndef SC_HAVE_ZLIB
+  return 0;
+#else
+  return 1;
+#endif
+}
+
+int
 sc_have_json (void)
 {
 #ifndef SC_HAVE_JSON
@@ -1573,5 +1581,3 @@ sc_have_json (void)
   return 1;
 #endif
 }
-
-#endif

--- a/src/sc.h
+++ b/src/sc.h
@@ -237,7 +237,6 @@ extern int          sc_trace_prio;
 #define SC_CHECK_ABORT(q,s)                     \
   ((q) ? (void) 0 : SC_ABORT (s))
 #define SC_CHECK_MPI(r) SC_CHECK_ABORT ((r) == sc_MPI_SUCCESS, "MPI error")
-#define SC_CHECK_ZLIB(r) SC_CHECK_ABORT ((r) == Z_OK, "zlib error")
 
 /*
  * C++98 does not allow variadic macros
@@ -839,6 +838,13 @@ int                 sc_version_minor (void);
  */
 int                 sc_version_point (void);
 #endif /* 0 */
+
+/** Return a boolean indicating whether zlib has been configured.
+ * \return          True if zlib including adler32_combine (3)
+ *                  has been found on running configure
+ *                  or respectively on calling cmake.
+ */
+int                 sc_have_zlib (void);
 
 /** Return whether we have found a JSON library at configure time.
  * \return          True if and only if SC_HAVE_JSON is defined.

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -778,7 +778,7 @@ sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
       ocnt += lout;
 #endif
       SC_ASSERT (ocnt + 3 <= encoded_size);
-      opos[0] = '=';
+      opos[0] = (char) line_break_character;
       opos[1] = '\n';
       opos[2] = '\0';
       opos = NULL;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -390,16 +390,6 @@ sc_io_source_read_mirror (sc_io_source_t * source, void *data,
   return retval;
 }
 
-int
-sc_io_have_zlib (void)
-{
-#ifndef SC_HAVE_ZLIB
-  return 0;
-#else
-  return 1;
-#endif
-}
-
 /* byte count for one line of data must be a multiple of 3 */
 #define SC_IO_DBC 54
 #if SC_IO_DBC % 3 != 0
@@ -1072,6 +1062,8 @@ sc_vtk_write_binary (FILE * vtkfile, char *numeric_data, size_t byte_length)
   return 0;
 }
 
+#define SC_IO_CHECK_ZLIB(r) SC_CHECK_ABORT ((r) == Z_OK, "zlib error")
+
 int
 sc_vtk_write_compressed (FILE * vtkfile, char *numeric_data,
                          size_t byte_length)
@@ -1128,7 +1120,7 @@ sc_vtk_write_compressed (FILE * vtkfile, char *numeric_data,
     retval = compress2 ((Bytef *) comp_data, &comp_length,
                         (const Bytef *) (numeric_data + theblock * blocksize),
                         (uLong) blocksize, Z_BEST_COMPRESSION);
-    SC_CHECK_ZLIB (retval);
+    SC_IO_CHECK_ZLIB (retval);
     compression_header[3 + theblock] = comp_length;
     base_length = base64_encode_block (comp_data, comp_length,
                                        base_data, &encode_state);
@@ -1143,7 +1135,7 @@ sc_vtk_write_compressed (FILE * vtkfile, char *numeric_data,
     retval = compress2 ((Bytef *) comp_data, &comp_length,
                         (const Bytef *) (numeric_data + theblock * blocksize),
                         (uLong) lastsize, Z_BEST_COMPRESSION);
-    SC_CHECK_ZLIB (retval);
+    SC_IO_CHECK_ZLIB (retval);
     compression_header[3 + theblock] = comp_length;
     base_length = base64_encode_block (comp_data, comp_length,
                                        base_data, &encode_state);

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -391,15 +391,16 @@ sc_io_source_read_mirror (sc_io_source_t * source, void *data,
 }
 
 /* byte count for one line of data must be a multiple of 3 */
-#define SC_IO_DBC 54
+#define SC_IO_DBC 57
 #if SC_IO_DBC % 3 != 0
 #error "SC_IO_DBC must be a multiple of 3"
 #endif
 
 /* byte count for one line of base64 encoded data and newline */
 #define SC_IO_LBC (SC_IO_DBC / 3 * 4)
-#define SC_IO_LBD (SC_IO_LBC + 1)
-#define SC_IO_LBE (SC_IO_LBC + 2)
+#define SC_IO_LBD (SC_IO_LBC + 1)   /* after first line break byte */
+#define SC_IO_LBE (SC_IO_LBD + 1)   /* after second line break byte */
+#define SC_IO_LBF (SC_IO_LBE + 1)   /* after line break and NUL byte */
 
 /* see RFC 1950 and RFC 1951 for the uncompressed zlib format */
 #ifndef SC_HAVE_ZLIB
@@ -645,12 +646,12 @@ sc_io_nonuncompress (char *dest, size_t dest_size,
 void
 sc_io_encode (sc_array_t *data, sc_array_t *out)
 {
-  sc_io_encode_zlib (data, out, Z_BEST_COMPRESSION);
+  sc_io_encode_zlib (data, out, Z_BEST_COMPRESSION, '=');
 }
 
 void
 sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
-                   int zlib_compression_level)
+                   int zlib_compression_level, int line_break_character)
 {
   int                 i;
   size_t              input_size;
@@ -723,7 +724,7 @@ sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
   SC_ASSERT (out->elem_size == 1);
   input_size = (size_t) (SC_IO_ENCODE_INFO_LEN + input_compress_bound);
   base64_lines = (input_size + SC_IO_DBC - 1) / SC_IO_DBC;
-  encoded_size = 4 * ((input_size + 2) / 3) + base64_lines + 1;
+  encoded_size = 4 * ((input_size + 2) / 3) + 2 * base64_lines + 1;
   sc_array_resize (out, encoded_size);
 
   /* run base64 encoder */
@@ -746,13 +747,14 @@ sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
       /* not the final line */
       SC_ASSERT (irem > SC_IO_DBC);
       SC_ASSERT (lout == SC_IO_LBC);
-      SC_ASSERT (ocnt + SC_IO_LBE <= encoded_size);
+      SC_ASSERT (ocnt + SC_IO_LBF <= encoded_size);
       memcpy (opos, base_out, SC_IO_LBC);
-      opos[SC_IO_LBC] = '\n';
-      opos[SC_IO_LBD] = '\0';
-      opos += SC_IO_LBD;
+      opos[SC_IO_LBC] = (char) line_break_character;
+      opos[SC_IO_LBD] = '\n';
+      opos[SC_IO_LBE] = '\0';
+      opos += SC_IO_LBE;
 #ifdef SC_ENABLE_DEBUG
-      ocnt += SC_IO_LBD;
+      ocnt += SC_IO_LBE;
 #endif
       ipos += SC_IO_DBC;
       irem -= SC_IO_DBC;
@@ -775,12 +777,13 @@ sc_io_encode_zlib (sc_array_t *data, sc_array_t *out,
 #ifdef SC_ENABLE_DEBUG
       ocnt += lout;
 #endif
-      SC_ASSERT (ocnt + 2 <= encoded_size);
-      opos[0] = '\n';
-      opos[1] = '\0';
+      SC_ASSERT (ocnt + 3 <= encoded_size);
+      opos[0] = '=';
+      opos[1] = '\n';
+      opos[2] = '\0';
       opos = NULL;
 #ifdef SC_ENABLE_DEBUG
-      ocnt += 2;
+      ocnt += 3;
 #endif
       SC_ASSERT (ocnt == encoded_size);
       ipos = NULL;
@@ -887,11 +890,11 @@ sc_io_decode (sc_array_t *data, sc_array_t *out,
 
   /* decode line by line from base 64 */
   base64_init_decodestate (&bstate);
-  base64_lines = (encoded_size - 1 + SC_IO_LBC) / SC_IO_LBD;
+  base64_lines = (encoded_size - 1 + SC_IO_LBD) / SC_IO_LBE;
   compressed_size = base64_lines * SC_IO_DBC;
   ipos = data->array;
   SC_ASSERT (encoded_size >= base64_lines + 1);
-  irem = encoded_size - 1 - base64_lines;
+  irem = encoded_size - 1 - 2 * base64_lines;
   sc_array_init_count (&compressed, 1, compressed_size);
   opos = compressed.array;
   ocnt = 0;
@@ -905,10 +908,12 @@ sc_io_decode (sc_array_t *data, sc_array_t *out,
       SC_LERROR ("base 64 decode short\n");
       goto decode_error;
     }
+#if 0
     if (ipos[lein] != '\n') {
       SC_LERROR ("base 64 missing newline\n");
       goto decode_error;
     }
+#endif
     if (zlin < base64_lines - 1) {
       SC_ASSERT (lein == SC_IO_LBC);
       if (lout != SC_IO_DBC) {
@@ -916,7 +921,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out,
         goto decode_error;
       }
       memcpy (opos, base_out, SC_IO_DBC);
-      ipos += SC_IO_LBD;
+      ipos += SC_IO_LBE;
       SC_ASSERT (irem >= SC_IO_LBC);
       irem -= SC_IO_LBC;
       opos += SC_IO_DBC;
@@ -926,7 +931,7 @@ sc_io_decode (sc_array_t *data, sc_array_t *out,
       SC_ASSERT (lein <= SC_IO_LBC);
       SC_ASSERT (lout <= SC_IO_DBC);
       memcpy (opos, base_out, lout);
-      ipos += lein + 1;
+      ipos += lein + 2;
       SC_ASSERT (irem >= lein);
       irem -= lein;
       opos += lout;

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -282,12 +282,6 @@ int                 sc_io_source_read_mirror (sc_io_source_t * source,
                                               size_t bytes_avail,
                                               size_t *bytes_out);
 
-/** Return a boolean indicating whether zlib has been configured.
- * \return          True if zlib has been found on running configure,
- *                  or respectively on calling cmake.
- */
-int                 sc_io_have_zlib (void);
-
 /** Encode a block of arbitrary data with the default sc_io format.
  * The corresponding decoder function is \ref sc_io_decode.
  * This function cannot crash unless out of memory.
@@ -325,7 +319,7 @@ void                sc_io_encode (sc_array_t *data, sc_array_t *out);
  * If zlib is detected on configuration, we compress with given level.
  * If zlib is not detected, we write data equivalent to Z_NO_COMPRESSION.
  * The status of zlib detection can be queried at compile time using
- * \#ifdef SC_HAVE_ZLIB or at run time using \ref sc_io_have_zlib.
+ * \#ifdef SC_HAVE_ZLIB or at run time using \ref sc_have_zlib.
  * Both approaches are readable by a standard zlib uncompress call.
  *
  * Secondly, we process the input data size as an 8-byte big-endian number,

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -75,6 +75,20 @@ test_helpers (const char *str, const char *label, int tint, int tlong)
   return nft;
 }
 
+static void
+encode_and_print (sc_array_t *src)
+{
+  sc_array_t          dest;
+
+  /* encode */
+  SC_ASSERT (src != NULL);
+  sc_array_init (&dest, 1);
+  sc_io_encode (src, &dest);
+  SC_GLOBAL_PRODUCTIONF ("\"%s\": %u: %s", src->array,
+                         (unsigned int) strlen (dest.array), dest.array);
+  sc_array_reset (&dest);
+}
+
 static int
 single_inplace_test (sc_array_t *src, int itest)
 {
@@ -251,6 +265,7 @@ test_encode_decode (void)
   int                 num_failed_tests = 0;
   int                 i, j;
   size_t              slen;
+  const char         *str0 = "Hello, world!";
   const char         *str1 = "Hello world.  This is a short text.";
   const char         *str2 =
     "This is a much longer text.  We just paste stuff.\n"
@@ -266,6 +281,12 @@ test_encode_decode (void)
  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE\
  POSSIBILITY OF SUCH DAMAGE.";
   sc_array_t          src;
+
+  sc_array_init_data (&src, (void *) "", 1, 1);
+  encode_and_print (&src);
+
+  sc_array_init_data (&src, (void *) str0, 1, strlen (str0) + 1);
+  encode_and_print (&src);
 
   sc_array_init_data (&src, (void *) str1, 1, strlen (str1) + 1);
   single_code_test (&src, -2);

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -115,7 +115,7 @@ single_inplace_test (sc_array_t *src, int itest)
     }
     sc_array_reset (&inp);
 
-    if (!sc_io_have_zlib () || itest != -1) {
+    if (!sc_have_zlib () || itest != -1) {
       /* for the examples we call, test -1 has a large enough data
          size that the encoded data is shorter than the plaintext. */
 


### PR DESCRIPTION
# Update zlib encode/compression convention

## Proposed changes

The compression function for arbitrary array data has been updated to go to 76 code bytes per line and to include a 2-byte general line break. This allows for writing both Unix and MIME type ASCII data.

In passing, remove `sc_io_have_zlib` in favor of `sc_have_zlib`. This is a breaking change requiring a new API version eventually.
