### PR TITLE
Make sc_io_open independent of the MPI IO status

### DIFF
--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1398,6 +1398,13 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
   retval = sc_io_error_class (mpiret, &errcode);
   SC_CHECK_MPI (retval);
 
+  if (mpiret == sc_MPI_SUCCESS && amode == SC_IO_WRITE_CREATE) {
+    /* fopen with the mode "wb" truncates the file to length zero */
+    mpiret = MPI_File_set_size (*mpifile, 0);
+    retval = sc_io_error_class (mpiret, &errcode);
+    SC_CHECK_MPI (retval);
+  }
+
   return errcode;
 #elif defined (SC_ENABLE_MPI)
   {

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -543,7 +543,7 @@ void                sc_io_read (sc_MPI_File mpifile, void *ptr,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read bytes.
+ * \param [out] ocount  The number of read elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -562,7 +562,7 @@ int                 sc_io_read_at (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read bytes.
+ * \param [out] ocount  The number of read elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -580,7 +580,7 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read bytes.
+ * \param [out] ocount  The number of read elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -615,7 +615,7 @@ void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written bytes.
+ * \param [out] ocount  The number of written elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -637,7 +637,7 @@ int                 sc_io_write_at (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written bytes.
+ * \param [out] ocount  The number of written elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -656,7 +656,7 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written bytes.
+ * \param [out] ocount  The number of written elments of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -543,7 +543,7 @@ void                sc_io_read (sc_MPI_File mpifile, void *ptr,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read elments of type \b t.
+ * \param [out] ocount  The number of read elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -562,7 +562,7 @@ int                 sc_io_read_at (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read elments of type \b t.
+ * \param [out] ocount  The number of read elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -580,7 +580,7 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to read from disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read elments of type \b t.
+ * \param [out] ocount  The number of read elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -615,7 +615,7 @@ void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written elments of type \b t.
+ * \param [out] ocount  The number of written elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -637,7 +637,7 @@ int                 sc_io_write_at (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written elments of type \b t.
+ * \param [out] ocount  The number of written elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
@@ -656,7 +656,7 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
  * \param [in] ptr      Data array to write to disk.
  * \param [in] zcount   Number of array members.
  * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written elments of type \b t.
+ * \param [out] ocount  The number of written elements of type \b t.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -132,7 +132,8 @@ typedef enum
   SC_IO_READ,                         /**< open a file in read-only mode */
   SC_IO_WRITE_CREATE,                 /**< open a file in write-only mode;
                                            if the file exists, the file will
-                                           be overwritten */
+                                           be truncated to length zero and
+                                           then overwritten */
   SC_IO_WRITE_APPEND                  /**< append to an already existing file */
 }
 sc_io_open_mode_t;
@@ -508,6 +509,9 @@ void                sc_fflush_fsync_fclose (FILE * file);
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
+ * \note                This function does not exactly follow the MPI_File
+ *                      semantic in the sense that it truncates files to the
+ *                      length zero before overwriting them.
  */
 int                 sc_io_open (sc_MPI_Comm mpicomm,
                                 const char *filename, sc_io_open_mode_t amode,


### PR DESCRIPTION
# Make `sc_io_open` independent of MPI IO status

This PR is a prerequisite to guarantee that the files produced by the code in https://github.com/cburstedde/p4est/pull/212 are independent of the the MPI IO status.

Proposed changes:
- For the mode `SC_IO_WRITE_CREATE`  for `sc_io_open` we unify the behavior in the case with and without MPI IO. Before these changes an existing file was not truncated to the length zero  with MPI IO. This differed from the case without MPI IO.
- Clarify documentation of `sc_io_open`.
- Fix documentation of `count` parameter of `sc_io` wrapper functions.
