### PR TITLE
Add package id query function.

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -89,6 +89,8 @@ const int sc_log2_lookup_table[256] =
 /* *INDENT-ON* */
 
 int                 sc_package_id = -1;
+int                 sc_initialized = 0;
+
 FILE               *sc_trace_file = NULL;
 int                 sc_trace_prio = SC_LP_STATISTICS;
 
@@ -1346,6 +1348,14 @@ sc_init (sc_MPI_Comm mpicomm,
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LAPACK_LIBS", SC_LAPACK_LIBS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "FLIBS", SC_FLIBS);
 #endif
+
+  sc_initialized = 1;
+}
+
+int
+sc_is_initialized (void)
+{
+  return sc_initialized;
 }
 
 int

--- a/src/sc.c
+++ b/src/sc.c
@@ -122,6 +122,12 @@ static sc_package_t *sc_packages = NULL;
 static pthread_mutex_t sc_default_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t sc_error_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+int
+sc_get_package_id (void)
+{
+  return sc_package_id;
+}
+
 static void
 sc_check_abort_thread (int condition, int package, const char *message)
 {

--- a/src/sc.c
+++ b/src/sc.c
@@ -1391,6 +1391,10 @@ sc_finalize_noabort (void)
     }
     sc_trace_file = NULL;
   }
+
+  sc_package_id = -1;
+  sc_initialized = 0;
+
   return num_errors;
 }
 

--- a/src/sc.h
+++ b/src/sc.h
@@ -730,6 +730,12 @@ void                sc_package_unregister (int package_id);
  */
 void                sc_package_print_summary (int log_priority);
 
+/** Query SC's own package identity.
+ * \return          This is -1 before \ref sc_init has been called
+ *                  and a proper package identifier (>= 0) afterwards.
+ */
+int                 sc_get_package_id (void);
+
 /** Sets the global program identifier (e.g. the MPI rank) and some flags.
  * This function is optional.
  * This function must only be called before additional threads are created.

--- a/src/sc.h
+++ b/src/sc.h
@@ -750,10 +750,9 @@ void                sc_init (sc_MPI_Comm mpicomm,
                              sc_log_handler_t log_handler, int log_threshold);
 
 /** Return whether SC has been initialized or not.
-*
- * \return          True if SC has been initialized with a call to
+ * \return          True if libsc has been initialized with a call to
  *                  \ref sc_init and false otherwise.
- *
+ *                  After \ref sc_finalize the result resets to false.
  * \note            This routine is not thread-safe.
  */
 int                 sc_is_initialized (void);
@@ -761,7 +760,7 @@ int                 sc_is_initialized (void);
 /** Query SC's own package identity.
  * \return          This is -1 before \ref sc_init has been called
  *                  and a proper package identifier (>= 0) afterwards.
- *
+ *                  After \ref sc_finalize the identifier resets to -1.
  * \note            This routine is not thread-safe.
  */
 int                 sc_get_package_id (void);
@@ -770,16 +769,18 @@ int                 sc_get_package_id (void);
  * signal handlers and resets sc_identifier and sc_root_*.
  * This function aborts on any inconsistency found unless
  * the global variable default_abort_mismatch is false.
- * This function is optional.
+ * Function is optional if memory cleanliness is no concern.
  * This function does not require sc_init to be called first.
+ * In any case it makes \ref sc_is_initialized return false.
  */
 void                sc_finalize (void);
 
 /** Unregisters all packages, runs the memory check, removes the
  * signal handlers and resets sc_identifier and sc_root_*.
  * This function never aborts but returns the number of errors encountered.
- * This function is optional.
+ * Function is optional if memory cleanliness is no concern.
  * This function does not require sc_init to be called first.
+ * In any case it makes \ref sc_is_initialized return false.
  * \return          0 when everything is consistent, nonzero otherwise.
  */
 int                 sc_finalize_noabort (void);

--- a/src/sc.h
+++ b/src/sc.h
@@ -730,12 +730,6 @@ void                sc_package_unregister (int package_id);
  */
 void                sc_package_print_summary (int log_priority);
 
-/** Query SC's own package identity.
- * \return          This is -1 before \ref sc_init has been called
- *                  and a proper package identifier (>= 0) afterwards.
- */
-int                 sc_get_package_id (void);
-
 /** Sets the global program identifier (e.g. the MPI rank) and some flags.
  * This function is optional.
  * This function must only be called before additional threads are created.
@@ -754,6 +748,19 @@ int                 sc_get_package_id (void);
 void                sc_init (sc_MPI_Comm mpicomm,
                              int catch_signals, int print_backtrace,
                              sc_log_handler_t log_handler, int log_threshold);
+
+/** Return whether SC has been initialized or not.
+*
+ * \return          True if SC has been initialized with a call to
+ *                  \ref sc_init and false otherwise.
+ */
+int                 sc_is_initialized (void);
+
+/** Query SC's own package identity.
+ * \return          This is -1 before \ref sc_init has been called
+ *                  and a proper package identifier (>= 0) afterwards.
+ */
+int                 sc_get_package_id (void);
 
 /** Unregisters all packages, runs the memory check, removes the
  * signal handlers and resets sc_identifier and sc_root_*.

--- a/src/sc.h
+++ b/src/sc.h
@@ -753,12 +753,16 @@ void                sc_init (sc_MPI_Comm mpicomm,
 *
  * \return          True if SC has been initialized with a call to
  *                  \ref sc_init and false otherwise.
+ *
+ * \note            This routine is not thread-safe.
  */
 int                 sc_is_initialized (void);
 
 /** Query SC's own package identity.
  * \return          This is -1 before \ref sc_init has been called
  *                  and a proper package identifier (>= 0) afterwards.
+ *
+ * \note            This routine is not thread-safe.
  */
 int                 sc_get_package_id (void);
 


### PR DESCRIPTION
In some scenarios it is useful to have a dedicated query function for SC's own package id. For example, not all wrapper
generators or FFIs (foreign function interfaces) support to read global external variables.