### PR TITLE
Fix linking with jansson when using installed libsc built with cmake.

### DIFF
--- a/cmake/jansson.cmake
+++ b/cmake/jansson.cmake
@@ -6,7 +6,7 @@ find_package(jansson CONFIG)
 
 if(jansson_FOUND)
 
-  message(STATUS "jansson library found via find_package")
+  message(STATUS "[libsc] jansson library found via find_package")
   set(SC_HAVE_JSON 1)
 
 else()
@@ -15,11 +15,15 @@ else()
   find_package(PkgConfig)
 
   if (PKG_CONFIG_FOUND)
-    pkg_check_modules(LIBSC_JANSSON QUIET IMPORTED_TARGET jansson)
+    pkg_check_modules(LIBSC_JANSSON QUIET jansson IMPORTED_TARGET GLOBAL)
 
     if (LIBSC_JANSSON_FOUND)
-      message(STATUS "jansson library found via pkg-config")
-      add_library(jansson::jansson ALIAS PkgConfig::LIBSC_JANSSON)
+      message(STATUS "[libsc] jansson library found via pkg-config")
+
+      add_library(jansson::jansson INTERFACE IMPORTED GLOBAL)
+      target_include_directories(jansson::jansson INTERFACE "${LIBSC_JANSSON_INCLUDE_DIRS}")
+      target_link_libraries(jansson::jansson INTERFACE "${LIBSC_JANSSON_LIBRARIES}")
+
       set(jansson_FOUND 1)
       set(SC_HAVE_JSON 1)
     else()


### PR DESCRIPTION
# Fix linking with libjansson

the problem was report in p4est issue https://github.com/cburstedde/p4est/issues/227 :
when p4est is using an installed version of libsc (built with cmake), file SC-targets.cmake was kind of ill-formed, because linking  variable was referencing jansson as  PkgConfig::LIBSC_JANSSON instead of jansson::jansson

Proposed changes:
this PR fixes the problem found in this particular case.