### PR TITLE
CMake: Enable valgrind with CTest

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -41,7 +41,7 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout source code
 
     - name: Install system dependencies
@@ -89,10 +89,53 @@ jobs:
           ./build/CMakeFiles/CMakeConfigureLog.yaml
           ./build/Testing/Temporary/LastTest.log
 
+  linux-valgrind:
+    runs-on: ubuntu-22.04
+    name: CMake with Valgrind
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        cc: [gcc]
+        shared: [false]
+        mpi: [true]
+        valgrind: [ON]
+
+    env:
+      CC: ${{ matrix.cc }}
+
+    steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update -yq
+        sudo apt-get install -yq --no-install-recommends \
+            libmpich-dev mpich valgrind
+
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: CMake configure
+      run: cmake --preset default -Dmpi:BOOL=${{ matrix.mpi }} --install-prefix=${{ runner.temp }} -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} -DTEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }}
+
+    - name: CMake build
+      run: cmake --build --preset default --parallel
+
+    - name: CMake Test
+      run: ctest --preset default
+
+    - name: Upload log files
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux_cmake_valgrind_log
+        path: |
+          ./build/CMakeFiles/CMakeConfigureLog.yaml
+          ./build/Testing/Temporary/LastTest.log
+
   mac:
     runs-on: macos-latest
     name: CMake build on MacOS
-    timeout-minutes: 20
+    timeout-minutes: 15
 
     strategy:
       matrix:
@@ -107,7 +150,7 @@ jobs:
       CC: ${{ matrix.cc }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout source code
 
     - name: Install system dependencies
@@ -165,7 +208,7 @@ jobs:
       CMAKE_GENERATOR: "MinGW Makefiles"
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout source code
 
     - name: CMake configure without MPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ add_subdirectory(src)
 
 if(BUILD_TESTING)
   include(cmake/valgrind.cmake)
-  
+
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
     add_subdirectory(example)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ install(TARGETS sc
 add_subdirectory(src)
 
 if(BUILD_TESTING)
+  include(cmake/valgrind.cmake)
+  
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
     add_subdirectory(example)
   endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -5,6 +5,7 @@ option(mpi "use MPI library" off)
 option(openmp "use OpenMP" off)
 option(zlib "build ZLIB" on)
 option(BUILD_TESTING "build libsc self-tests" on)
+option(TEST_WITH_VALGRIND "run self-tests with valgrind" OFF)
 option(BUILD_SHARED_LIBS "build shared libsc")
 
 # --- default install directory under build/local

--- a/cmake/valgrind.cmake
+++ b/cmake/valgrind.cmake
@@ -1,0 +1,8 @@
+set(VALGRIND_COMMAND)
+
+find_program(VALGRIND "valgrind")
+if(VALGRIND AND TEST_WITH_VALGRIND)
+    set(VALGRIND_COMMAND ${VALGRIND} --error-exitcode=1)
+elseif(TEST_WITH_VALGRIND)
+    message(FATAL_ERROR "TEST_WITH_VALGRIND was set, but valgrind was not found")
+endif()

--- a/doc/author_williams.txt
+++ b/doc/author_williams.txt
@@ -1,0 +1,1 @@
+I hereby place my contributions to libsc under the FreeBSD license.  Kyle Williams.

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -28,6 +28,7 @@ There have been breaking changes, very strictly speaking.
  - Add a generic external library installation option.
  - Update CMake logic to configure zlib and jansson.
  - Make sc_getopt.h a purely internal header file.
+ - Add CMake option to run tests with Valgrind
 
 ### Functionality
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,27 +14,33 @@ endif()
 
 list(APPEND sc_tests builtin io_sink)
 
+set(MPI_WRAPPER)
+if(MPIEXEC_EXECUTABLE)
+  set(MPIEXEC_MAX_NUMPROCS 2)
+  set(MPI_WRAPPER ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS})
+endif()
+
 # ---
-set(MPIEXEC_MAX_NUMPROCS 2)
 foreach(t IN LISTS sc_tests)
 
   add_executable(sc_test_${t} test_${t}.c)
   target_link_libraries(sc_test_${t} PRIVATE SC::SC)
+  target_compile_definitions(sc_test_${t} PRIVATE $<$<BOOL:${TEST_WITH_VALGRIND}>:SC_ENABLE_VALGRIND=1>)
 
-  if(MPIEXEC_EXECUTABLE)
-    add_test(NAME ${t} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:sc_test_${t}>)
-  else()
-    add_test(NAME ${t} COMMAND sc_test_${t})
-  endif()
+  add_test(NAME ${t} COMMAND ${MPI_WRAPPER} ${VALGRIND_COMMAND} $<TARGET_FILE:sc_test_${t}>)
 
 endforeach()
 
-set_property(TEST ${sc_tests} PROPERTY LABELS "unit;libsc")
+set_tests_properties(${sc_tests} 
+PROPERTIES 
+  LABELS "unit;libsc"
+  TIMEOUT 60 
+)
 
 if(MPIEXEC_EXECUTABLE)
-  set_property(TEST ${sc_tests} PROPERTY RESOURCE_LOCK cpu_mpi)
+  set_tests_properties(${sc_tests} PROPERTIES RESOURCE_LOCK cpu_mpi)
 endif()
 
 if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
-  set_property(TEST ${sc_tests} PROPERTY ENVIRONMENT_MODIFICATION PATH=path_list_append:$<TARGET_FILE_DIR:sc>)
+  set_tests_properties(${sc_tests} PROPERTIES ENVIRONMENT_MODIFICATION PATH=path_list_append:$<TARGET_FILE_DIR:sc>)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,10 +31,10 @@ foreach(t IN LISTS sc_tests)
 
 endforeach()
 
-set_tests_properties(${sc_tests} 
-PROPERTIES 
+set_tests_properties(${sc_tests}
+PROPERTIES
   LABELS "unit;libsc"
-  TIMEOUT 60 
+  TIMEOUT 60
 )
 
 if(MPIEXEC_EXECUTABLE)


### PR DESCRIPTION
# Title: Enable Valgrind with CTest

# Resolves #101.

# Overview:
This PR introduces a CMake flag, `TEST_WITH_VALGRIND`, which will run test with valgrind. 

# Details:
- When `TEST_WITH_VALGRIND` is enabled, the configuration attempts to locate Valgrind and defines `SC_ENABLE_VALGRIND=1`.
- Sets the test command as `mpiexec -np 2 valgrind --exit-errorcode=1 sc_test_{}` as with autotools.
- If Valgrind is not enabled, the test command defaults to `mpiexec -np 2 sc_test_{}` (when `mpi=ON` of course).
- A fatal error is emitted by CMake if `TEST_WITH_VALGRIND=ON` but Valgrind is not found.
- Adds workflow to run configure with valgrind enabled and test to mirror the autotools workflow.