### PR TITLE
Simplify MPI/IO wrappers

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -31,6 +31,7 @@ There have been breaking changes, very strictly speaking.
 ### Functionality
 
  - Further align I/O wrappers with and without MPI I/O.
+ - Simplify the replacements for MPI_{read,write}_at*.
  - Update zlib and base64 encode/compression routines.
 
 ## 2.8.5

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1367,7 +1367,7 @@ sc_io_parse_access_mode (sc_io_open_mode_t amode, const char **mode)
 
 #else
 
-typedef int sc_io_access_mode_t;
+typedef int         sc_io_access_mode_t;
 
 static void
 sc_io_parse_access_mode (sc_io_open_mode_t amode, int *mode)
@@ -1401,10 +1401,10 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
 {
   sc_io_access_mode_t mode;
   int                 mpiret, errcode, retval;
-#ifdef SC_ENABLE_MPIIO
 
   sc_io_parse_access_mode (amode, &mode);
 
+#ifdef SC_ENABLE_MPIIO
   mpiret = MPI_File_open (mpicomm, filename, mode, mpiinfo, mpifile);
   retval = sc_io_error_class (mpiret, &errcode);
   SC_CHECK_MPI (retval);
@@ -1418,10 +1418,6 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
 
   return errcode;
 #else
-  int                 rank;
-
-  sc_io_parse_access_mode (amode, &mode);
-
   /* allocate internal file context */
   *mpifile = (sc_MPI_File) SC_ALLOC (struct sc_no_mpiio_file, 1);
   (*mpifile)->filename = filename;
@@ -1429,9 +1425,9 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
   (*mpifile)->file = NULL;
 
   /* get my rank and open file only on root process */
-  mpiret = sc_MPI_Comm_rank (mpicomm, &rank);
+  mpiret = sc_MPI_Comm_rank (mpicomm, &(*mpifile)->mpirank);
   SC_CHECK_MPI (mpiret);
-  if (rank == 0) {
+  if ((*mpifile)->mpirank == 0) {
     errno = 0;
     (*mpifile)->file = fopen (filename, mode);
     mpiret = errno;
@@ -1558,8 +1554,7 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
 
     *ocount = 0;
 
-    mpiret = sc_MPI_Comm_rank (mpifile->mpicomm, &rank);
-    SC_CHECK_MPI (mpiret);
+    rank = mpifile->mpirank;
     mpiret = sc_MPI_Comm_size (mpifile->mpicomm, &mpisize);
     SC_CHECK_MPI (mpiret);
 

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1425,6 +1425,8 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
   (*mpifile)->file = NULL;
 
   /* get my rank and open file only on root process */
+  mpiret = sc_MPI_Comm_size (mpicomm, &(*mpifile)->mpisize);
+  SC_CHECK_MPI (mpiret);
   mpiret = sc_MPI_Comm_rank (mpicomm, &(*mpifile)->mpirank);
   SC_CHECK_MPI (mpiret);
   if ((*mpifile)->mpirank == 0) {
@@ -1552,11 +1554,8 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
     int                 mpisize, rank, count, size;
     int                 active, errval;
 
-    *ocount = 0;
-
+    mpisize = mpifile->mpisize;
     rank = mpifile->mpirank;
-    mpiret = sc_MPI_Comm_size (mpifile->mpicomm, &mpisize);
-    SC_CHECK_MPI (mpiret);
 
     /* initially only rank 0 writes to the disk */
     active = (rank == 0) ? -1 : 0;
@@ -1815,12 +1814,8 @@ sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset,
     int                 mpisize, rank, count, size;
     int                 active, errval;
 
-    *ocount = 0;
-
-    mpiret = sc_MPI_Comm_rank (mpifile->mpicomm, &rank);
-    SC_CHECK_MPI (mpiret);
-    mpiret = sc_MPI_Comm_size (mpifile->mpicomm, &mpisize);
-    SC_CHECK_MPI (mpiret);
+    mpisize = mpifile->mpisize;
+    rank = mpifile->mpirank;
 
     /* initially only rank 0 writes to the disk */
     active = (rank == 0) ? -1 : 0;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1499,13 +1499,15 @@ sc_io_read_at (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
 #endif
   int                 mpiret, errcode, retval;
 
+  SC_ASSERT (ocount != NULL);
   *ocount = 0;
 
 #ifdef SC_ENABLE_MPIIO
   sc_MPI_Status       mpistatus;
 
   mpiret = MPI_File_read_at (mpifile, offset, ptr, zcount, t, &mpistatus);
-  if (mpiret == sc_MPI_SUCCESS) {
+  if (mpiret == sc_MPI_SUCCESS && zcount > 0) {
+    /* working around 0 count not working for some implementations */
     mpiret = sc_MPI_Get_count (&mpistatus, t, ocount);
     SC_CHECK_MPI (mpiret);
     return sc_MPI_SUCCESS;
@@ -1538,11 +1540,13 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
   int                 retval;
   sc_MPI_Status       mpistatus;
 
+  SC_ASSERT (ocount != NULL);
   *ocount = 0;
 
   mpiret = MPI_File_read_at_all (mpifile, offset, ptr,
                                  (int) zcount, t, &mpistatus);
-  if (mpiret == sc_MPI_SUCCESS) {
+  if (mpiret == sc_MPI_SUCCESS && zcount > 0) {
+    /* working around 0 count not working for some implementations */
     mpiret = sc_MPI_Get_count (&mpistatus, t, ocount);
     SC_CHECK_MPI (mpiret);
 
@@ -1746,11 +1750,13 @@ sc_io_write_at (sc_MPI_File mpifile, sc_MPI_Offset offset,
 #ifdef SC_ENABLE_MPIIO
   sc_MPI_Status       mpistatus;
 
+  SC_ASSERT (ocount != NULL);
   *ocount = 0;
 
   mpiret = MPI_File_write_at (mpifile, offset, (void *) ptr,
                               (int) zcount, t, &mpistatus);
-  if (mpiret == sc_MPI_SUCCESS) {
+  if (mpiret == sc_MPI_SUCCESS && zcount > 0) {
+    /* working around 0 count not working for some implementations */
     mpiret = sc_MPI_Get_count (&mpistatus, t, ocount);
     SC_CHECK_MPI (mpiret);
     return sc_MPI_SUCCESS;
@@ -1791,11 +1797,13 @@ sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset,
 #ifdef SC_ENABLE_MPIIO
   sc_MPI_Status       mpistatus;
 
+  SC_ASSERT (ocount != NULL);
   *ocount = 0;
 
   mpiret = MPI_File_write_at_all (mpifile, offset, (void *) ptr,
                                   (int) zcount, t, &mpistatus);
-  if (mpiret == sc_MPI_SUCCESS) {
+  if (mpiret == sc_MPI_SUCCESS && zcount > 0) {
+    /* working around 0 count not working for some implementations */
     mpiret = sc_MPI_Get_count (&mpistatus, t, ocount);
     SC_CHECK_MPI (mpiret);
     return sc_MPI_SUCCESS;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1435,11 +1435,18 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
       (*mpifile)->file = sc_MPI_FILE_NULL;
       mpiret = sc_MPI_SUCCESS;
     }
+
     /* broadcast errno */
     sc_MPI_Bcast (&mpiret, 1, sc_MPI_INT, 0, mpicomm);
 
     retval = sc_io_error_class (mpiret, &errcode);
     SC_CHECK_MPI (retval);
+
+    /* free file structure on open error */
+    if (errcode != sc_MPI_SUCCESS) {
+      SC_FREE (*mpifile);
+      *mpifile = sc_MPI_FILE_NULL;
+    }
 
     return errcode;
   }
@@ -1459,6 +1466,12 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
 
     retval = sc_io_error_class (errno, &errcode);
     SC_CHECK_MPI (retval);
+
+    /* free file structure on open error */
+    if (errcode != sc_MPI_SUCCESS) {
+      SC_FREE (*mpifile);
+      *mpifile = sc_MPI_FILE_NULL;
+    }
 
     return errcode;
   }

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -659,6 +659,7 @@ struct sc_no_mpiio_file
   sc_MPI_Comm         mpicomm;          /**< The MPI communicator. */
   const char         *filename;         /**< Name of the file. */
   FILE               *file;             /**< Underlying file object. */
+  int                 mpisize;          /**< Ranks in communicator. */
   int                 mpirank;          /**< Rank of this process. */
 };
 

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -658,9 +658,7 @@ struct sc_no_mpiio_file
 {
   const char         *filename;         /**< Name of the file. */
   FILE               *file;             /**< Underlying file object. */
-#ifdef SC_ENABLE_MPI
-  sc_MPI_Comm         mpicomm;
-#endif
+  sc_MPI_Comm         mpicomm;          /**< MPI communicatior. */
 };
 
 /** Replacement object for an MPI file. */

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -656,9 +656,10 @@ typedef long        sc_MPI_Offset;      /**< Emulate the MPI offset type. */
  */
 struct sc_no_mpiio_file
 {
+  sc_MPI_Comm         mpicomm;          /**< The MPI communicator. */
   const char         *filename;         /**< Name of the file. */
   FILE               *file;             /**< Underlying file object. */
-  sc_MPI_Comm         mpicomm;          /**< MPI communicatior. */
+  int                 mpirank;          /**< Rank of this process. */
 };
 
 /** Replacement object for an MPI file. */


### PR DESCRIPTION
# Simplify MPI/IO wrappers

## Proposed changes

The sc_io files wrap several MPI file functions to account for configuration with and without MPI, and with MPI but without MPI I/O found/selected. These configurations are distinguished at compile time, and in this PR we simplify the code to leave as little content inside of ifdefs as possible. Along the way, we have some minor edits for assertions and variable names.

There is one fix to free the file structure on file open error return. Wondering whether this is sufficiently documented.

What's left is to recheck the standards (see TO DO in the comments). For the functions that do not move the MPI file pointer, the non-MPI replacements should take care to replicate this behavior with ftell/fseek as closely as possible.