### PR TITLE
Intel oneAPI Windows: add support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ $<$<BOOL:${SC_ENABLE_MPI}>:MPI::MPI_C>
 $<$<BOOL:${SC_HAVE_ZLIB}>:ZLIB::ZLIB>
 $<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
 $<$<BOOL:${SC_NEED_M}>:m>
+$<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
 )
 
 # imported target, for use from FetchContent

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -171,9 +171,9 @@ check_include_file(sys/types.h SC_HAVE_SYS_TYPES_H)
 check_include_file(sys/time.h SC_HAVE_SYS_TIME_H)
 check_include_file(time.h SC_HAVE_TIME_H)
 
+check_symbol_exists(gettimeofday sys/time.h SC_HAVE_GETTIMEOFDAY)
+
 if(WIN32)
-  # even though Windows has time.h, struct timeval is in Winsock2.h
-  check_include_file(Winsock2.h SC_HAVE_WINSOCK2_H)
   set(WINSOCK_LIBRARIES wsock32 ws2_32 Iphlpapi)
 endif()
 

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -143,8 +143,8 @@
 /* Define to 1 if you have the <time.h> header file. */
 #cmakedefine SC_HAVE_TIME_H 1
 
-/* Define to 1 if you have the <winsock2.h> header file. */
-#cmakedefine SC_HAVE_WINSOCK2_H 1
+/* Define to 1 'gettimeofday' is available */
+#cmakedefine SC_HAVE_GETTIMEOFDAY 1
 
 /* desired alignment of allocations in bytes */
 #define SC_MEMALIGN_BYTES (SC_SIZEOF_VOID_P)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,6 @@ sc_puff.c
 sc_options.c sc_getopt.c sc_getopt1.c
 )
 
-if(SC_HAVE_WINSOCK2_H)
+if(MSVC AND NOT SC_HAVE_GETTIMEOFDAY)
   target_sources(sc PRIVATE sc_builtin/gettimeofday.c)
-  target_link_libraries(sc PRIVATE ${WINSOCK_LIBRARIES})
 endif()

--- a/src/sc.h
+++ b/src/sc.h
@@ -170,6 +170,15 @@
 #endif
 #ifdef SC_HAVE_SYS_TIME_H
 #include <sys/time.h>
+#elif defined(_MSC_VER) && !SC_HAVE_GETTIMEOFDAY
+#define WIN32_LEAN_AND_MEAN
+#include <Winsock2.h>
+struct timezone
+{
+  int                 tz_minuteswest;
+  int                 tz_dsttime;
+};
+int gettimeofday (struct timeval*, struct timezone*);
 #endif
 #ifdef SC_HAVE_UNISTD_H
 #include <unistd.h>

--- a/src/sc_builtin/gettimeofday.c
+++ b/src/sc_builtin/gettimeofday.c
@@ -1,21 +1,6 @@
 /* public domain: https://stackoverflow.com/a/26085827 */
 
-#define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <stdint.h>             /* portable: uint64_t   MSVC: __int64 */
-
-/* MSVC defines this in winsock2.h!? */
-typedef struct timeval
-{
-  long                tv_sec;
-  long                tv_usec;
-} timeval;
-
-struct timezone
-{
-  int                 tz_minuteswest;
-  int                 tz_dsttime;
-};
+#include <sc.h>
 
 int
 gettimeofday (struct timeval *tp, struct timezone *tzp)

--- a/src/sc_mpi.c
+++ b/src/sc_mpi.c
@@ -30,9 +30,6 @@
 #ifdef SC_HAVE_SYS_TIME_H
 #include <sys/time.h>
 #endif
-#if defined(SC_HAVE_WINSOCK2_H)
-#include <Winsock2.h>
-#endif
 
 int
 sc_MPI_Init (int *argc, char ***argv)


### PR DESCRIPTION
Intel oneAPI works on Windows with this PR, it did not previously. The CMake logic is also corrected to only use the custom gettimeofday when needed as MinGW doesn't need it.

SC_HAVE_WINSOCK2_H was no longer needed and hence removed

Microsoft VIsual Studio itself still doesn't work due to the `__attribute__` properties that are not supported by Visual Studio.

This was tested with oneAPI Windows with and without MPI.