### PR TITLE
make logic more programmatic

### DIFF
--- a/src/sc.c
+++ b/src/sc.c
@@ -43,6 +43,11 @@ typedef void        (*sc_sig_t) (int);
 #include <pthread.h>
 #endif
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
+
 typedef struct sc_package
 {
   int                 is_registered;
@@ -287,10 +292,10 @@ sc_log_handler (FILE * log_stream, const char *filename, int lineno,
     char                bn[BUFSIZ], *bp;
 
     snprintf (bn, BUFSIZ, "%s", filename);
-#ifdef _MSC_VER
-    bp = bn;
-#else
+#ifdef SC_HAVE_LIBGEN_H
     bp = basename (bn);
+#else
+    bp = bn;
 #endif
     fprintf (log_stream, "%s:%d ", bp, lineno);
   }
@@ -1030,7 +1035,9 @@ sc_abort_handler (void)
 
   fflush (stdout);
   fflush (stderr);
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+  Sleep (1);
+#else
   sleep (1);                    /* allow time for pending output */
 #endif
   if (sc_mpicomm != sc_MPI_COMM_NULL) {
@@ -1081,7 +1088,9 @@ sc_abort_collective (const char *msg)
     SC_ABORT (msg);
   }
   else {
-#ifndef _MSC_VER
+#ifdef _MSC_VER
+    Sleep (3);
+#else
     sleep (3);                  /* wait for root rank's sc_MPI_Abort ()... */
 #endif
     abort ();                   /* ... otherwise this may call sc_MPI_Abort () */

--- a/src/sc.h
+++ b/src/sc.h
@@ -152,7 +152,7 @@
 #endif
 #include <ctype.h>
 #include <float.h>
-#if defined SC_HAVE_LIBGEN_H && !defined _MSC_VER
+#if defined SC_HAVE_LIBGEN_H
 #include <libgen.h>
 #endif
 #include <limits.h>

--- a/src/sc_options.c
+++ b/src/sc_options.c
@@ -255,10 +255,10 @@ sc_options_new (const char *program_path)
   opt = SC_ALLOC_ZERO (sc_options_t, 1);
 
   snprintf (opt->program_path, BUFSIZ, "%s", program_path);
-#ifdef _MSC_VER
-  opt->program_name = opt->program_path;
-#else
+#ifdef SC_HAVE_LIBGEN_H
   opt->program_name = basename (opt->program_path);
+#else
+  opt->program_name = opt->program_path;
 #endif
   opt->option_items = sc_array_new (sizeof (sc_option_item_t));
   opt->subopt_names = sc_array_new (sizeof (char *));


### PR DESCRIPTION
rather than blanket ifdef _MSC_VER,
 the programmatic define for libgen.h is adequate.

For MSVC, rather than not sleep, use the Sleep equivalent to sleep

This is not related to the other PRs currently open.
