### PR TITLE
cmake:SC_BUILD_TESTING to allow parent project control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ install(TARGETS sc EXPORT ${PROJECT_NAME}-targets)
 
 add_subdirectory(src)
 
-if(BUILD_TESTING)
+if(SC_BUILD_TESTING)
   include(cmake/valgrind.cmake)
 
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
@@ -75,7 +75,7 @@ if(BUILD_TESTING)
   endif()
 
   add_subdirectory(test)
-endif(BUILD_TESTING)
+endif()
 
 # --- packaging
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,7 +1,7 @@
 option(mpi "use MPI library" off)
 option(openmp "use OpenMP" off)
 option(zlib "build ZLIB" off)
-option(BUILD_TESTING "build libsc self-tests" on)
+option(SC_BUILD_TESTING "build libsc self-tests" on)
 option(TEST_WITH_VALGRIND "run self-tests with valgrind" OFF)
 option(BUILD_SHARED_LIBS "build shared libsc")
 option(CMAKE_TLS_VERIFY "verify TLS certificate" on)


### PR DESCRIPTION
by using a more specific name like "SC_BUILD_TESTING" instead of "BUILD_TESTING" this allows parent projects like p4est and Forestclaw to select which tests to build and run. This avoids outdated test dependencies causing a top-level project to fail build/test.

