### PR TITLE
Feature sink source

### DIFF
--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -103,6 +103,25 @@ sc_io_sink_destroy (sc_io_sink_t * sink)
 }
 
 int
+sc_io_sink_destroy_null (sc_io_sink_t ** sink)
+{
+  int                 retval = SC_IO_ERROR_NONE;
+
+  /* pointer to sink pointer must be set */
+  SC_ASSERT (sink != NULL);
+
+  /* if sink is still open, close it and NULL the pointer to it */
+  if (*sink != NULL) {
+    retval = sc_io_sink_destroy (*sink);
+    *sink = NULL;
+  }
+
+  /* in any case the sink does no longer exist */
+  SC_ASSERT (*sink == NULL);
+  return retval;
+}
+
+int
 sc_io_sink_write (sc_io_sink_t * sink, const void *data, size_t bytes_avail)
 {
   size_t              bytes_out;
@@ -253,6 +272,25 @@ sc_io_source_destroy (sc_io_source_t * source)
   SC_FREE (source);
 
   return retval ? SC_IO_ERROR_FATAL : SC_IO_ERROR_NONE;
+}
+
+int
+sc_io_source_destroy_null (sc_io_source_t ** source)
+{
+  int                 retval = SC_IO_ERROR_NONE;
+
+  /* pointer to source pointer must be set */
+  SC_ASSERT (source != NULL);
+
+  /* if source is still open, close it and NULL the pointer to it */
+  if (*source != NULL) {
+    retval = sc_io_source_destroy (*source);
+    *source = NULL;
+  }
+
+  /* in any case the source does no longer exist */
+  SC_ASSERT (*source == NULL);
+  return retval;
 }
 
 int

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -291,6 +291,7 @@ int                 sc_io_source_destroy_null (sc_io_source_t ** source);
  * \param [in] bytes_avail      Number of bytes available in data buffer.
  * \param [in,out] bytes_out    If not NULL, byte count read into data buffer.
  *                              Otherwise, requires to read exactly bytes_avail.
+ *                              If this condition is not met, return an error.
  * \return                      0 on success, nonzero on error.
  */
 int                 sc_io_source_read (sc_io_source_t * source,

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -127,12 +127,13 @@ typedef struct sc_io_sink
   sc_io_mode_t        mode;            /**< write semantics */
   sc_io_encode_t      encode;          /**< encoding of data */
   sc_array_t         *buffer;          /**< buffer for the iotype
-                                            SC_IO_TYPE_BUFFER*/
-  size_t              buffer_bytes;    /**< distinguish from array elems */
+                                            \ref SC_IO_TYPE_BUFFER */
+  size_t              buffer_bytes;    /**< distinguish from array elements */
   FILE               *file;            /**< file pointer for iotype unequal to
-                                            SC_IO_TYPE_BUFFER */
+                                            \ref SC_IO_TYPE_BUFFER */
   size_t              bytes_in;        /**< input bytes count */
   size_t              bytes_out;       /**< written bytes count */
+  int                 is_eof;          /**< Have we reached the end of file? */
 }
 sc_io_sink_t;
 
@@ -208,7 +209,7 @@ int                 sc_io_sink_destroy_null (sc_io_sink_t ** sink);
 /** Write data to a sink.  Data may be buffered and sunk in a later call.
  * The internal counters sink->bytes_in and sink->bytes_out are updated.
  * \param [in,out] sink         The sink object to write to.
- * \param [in] data             Data passed into sink.
+ * \param [in] data             Data passed into sink must be non-NULL.
  * \param [in] bytes_avail      Number of data bytes passed in.
  * \return                      0 on success, nonzero on error.
  */

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -191,6 +191,19 @@ sc_io_sink_t       *sc_io_sink_new (int iotype, int iomode,
  */
 int                 sc_io_sink_destroy (sc_io_sink_t * sink);
 
+/** Free data sink and NULL the pointer to it.
+ * Except for the handling of the pointer argument,
+ * the behavior is the same as for \ref sc_io_sink_destroy.
+ * \param [in,out] sink         Non-NULL pointer to sink pointer.
+ *                              The sink pointer may be NULL, in which case
+ *                              this function does nothing successfully,
+ *                              or a valid \ref sc_io_sink, which is
+ *                              passed to \ref sc_io_sink_destroy, and the
+ *                              sink pointer is set to NULL afterwards.
+ * \return                      0 on success, nonzero on error.
+ */
+int                 sc_io_sink_destroy_null (sc_io_sink_t ** sink);
+
 /** Write data to a sink.  Data may be buffered and sunk in a later call.
  * The internal counters sink->bytes_in and sink->bytes_out are updated.
  * \param [in,out] sink         The sink object to write to.
@@ -250,6 +263,19 @@ sc_io_source_t     *sc_io_source_new (int iotype, int ioencode, ...);
  */
 int                 sc_io_source_destroy (sc_io_source_t * source);
 
+/** Free data source and NULL the pointer to it.
+ * Except for the handling of the pointer argument,
+ * the behavior is the same as for \ref sc_io_source_destroy.
+ * \param [in,out] source       Non-NULL pointer to source pointer.
+ *                              The source pointer may be NULL, in which case
+ *                              this function does nothing successfully,
+ *                              or a valid \ref sc_io_source, which is
+ *                              passed to \ref sc_io_source_destroy, and the
+ *                              source pointer is set to NULL afterwards.
+ * \return                      0 on success, nonzero on error.
+ */
+int                 sc_io_source_destroy_null (sc_io_source_t ** source);
+
 /** Read data from a source.
  * The internal counters source->bytes_in and source->bytes_out are updated.
  * Data is read until the data buffer has not enough room anymore, or source
@@ -258,7 +284,7 @@ int                 sc_io_source_destroy (sc_io_source_t * source);
  * check its return value to find out.
  * Returns an error if bytes_out is NULL and less than bytes_avail are read.
  * \param [in,out] source       The source object to read from.
- * \param [in] data             Data buffer for reading from sink.
+ * \param [in] data             Data buffer for reading from source.
  *                              If NULL the output data will be thrown away.
  * \param [in] bytes_avail      Number of bytes available in data buffer.
  * \param [in,out] bytes_out    If not NULL, byte count read into data buffer.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -142,14 +142,15 @@ typedef struct sc_io_source
   sc_io_type_t        iotype;          /**< type of the I/O operation */
   sc_io_encode_t      encode;          /**< encoding of data */
   sc_array_t         *buffer;          /**< buffer for the iotype
-                                            SC_IO_TYPE_BUFFER*/
-  size_t              buffer_bytes;    /**< distinguish from array elems */
+                                            \ref SC_IO_TYPE_BUFFER */
+  size_t              buffer_bytes;    /**< distinguish from array elements */
   FILE               *file;            /**< file pointer for iotype unequal to
-                                            SC_IO_TYPE_BUFFER */
+                                            \ref SC_IO_TYPE_BUFFER */
   size_t              bytes_in;        /**< input bytes count */
   size_t              bytes_out;       /**< read bytes count */
+  int                 is_eof;          /**< Have we reached the end of file? */
   sc_io_sink_t       *mirror;          /**< if activated, a sink to store the
-                                            data*/
+                                            data */
   sc_array_t         *mirror_buffer;   /**< if activated, the buffer for the
                                             mirror */
 }
@@ -285,7 +286,8 @@ int                 sc_io_source_destroy_null (sc_io_source_t ** source);
  * Returns an error if bytes_out is NULL and less than bytes_avail are read.
  * \param [in,out] source       The source object to read from.
  * \param [in] data             Data buffer for reading from source.
- *                              If NULL the output data will be thrown away.
+ *                              If NULL the output data will be ignored
+ *                              and we seek forward in the input.
  * \param [in] bytes_avail      Number of bytes available in data buffer.
  * \param [in,out] bytes_out    If not NULL, byte count read into data buffer.
  *                              Otherwise, requires to read exactly bytes_avail.


### PR DESCRIPTION
# Improvements to the sc_io source/sink functionality 

There are quite a few comment and documentation updates and two functional ones:

 1. We remember the end-of-file status on reading from a buffer or file and exit early next time around.
 2. When we read from an array buffer, we read at most its current elements and not, as previously, to the end of its internal memory allocation, which may be larger and contain undefined data.

In particular the latter update may have implications to existing code!