### PR TITLE
Feature hash array

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -40,6 +40,7 @@ There have been breaking changes, very strictly speaking.
  - Add sc_io_source, sink_destroy_null functions.
  - Make sure not to sc_io_source_read an array beyond its length.
  - Add sc_io_file_load, save functions and test program.
+ - Update sc_hash_array to hide much of internal state.
  - Update zlib and base64 encode/compression routines.
 
 ## 2.8.5

--- a/src/sc_containers.c
+++ b/src/sc_containers.c
@@ -1641,6 +1641,7 @@ sc_hash_array_lookup (sc_hash_array_t * hash_array, void *v, size_t *position)
   SC_ASSERT (hash_array != NULL);
   SC_ASSERT (hash_array->a.elem_count == hash_array->h->elem_count);
   SC_ASSERT (hash_array->internal_data->foreach_fn == NULL);
+  SC_ASSERT (hash_array->internal_data->current_item == NULL);
 
   hash_array->internal_data->current_item = v;
   found = sc_hash_lookup (hash_array->h, (void *) (-1L), &found_void);
@@ -1668,6 +1669,7 @@ sc_hash_array_insert_unique (sc_hash_array_t * hash_array, void *v,
   SC_ASSERT (hash_array != NULL);
   SC_ASSERT (hash_array->a.elem_count == hash_array->h->elem_count);
   SC_ASSERT (hash_array->internal_data->foreach_fn == NULL);
+  SC_ASSERT (hash_array->internal_data->current_item == NULL);
 
   hash_array->internal_data->current_item = v;
   added = sc_hash_insert_unique (hash_array->h, (void *) (-1L), &found_void);
@@ -1708,6 +1710,7 @@ sc_hash_array_foreach (sc_hash_array_t * hash_array, sc_hash_foreach_t fn)
   SC_ASSERT (hash_array != NULL);
   SC_ASSERT (hash_array->a.elem_count == hash_array->h->elem_count);
   SC_ASSERT (hash_array->internal_data->foreach_fn == NULL);
+  SC_ASSERT (hash_array->internal_data->current_item == NULL);
 
   /* verify remaining input arguments */
   SC_ASSERT (fn != NULL);

--- a/src/sc_containers.h
+++ b/src/sc_containers.h
@@ -98,7 +98,7 @@ typedef unsigned int (*sc_hash_function_t) (const void *v, const void *u);
 typedef int         (*sc_equal_function_t) (const void *v1,
                                             const void *v2, const void *u);
 
-/** Function to call on every data item of a hash table.
+/** Function to call on every data item of a hash table or hash array.
  * \param [in] v   The address of the pointer to the current object.
  * \param [in] u   Arbitrary user data.
  * \return Return true if the traversal should continue, false to stop.
@@ -1070,6 +1070,7 @@ typedef struct sc_hash_array
   /* implementation variables */
   sc_array_t          a;        /**< Array storing the elements. */
   sc_hash_t          *h;        /**< Hash map pointing into element array. */
+  void               *user_data;        /**< Context passed by the user. */
   sc_hash_array_data_t *internal_data;  /**< Private context data. */
 }
 sc_hash_array_t;
@@ -1133,6 +1134,13 @@ int                 sc_hash_array_lookup (sc_hash_array_t * hash_array,
  */
 void               *sc_hash_array_insert_unique (sc_hash_array_t * hash_array,
                                                  void *v, size_t *position);
+
+/** Invoke a callback for every member of the hash array.
+ * \param [in,out] hash_array   Valid hash array.
+ * \param [in] fn               Callback executed on every hash array element.
+ */
+void                sc_hash_array_foreach (sc_hash_array_t * hash_array,
+                                           sc_hash_foreach_t fn);
 
 /** Extract the array data from a hash array and destroy everything else.
  * \param [in] hash_array   The hash array is destroyed after extraction.

--- a/src/sc_containers.h
+++ b/src/sc_containers.h
@@ -940,10 +940,10 @@ typedef struct sc_hash
 {
   /* interface variables */
   size_t              elem_count;       /**< total number of objects contained */
+  void               *user_data;        /**< User data passed to hash function. */
 
   /* implementation variables */
   sc_array_t         *slots;    /**< The slot count is slots->elem_count. */
-  void               *user_data;        /**< User data passed to hash function. */
   sc_hash_function_t  hash_fn;  /**< Function called to compute the hash value. */
   sc_equal_function_t equal_fn; /**< Function called to check objects for equality. */
   size_t              resize_checks;    /**< Running count of resize checks. */
@@ -1067,10 +1067,12 @@ typedef struct sc_hash_array_data sc_hash_array_data_t;
  */
 typedef struct sc_hash_array
 {
+  /* interface variables */
+  void               *user_data;        /**< Context passed by the user. */
+
   /* implementation variables */
   sc_array_t          a;        /**< Array storing the elements. */
   sc_hash_t          *h;        /**< Hash map pointing into element array. */
-  void               *user_data;        /**< Context passed by the user. */
   sc_hash_array_data_t *internal_data;  /**< Private context data. */
 }
 sc_hash_array_t;


### PR DESCRIPTION
# Complete hash array internal state update

## Proposed changes

We had begun to hide hash array internal state in 8e3ff6fced3353cd0e9e7d6f767ad2010235069a.
This breaks p4est since it accesses some internal data. p4est will be fixed after merging this PR.

In this PR we add sc_hash_array_foreach to avoid accessing obscure internal variables.
Me add some minor tweaks to sc_hash and sc_hash_array.