### PR TITLE
Permanent zlib link in build-wdeps.sh

### DIFF
--- a/doc/libsc-build-wdeps.sh
+++ b/doc/libsc-build-wdeps.sh
@@ -13,10 +13,6 @@
 # set installation root to local subdirectory
 PREFIX="$PWD/local"
 
-# download zlib
-ZVER=1.3
-ZSHA=ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
-
 # download jansson
 JVER=2.14
 JSHA=5798d010e41cf8d76b66236cfb2f2543c8d082181d16bc3085ab49538d4b9929
@@ -33,15 +29,15 @@ bdie () {
 }
 
 # download, build and install zlib
-ZTAR="zlib-$ZVER.tar.gz"
-wget -N "https://www.zlib.net/$ZTAR"                    && \
-test `sha256sum "$ZTAR" | cut -d ' ' -f1` = "$ZSHA"     && \
+ZTAR="zlib.tar.gz"
+wget -N "https://www.zlib.net/current/zlib.tar.gz"      && \
+ZDIR=`tar -tzf "$ZTAR" | head -1 | cut -f1 -d"/"`       && \
 tar -xvzf "$ZTAR"                                       && \
-cd "zlib-$ZVER"                                         && \
-./configure --prefix="$PREFIX/zlib"                     && \
+cd $ZDIR                                                && \
+./configure --prefix="$PREFIX/$ZDIR"                    && \
 make -j install                                         && \
 cd ..                                                   && \
-rm -r "zlib-$ZVER" "$ZTAR"                              || bdie "zlib"
+rm -r "$ZDIR" "$ZTAR"                              || bdie "zlib"
 
 # download, build and install jansson
 JTAR="jansson-$JVER.tar.gz"

--- a/doc/libsc-build-wdeps.sh
+++ b/doc/libsc-build-wdeps.sh
@@ -31,7 +31,7 @@ bdie () {
 # download, build and install zlib
 ZTAR="zlib.tar.gz"
 wget -N "https://www.zlib.net/current/zlib.tar.gz"      && \
-ZDIR=`tar -tzf "$ZTAR" | head -1 | cut -f1 -d"/"`       && \
+ZDIR=`tar -tzf "$ZTAR" | head -1 | perl -p -e 's/.*(zlib-[\d\.]+).*/\1/'` && \
 tar -xvzf "$ZTAR"                                       && \
 cd $ZDIR                                                && \
 ./configure --prefix="$PREFIX/$ZDIR"                    && \

--- a/doc/libsc-build-wdeps.sh
+++ b/doc/libsc-build-wdeps.sh
@@ -34,7 +34,7 @@ wget -N "https://www.zlib.net/current/zlib.tar.gz"      && \
 ZDIR=`tar -tzf "$ZTAR" | head -1 | perl -p -e 's/.*(zlib-[\d\.]+).*/\1/'` && \
 tar -xvzf "$ZTAR"                                       && \
 cd $ZDIR                                                && \
-./configure --prefix="$PREFIX/$ZDIR"                    && \
+./configure --prefix="$PREFIX/zlib"                     && \
 make -j install                                         && \
 cd ..                                                   && \
 rm -r "$ZDIR" "$ZTAR"                              || bdie "zlib"

--- a/doc/libsc-build-wdeps.sh
+++ b/doc/libsc-build-wdeps.sh
@@ -30,7 +30,7 @@ bdie () {
 
 # download, build and install zlib
 ZTAR="zlib.tar.gz"
-wget -N "https://www.zlib.net/current/zlib.tar.gz"      && \
+wget -N "https://www.zlib.net/current/$ZTAR"            && \
 ZDIR=`tar -tzf "$ZTAR" | head -1 | perl -p -e 's/.*(zlib-[\d\.]+).*/\1/'` && \
 tar -xvzf "$ZTAR"                                       && \
 cd $ZDIR                                                && \


### PR DESCRIPTION
The libsc-build-wdeps.sh script had trouble downloading `zlib-1.3`, since apparently the link to this version was discontinued after the recent release of `zlib-1.3.1`  resulting in a `404 not found` error. The script was changed to always download the most recent version of zlib by use of a permalink provided on the zlib website.
