### PR TITLE
CMake: Add CTest inclusion

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CTest)
+
 set(sc_tests allgather arrays keyvalue notify reduce search sortb version)
 
 if(SC_HAVE_RANDOM AND SC_HAVE_SRANDOM)


### PR DESCRIPTION
# CMake: Add CTest inclusion

Proposed changes: Since we experienced a failing valgrind CI,
```
Cannot find file: /home/runner/work/libsc/libsc/checkCMakeMPIvalgrind/DartConfiguration.tcl
Memory checker (MemoryCheckCommand) not set, or cannot find the specified program.
Errors while running CTest
```
we include CTest in `test/CMakeLists.txt` to ensure that the valgrind installation is found by ctest.
