### PR TITLE
Deprecate MPI without MPI I/O

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -55,7 +55,9 @@
  *                    compiler wrappers.  If this option is not given, wrappers
  *                    for MPI routines are used instead and the code is compiled
  *                    in serial only.
- * * `--disable-mpiio`  may be used to avoid using `MPI_File` based calls.
+ * * `--disable-mpiio`  may be used to avoid using `MPI_File` based calls. The
+                      usage of `--disable-mpiio` is deprecated and should not be
+                      used anymore.
  *
  * A typical development configure line looks as follows:
  * > `relative/path/to/configure CFLAGS="-Wall -O0 -g" --enable-mpi --enable-debug`

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -90,7 +90,7 @@
  * data in serial and the data can be stored element-wise compressed.
  *
  * If MPI I/O is available, it is used to write and read in
- * parallel. Otherwise, the behaviour is emulated using serial I/O and MPI.
+ * parallel. The configuration case of MPI without MPI I/O is deprecated.
  * Without MPI this module still enables the user to write and read equivalent
  * files but only in serial.
  *

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -37,6 +37,7 @@ There have been breaking changes, very strictly speaking.
  - Further align I/O wrappers with and without MPI I/O.
  - Simplify the replacements for MPI_{read,write}_at*.
  - Further updates to the MPI I/O wrapper code.
+ - Deprecate the confiuration with MPI but without MPI I/O.
  - Add sc_io_source, sink_destroy_null functions.
  - Make sure not to sc_io_source_read an array beyond its length.
  - Add sc_io_file_load, save functions and test program.

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -37,7 +37,8 @@ There have been breaking changes, very strictly speaking.
  - Further align I/O wrappers with and without MPI I/O.
  - Simplify the replacements for MPI_{read,write}_at*.
  - Further updates to the MPI I/O wrapper code.
- - Deprecate the confiuration with MPI but without MPI I/O.
+ - Deprecate the configuration with MPI but without MPI I/O.
+ - Remove sc_io_{write,read}_all.
  - Add sc_io_source, sink_destroy_null functions.
  - Make sure not to sc_io_source_read an array beyond its length.
  - Add sc_io_file_load, save functions and test program.

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -34,7 +34,8 @@ There have been breaking changes, very strictly speaking.
 
 ### Functionality
 
- - Further align I/O wrappers with and without MPI I/O.
+ - Further align I/O wrappers with and without MPI.
+ - Change the semantic of sc_io_open to always truncate a newly created file.
  - Simplify the replacements for MPI_{read,write}_at*.
  - Further updates to the MPI I/O wrapper code.
  - Deprecate the configuration with MPI but without MPI I/O.

--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -200,9 +200,8 @@ sc3_MPI_Op_t;
 /** We wrap some MPI error codes and the I/O error classes. */
 typedef enum sc3_MPI_Errorcode
 {
-  /* we separate the error values from errno values */
   SC3_MPI_SUCCESS = 0,  /**< An MPI function has exited successfully. */
-  SC3_MPI_ERR_ARG = 14000, /**< An MPI function encountered invalid arguments. */
+  SC3_MPI_ERR_ARG ,     /**< An MPI function encountered invalid arguments. */
   SC3_MPI_ERR_COUNT,     /**< An MPI function encountered an invalid count argument. */
   SC3_MPI_ERR_UNKNOWN,  /**< An MPI function has produced an unknown error. */
   SC3_MPI_ERR_OTHER,    /**< An MPI function has produced some known error. */

--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -120,6 +120,9 @@ typedef MPI_Op      sc3_MPI_Op_t;
 typedef enum sc3_MPI_IO_Errorcode
 {
   /* only MPI I/O error classes */
+  /* WARNING: This enum is only used in the deprecated case of activated MPI but
+   * deactivated MPI I/O.
+   */
   SC3_MPI_ERR_FILE = MPI_ERR_LASTCODE,
   SC3_MPI_ERR_NOT_SAME,
   SC3_MPI_ERR_AMODE,

--- a/src/sc3_mpi_types.h
+++ b/src/sc3_mpi_types.h
@@ -201,7 +201,7 @@ sc3_MPI_Op_t;
 typedef enum sc3_MPI_Errorcode
 {
   SC3_MPI_SUCCESS = 0,  /**< An MPI function has exited successfully. */
-  SC3_MPI_ERR_ARG ,     /**< An MPI function encountered invalid arguments. */
+  SC3_MPI_ERR_ARG = 14000, /**< An MPI function encountered invalid arguments. */
   SC3_MPI_ERR_COUNT,     /**< An MPI function encountered an invalid count argument. */
   SC3_MPI_ERR_UNKNOWN,  /**< An MPI function has produced an unknown error. */
   SC3_MPI_ERR_OTHER,    /**< An MPI function has produced some known error. */

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1704,16 +1704,6 @@ sc_io_read (sc_MPI_File mpifile, void *ptr, size_t zcount,
 }
 
 int
-sc_io_read_at_legal (void)
-{
-#ifdef SC_ENABLE_MPIIO
-  return 1;
-#else
-  return 0;
-#endif
-}
-
-int
 sc_io_read_at (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
                int count, sc_MPI_Datatype t, int *ocount)
 {
@@ -2002,12 +1992,6 @@ sc_io_write (sc_MPI_File mpifile, const void *ptr, size_t zcount,
   /* we do not provide a non-MPI I/O implementation of sc_io_write */
   SC_ABORT ("no non-MPI I/O implementation of sc_io_write/sc_mpi_write");
 #endif
-}
-
-int
-sc_io_write_at_legal (void)
-{
-  return sc_io_read_at_legal ();
 }
 
 int

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1640,6 +1640,7 @@ sc_io_open (sc_MPI_Comm mpicomm, const char *filename,
 
   return errcode;
 #else
+  /* WARNING: This code with activated MPI (SC_ENABLE_MPI) is deprecated. */
   /* allocate internal file context */
   *mpifile = (sc_MPI_File) SC_ALLOC (struct sc_no_mpiio_file, 1);
   (*mpifile)->filename = filename;
@@ -1740,6 +1741,8 @@ sc_io_read_at (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
   return errcode;
 #else
 
+  /* WARNING: This code with activated MPI (SC_ENABLE_MPI) is deprecated. */
+
   /* The value count > 0 is only legal on rank 0.
    * On all other ranks the code is only legal for count == 0.
    */
@@ -1823,6 +1826,9 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
   return errcode;
 #elif defined SC_ENABLE_MPI
   /* MPI but no MPI IO */
+
+  /* WARNING: This code and configuration case is deprecated. */
+
   {
     int                 mpisize, rank, count, size;
     int                 active, errval;
@@ -2033,6 +2039,8 @@ sc_io_write_at (sc_MPI_File mpifile, sc_MPI_Offset offset,
   return errcode;
 #else
 
+  /* WARNING: This code with activated MPI (SC_ENABLE_MPI) is deprecated. */
+
   /* The value count > 0 is only legal on rank 0.
    * On all other ranks the code is only legal for count == 0.
    */
@@ -2116,6 +2124,9 @@ sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset,
   return errcode;
 #elif defined SC_ENABLE_MPI
   /* MPI but no MPI IO */
+
+  /* WARNING: This code and configuration case is deprecated. */
+
   /* offset is ignored and we use here the append mode.
    * This is the case since the C-standard open mode
    * "wb" would earse the existing file and create a
@@ -2282,6 +2293,9 @@ sc_io_close (sc_MPI_File * mpifile)
   mpiret = sc_io_error_class (mpiret, &eclass);
   SC_CHECK_MPI (mpiret);
 #else
+
+  /* WARNING: This code with activated MPI (SC_ENABLE_MPI) is deprecated. */
+
   int                 retval;
 
   eclass = sc_MPI_SUCCESS;

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1961,13 +1961,6 @@ sc_io_read_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset, void *ptr,
 #endif
 }
 
-int
-sc_io_read_all (sc_MPI_File mpifile, void *ptr, int count, sc_MPI_Datatype t,
-                int *ocount)
-{
-  return sc_io_read_at_all (mpifile, 0, ptr, count, t, ocount);
-}
-
 void
 sc_io_write (sc_MPI_File mpifile, const void *ptr, size_t zcount,
              sc_MPI_Datatype t, const char *errmsg)
@@ -2255,13 +2248,6 @@ sc_io_write_at_all (sc_MPI_File mpifile, sc_MPI_Offset offset,
   /* There is no collective write without MPI. */
   return sc_io_write_at (mpifile, offset, ptr, count, t, ocount);
 #endif
-}
-
-int
-sc_io_write_all (sc_MPI_File mpifile, const void *ptr, int count,
-                 sc_MPI_Datatype t, int *ocount)
-{
-  return sc_io_write_at_all (mpifile, 0, ptr, count, t, ocount);
 }
 
 int

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -43,22 +43,6 @@
  *    They losslessly transform a block of arbitrary data into a compressed
  *    and base64-encoded format and back that is unambiguously defined and
  *    human-friendly.
- * \note WARNING: The case of activated MPI but deactivated MPI I/O is deprecated.
- * \note For the function \ref sc_io_write_at_all without MPI IO but with MPI
- *       the \b offset argument is ignored. In this case the function writes at
- *       the current end of the file. Hereby, the MPI ranks write in the
- *       rank-induced order. That is why the function may work equivalent to
- *       the MPI IO and non-MPI case but it can not be guaranteed.
- *       Furthermore, it is important to notice that \ref sc_io_write_at and
- *       \ref sc_io_read_at are only valid to call with zcount > 0 on rank 0,
- *       if MPI IO is not available. During runtime this can be checked by the
- *       user by calling \ref sc_io_read_at_legal and \ref sc_io_write_at_legal,
- *       respectively.
- *       The recommended way of reading/writing with multiple ranks with
- *       zcount > 0 if \ref sc_io_read_at_legal / \ref sc_io_write_at_legal
- *       returns 0 is to use \ref sc_io_read_at_all / \ref sc_io_write_at_all
- *       with the whished zcount on the ranks whished by the user and set zcount
- *       to 0 on the remaining ranks. 
  *
  * \ingroup io
  */
@@ -584,8 +568,6 @@ void                sc_fflush_fsync_fclose (FILE * file);
 
 /** Opens a MPI file or without MPI I/O or even without MPI a file context.
  *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
- *
  * \param[in] mpicomm   MPI communicator
  * \param[in] filename  The path to the file that we want to open.
  * \param[in] amode     An access mode.
@@ -626,27 +608,9 @@ void                sc_io_read (sc_MPI_File mpifile, void *ptr,
                                 size_t zcount, sc_MPI_Datatype t,
                                 const char *errmsg);
 
-/** Check for restricted usage of \ref sc_io_read_at.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
- *
- * \return              0 if the restriction described in the note of \ref
- *                      sc_io_read_at applies, i.e. count > 0 is only legal
- *                      on rank 0. This is equivalent to MPI I/O being not
- *                      available.
- *                      Otherwise, the function returns 1, i.e. MPI I/O is
- *                      available and the restriction in the note of \ref
- *                      sc_io_read_at does not apply, i.e. the user can pass
- *                      any valid count on any valid rank.
- *
- */
-int                 sc_io_read_at_legal (void);
-
 /** Read MPI file content into memory for an explicit offset.
  * This function does not update the file pointer of the MPI file.
  * Contrary to \ref sc_io_read, it does not abort on read errors.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in counts of the type \b t.
@@ -657,11 +621,6 @@ int                 sc_io_read_at_legal (void);
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
- * \note                If MPI I/O is not available this function has restricted
- *                      functionality in the sense that for \b count > 0, this
- *                      function is only legal to call on rank 0. On all other
- *                      ranks \b count must be 0. If this requirement is
- *                      violated this function returns \ref sc_MPI_ERR_ARG.
  */
 int                 sc_io_read_at (sc_MPI_File mpifile,
                                    sc_MPI_Offset offset, void *ptr,
@@ -670,8 +629,6 @@ int                 sc_io_read_at (sc_MPI_File mpifile,
 
 /** Read MPI file content collectively into memory for an explicit offset.
  * This function does not update the file pointer of the MPI file.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in counts of the type \b t.
@@ -693,8 +650,6 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
  * with offset = 0 but the call of this function is not equivalent
  * to a call of MPI_File_read_all since this function ignores the current
  * position of the file cursor.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] ptr      Data array to read from disk.
@@ -727,27 +682,9 @@ void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
                                  size_t zcount, sc_MPI_Datatype t,
                                  const char *errmsg);
 
-/** Check for restricted usage of \ref sc_io_write_at.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
- *
- * \return              0 if the restriction described in the note of \ref
- *                      sc_io_write_at applies, i.e. count > 0 is only legal
- *                      on rank 0. This is equivalent to MPI I/O being not
- *                      available.
- *                      Otherwise, the function returns 1, i.e. MPI I/O is
- *                      available and the restriction in the note of \ref
- *                      sc_io_write_at does not apply, i.e. the user can pass
- *                      any valid count on any valid rank.
- *
- */
-int                 sc_io_write_at_legal (void);
-
 /** Write MPI file content into memory for an explicit offset.
  * This function does not update the file pointer that is part of mpifile.
  * Contrary to \ref sc_io_write, it does not abort on read errors.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in etype, where the etype is given by
@@ -759,11 +696,6 @@ int                 sc_io_write_at_legal (void);
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to
  *                      \ref sc_MPI_Error_string.
- * \note                If MPI I/O is not available this function has restricted
- *                      functionality in the sense that for \b count > 0, this
- *                      function is only legal to call on rank 0. On all other
- *                      ranks \b count must be 0. If this requirement is
- *                      violated this function returns \ref sc_MPI_ERR_ARG.
  */
 int                 sc_io_write_at (sc_MPI_File mpifile,
                                     sc_MPI_Offset offset,
@@ -773,16 +705,9 @@ int                 sc_io_write_at (sc_MPI_File mpifile,
 /** Write MPI file content collectively into memory for an explicit offset.
  * This function does not update the file pointer that is part of mpifile.
  *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
- * \note  If there is no MPI IO but MPI available, the offset parameter is
- *        ignored and the ranks just write at the current end of the file
- *        according to their rank-induced order.
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in etype, where the etype is given by
- *                      the type t. This parameter is ignored in the case of
- *                      having MPI but no MPI IO. In this case this function
- *                      writes to the current end of the file as described
- *                      above.
+ *                      the type t.
  * \param [in] ptr      Data array to write to disk.
  * \param [in] count    Number of array members.
  * \param [in] t        The MPI type for each array member.
@@ -818,8 +743,6 @@ int                 sc_io_write_all (sc_MPI_File mpifile,
                                      sc_MPI_Datatype t, int *ocount);
 
 /** Close collectively a sc_MPI_File.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param[in] file  MPI file object that is closed.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -820,7 +820,7 @@ int                 sc_io_write_all (sc_MPI_File mpifile,
 /** Close collectively a sc_MPI_File.
  *
  * \note This case of activated MPI but deactivated MPI I/O is deprecated.
- * 
+ *
  * \param[in] file  MPI file object that is closed.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -645,25 +645,6 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
                                        int count, sc_MPI_Datatype t,
                                        int *ocount);
 
-/** Read memory content collectively from an MPI file.
- * A call of this function is equivalent to call \ref sc_io_read_at_all
- * with offset = 0 but the call of this function is not equivalent
- * to a call of MPI_File_read_all since this function ignores the current
- * position of the file cursor.
- *
- * \param [in,out] mpifile      MPI file object opened for reading.
- * \param [in] ptr      Data array to read from disk.
- * \param [in] count    Number of array members.
- * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of read elements of type \b t.
- * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
- *                      The error code can be passed to
- *                      \ref sc_MPI_Error_string.
- */
-int                 sc_io_read_all (sc_MPI_File mpifile, void *ptr,
-                                    int count, sc_MPI_Datatype t,
-                                    int *ocount);
-
 #define sc_mpi_write        sc_io_write  /**< For backwards compatibility. */
 
 /** Write memory content to an MPI file.
@@ -720,25 +701,6 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
                                         sc_MPI_Offset offset,
                                         const void *ptr, int count,
                                         sc_MPI_Datatype t, int *ocount);
-
-/** Write memory content collectively to an MPI file.
- * A call of this function is equivalent to call \ref sc_io_write_at_all
- * with offset = 0 but the call of this function is not equivalent
- * to a call of MPI_File_write_all since this function ignores the current
- * position of the file cursor.
- *
- * \param [in,out] mpifile      MPI file object opened for writing.
- * \param [in] ptr      Data array to write to disk.
- * \param [in] count    Number of array members.
- * \param [in] t        The MPI type for each array member.
- * \param [out] ocount  The number of written elements of type \b t.
- * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
- *                      The error code can be passed to
- *                      \ref sc_MPI_Error_string.
- */
-int                 sc_io_write_all (sc_MPI_File mpifile,
-                                     const void *ptr, int count,
-                                     sc_MPI_Datatype t, int *ocount);
 
 /** Close collectively a sc_MPI_File.
  *

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -43,7 +43,7 @@
  *    They losslessly transform a block of arbitrary data into a compressed
  *    and base64-encoded format and back that is unambiguously defined and
  *    human-friendly.
- *
+ * \note WARNING: The case of activated MPI but deactivated MPI I/O is deprecated.
  * \note For the function \ref sc_io_write_at_all without MPI IO but with MPI
  *       the \b offset argument is ignored. In this case the function writes at
  *       the current end of the file. Hereby, the MPI ranks write in the
@@ -583,6 +583,9 @@ void                sc_fread (void *ptr, size_t size,
 void                sc_fflush_fsync_fclose (FILE * file);
 
 /** Opens a MPI file or without MPI I/O or even without MPI a file context.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param[in] mpicomm   MPI communicator
  * \param[in] filename  The path to the file that we want to open.
  * \param[in] amode     An access mode.
@@ -625,6 +628,8 @@ void                sc_io_read (sc_MPI_File mpifile, void *ptr,
 
 /** Check for restricted usage of \ref sc_io_read_at.
  *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \return              0 if the restriction described in the note of \ref
  *                      sc_io_read_at applies, i.e. count > 0 is only legal
  *                      on rank 0. This is equivalent to MPI I/O being not
@@ -640,6 +645,9 @@ int                 sc_io_read_at_legal (void);
 /** Read MPI file content into memory for an explicit offset.
  * This function does not update the file pointer of the MPI file.
  * Contrary to \ref sc_io_read, it does not abort on read errors.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in counts of the type \b t.
  * \param [in] ptr      Data array to read from disk.
@@ -662,6 +670,9 @@ int                 sc_io_read_at (sc_MPI_File mpifile,
 
 /** Read MPI file content collectively into memory for an explicit offset.
  * This function does not update the file pointer of the MPI file.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in counts of the type \b t.
  * \param [in] ptr      Data array to read from disk.
@@ -682,6 +693,9 @@ int                 sc_io_read_at_all (sc_MPI_File mpifile,
  * with offset = 0 but the call of this function is not equivalent
  * to a call of MPI_File_read_all since this function ignores the current
  * position of the file cursor.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] ptr      Data array to read from disk.
  * \param [in] count    Number of array members.
@@ -715,6 +729,8 @@ void                sc_io_write (sc_MPI_File mpifile, const void *ptr,
 
 /** Check for restricted usage of \ref sc_io_write_at.
  *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \return              0 if the restriction described in the note of \ref
  *                      sc_io_write_at applies, i.e. count > 0 is only legal
  *                      on rank 0. This is equivalent to MPI I/O being not
@@ -729,7 +745,10 @@ int                 sc_io_write_at_legal (void);
 
 /** Write MPI file content into memory for an explicit offset.
  * This function does not update the file pointer that is part of mpifile.
- * Contrary to \ref sc_io_write, it does not abort on read errors. 
+ * Contrary to \ref sc_io_write, it does not abort on read errors.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param [in,out] mpifile      MPI file object opened for reading.
  * \param [in] offset   Starting offset in etype, where the etype is given by
  *                      the type t.
@@ -754,6 +773,7 @@ int                 sc_io_write_at (sc_MPI_File mpifile,
 /** Write MPI file content collectively into memory for an explicit offset.
  * This function does not update the file pointer that is part of mpifile.
  *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  * \note  If there is no MPI IO but MPI available, the offset parameter is
  *        ignored and the ranks just write at the current end of the file
  *        according to their rank-induced order.
@@ -781,6 +801,9 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
  * with offset = 0 but the call of this function is not equivalent
  * to a call of MPI_File_write_all since this function ignores the current
  * position of the file cursor.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ *
  * \param [in,out] mpifile      MPI file object opened for writing.
  * \param [in] ptr      Data array to write to disk.
  * \param [in] count    Number of array members.
@@ -795,6 +818,9 @@ int                 sc_io_write_all (sc_MPI_File mpifile,
                                      sc_MPI_Datatype t, int *ocount);
 
 /** Close collectively a sc_MPI_File.
+ *
+ * \note This case of activated MPI but deactivated MPI I/O is deprecated.
+ * 
  * \param[in] file  MPI file object that is closed.
  * \return              A sc_MPI_ERR_* as defined in \ref sc_mpi.h.
  *                      The error code can be passed to

--- a/src/sc_io.h
+++ b/src/sc_io.h
@@ -32,7 +32,7 @@
  *    provide functions centered around \ref sc_io_sink_new and \ref
  *    sc_io_source_new.
  *  - To abstract parallel file I/O in a way that works both with and
- *    without MPI I/O support, we provide \ref sc_io_open, \ref sc_io_write
+ *    without MPI support, we provide \ref sc_io_open, \ref sc_io_write
  *    and friends.
  *  - To write to the VTK binary compressed format, we provide suitable
  *    functions to base64 encode and zlib-compress as required; see
@@ -566,7 +566,7 @@ void                sc_fread (void *ptr, size_t size,
  */
 void                sc_fflush_fsync_fclose (FILE * file);
 
-/** Opens a MPI file or without MPI I/O or even without MPI a file context.
+/** Opens a MPI file or without MPI a file context.
  *
  * \param[in] mpicomm   MPI communicator
  * \param[in] filename  The path to the file that we want to open.
@@ -574,7 +574,7 @@ void                sc_fflush_fsync_fclose (FILE * file);
  * \param[in] mpiinfo   The MPI info
  * \param[out] mpifile  The MPI file that is opened. This can be a
  *                      an actual MPI IO file or an internal file
- *                      conntext to preserve some MPI IO functionalities
+ *                      conntext to preserve some IO functionalities
  *                      without MPI IO and to have working code without
  *                      MPI at all. This output variable is only filled if the
  *                      return value of the function is \ref sc_MPI_SUCCESS.
@@ -726,8 +726,6 @@ int                 sc_io_write_at_all (sc_MPI_File mpifile,
  * with offset = 0 but the call of this function is not equivalent
  * to a call of MPI_File_write_all since this function ignores the current
  * position of the file cursor.
- *
- * \note This case of activated MPI but deactivated MPI I/O is deprecated.
  *
  * \param [in,out] mpifile      MPI file object opened for writing.
  * \param [in] ptr      Data array to write to disk.

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -139,6 +139,9 @@ sc_tag_t;
 typedef enum sc_MPI_IO_Errorcode
 {
   /* only MPI I/O error classes */
+  /* WARNING: This enum is only used in the deprecated case of activated MPI but
+   * deactivated MPI I/O.
+   */
   sc_MPI_ERR_FILE = MPI_ERR_LASTCODE,
   sc_MPI_ERR_NOT_SAME,
   sc_MPI_ERR_AMODE,

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -304,7 +304,6 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -348,8 +347,6 @@ sc_scda_fcontext_t *sc_scda_fopen_write (sc_MPI_Comm mpicomm,
  * All parameters except of \b data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -394,8 +391,6 @@ sc_scda_fcontext_t *sc_scda_fwrite_inline (sc_scda_fcontext_t * fc,
  * All parameters except of \b block_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -456,8 +451,6 @@ sc_scda_fcontext_t *sc_scda_fwrite_block (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -569,8 +562,6 @@ int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -673,7 +664,6 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -716,8 +706,6 @@ sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  * All parameters are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -785,8 +773,6 @@ sc_scda_fcontext_t *sc_scda_fread_section_header (sc_scda_fcontext_t * fc,
  * All parameters except of \b data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -821,8 +807,6 @@ sc_scda_fcontext_t *sc_scda_fread_inline_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b data_block are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -863,8 +847,6 @@ sc_scda_fcontext_t *sc_scda_fread_block_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -927,8 +909,6 @@ sc_scda_fcontext_t *sc_scda_fread_array_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -976,8 +956,6 @@ sc_scda_fcontext_t *sc_scda_fread_varray_sizes (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -1092,8 +1070,6 @@ int                 sc_scda_ferror_string (sc_scda_ferror_t errcode, char *str,
  * All parameters are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI the function may abort on file system dependent
- * errors.
  *
  * \param [in,out]  fc        File context previously created by
  *                            \ref sc_scda_fopen_write or \ref

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -303,7 +303,7 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  * introduced in this \b scda
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -346,7 +346,7 @@ sc_scda_fcontext_t *sc_scda_fopen_write (sc_MPI_Comm mpicomm,
  * \note
  * All parameters except of \b data are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -390,7 +390,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_inline (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b block_data are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -450,7 +450,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_block (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b array_data are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -561,7 +561,7 @@ int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
  * \note
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_write.
@@ -663,7 +663,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  * introduced in this \b scda
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -705,7 +705,7 @@ sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  * \note
  * All parameters are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -772,7 +772,7 @@ sc_scda_fcontext_t *sc_scda_fread_section_header (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b data are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -806,7 +806,7 @@ sc_scda_fcontext_t *sc_scda_fread_inline_data (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b data_block are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -846,7 +846,7 @@ sc_scda_fcontext_t *sc_scda_fread_block_data (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b array_data are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -908,7 +908,7 @@ sc_scda_fcontext_t *sc_scda_fread_array_data (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b elem_sizes are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -955,7 +955,7 @@ sc_scda_fcontext_t *sc_scda_fread_varray_sizes (sc_scda_fcontext_t * fc,
  * \note
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
@@ -1069,7 +1069,7 @@ int                 sc_scda_ferror_string (sc_scda_ferror_t errcode, char *str,
  * \note
  * All parameters are collective.
  *
- * This function returns NULL on MPI I/O errors.
+ * This function returns NULL on I/O errors.
  *
  * \param [in,out]  fc        File context previously created by
  *                            \ref sc_scda_fopen_write or \ref

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -214,7 +214,7 @@ typedef uint64_t    sc_scda_ulong;
 typedef enum sc_scda_ret
 {
   SC_SCDA_FERR_SUCCESS = 0, /**< successful function call */
-  SC_SCDA_FERR_FORMAT = sc_MPI_ERR_LASTCODE,  /**< File not conforming to the
+  SC_SCDA_FERR_FORMAT ,     /**< File not conforming to the
                                                    \b scda format. */
   SC_SCDA_FERR_USAGE,   /**< Incorrect workflow of an \b scda reading function.
                              For example, the user might have identified a

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -135,10 +135,10 @@
  * - \ref sc_scda_ferror_class and
  * - \ref sc_scda_ferror_string.
  *
- * If MPI I/O is available \b errcode may encode an MPI error code. In this case
+ * If MPI is available \b errcode may encode an MPI error code. In this case
  * the two error examination functions output the error class and error string
  * as it would be output by the corresponding MPI functions, respectively.
- * Without MPI I/O or MPI it is still possible that \b errcode encodes an I/O
+ * Without MPI it is still possible that \b errcode encodes an I/O
  * operation related error code. This case does not differ concerning the error
  * code examiniation.
  * Moreover, \b errcode can encode an error code related to \b scda, i.e.
@@ -264,7 +264,7 @@ sc_scda_ret_t;
  */
 typedef struct sc_scda_ferror
 {
-  int mpiret;            /**< MPI function return value; without MPI I/O or MPI
+  int mpiret;            /**< MPI function return value; without MPI
                               this variable can get filled by other I/O operation
                               error codes, which are still interpretable by
                               the error \b scda examination functions */
@@ -287,8 +287,8 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  * It is collective and creates the file on a parallel file system.
  * \note
  * All parameters are collective.
- * This function leaves the file open if MPI I/O is available.
- * Independent of the availability of MPI I/O the user can write one or more
+ * This function leaves the file open if MPI is available.
+ * Independent of the availability of MPI the user can write one or more
  * file sections before closing the file (context) using \ref sc_scda_fclose.
  *
  * It is the user's responsibility to write any further
@@ -304,7 +304,7 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent errors.
+ * Without MPI the function may abort on file system dependent errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -348,7 +348,7 @@ sc_scda_fcontext_t *sc_scda_fopen_write (sc_MPI_Comm mpicomm,
  * All parameters except of \b data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -394,7 +394,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_inline (sc_scda_fcontext_t * fc,
  * All parameters except of \b block_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -456,7 +456,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_block (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -569,7 +569,7 @@ int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -673,7 +673,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  * [preprint](https://doi.org/10.48550/arXiv.2307.06789).
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent errors.
+ * Without MPI the function may abort on file system dependent errors.
  *
  * \param [in]     mpicomm   The MPI communicator that is used to open the
  *                           parallel file.
@@ -716,7 +716,7 @@ sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  * All parameters are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -785,7 +785,7 @@ sc_scda_fcontext_t *sc_scda_fread_section_header (sc_scda_fcontext_t * fc,
  * All parameters except of \b data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -821,7 +821,7 @@ sc_scda_fcontext_t *sc_scda_fread_inline_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b data_block are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -863,7 +863,7 @@ sc_scda_fcontext_t *sc_scda_fread_block_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -927,7 +927,7 @@ sc_scda_fcontext_t *sc_scda_fread_array_data (sc_scda_fcontext_t * fc,
  * All parameters except of \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -976,7 +976,7 @@ sc_scda_fcontext_t *sc_scda_fread_varray_sizes (sc_scda_fcontext_t * fc,
  * All parameters except of \b array_data and \b elem_sizes are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc          File context previously opened by \ref
@@ -1092,7 +1092,7 @@ int                 sc_scda_ferror_string (sc_scda_ferror_t errcode, char *str,
  * All parameters are collective.
  *
  * This function returns NULL on MPI I/O errors.
- * Without MPI I/O the function may abort on file system dependent
+ * Without MPI the function may abort on file system dependent
  * errors.
  *
  * \param [in,out]  fc        File context previously created by

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -214,7 +214,7 @@ typedef uint64_t    sc_scda_ulong;
 typedef enum sc_scda_ret
 {
   SC_SCDA_FERR_SUCCESS = 0, /**< successful function call */
-  SC_SCDA_FERR_FORMAT ,     /**< File not conforming to the
+  SC_SCDA_FERR_FORMAT = 15000, /**< File not conforming to the
                                                    \b scda format. */
   SC_SCDA_FERR_USAGE,   /**< Incorrect workflow of an \b scda reading function.
                              For example, the user might have identified a


### PR DESCRIPTION
# Deprecate MPI without MPI I/O

Proposed changes:
- Deprecate the configuration with MPI and without MPI I/O.
- Avoid using MPI link-time constants as compile-time constants in non-deprecated configuration setups.
- Exclude the case of MPI without MPI I/O from the documentation in `sc_io.h`.
- Remove `sc_io_{write,read}_at_legal` since they are only related to the deprecated configuration setup.
- Remove `sc_io_{write,read}_all` since it is unused and not conforming to the corresponding `MPI_File` functions in any configuration setup.
- Update the release notes for the changes in this PR, change existing release notes concerning MPI without MPI I/O and adding a note for the PR https://github.com/cburstedde/libsc/pull/130.

This draft PR would also profit from the changes in @cburstedde's branch https://github.com/cburstedde/libsc/tree/feature-disable-mpiio introducing warnings if the deprecated configuration setup is used.

Moreover, this draft PR relates to the issue https://github.com/cburstedde/libsc/issues/170 by not using `MPI_ERR_LASTCODE` in non-deprecated configuration setups.
