### PR TITLE
Feature disable mpiio

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -247,6 +247,14 @@ set(CMAKE_REQUIRED_DEFINITIONS)
 check_symbol_exists("SC_ENABLE_MPI" ${PROJECT_BINARY_DIR}/include/sc_config.h SC_ENABLE_MPI)
 check_symbol_exists("SC_ENABLE_MPIIO" ${PROJECT_BINARY_DIR}/include/sc_config.h SC_ENABLE_MPIIO)
 
+# check consistency of MPI configuration
 if(mpi AND NOT (SC_ENABLE_MPI AND SC_ENABLE_MPIIO))
   message(FATAL_ERROR "libsc MPI support was requested, but not configured in ${PROJECT_BINARY_DIR}/include/sc_config.h")
+endif()
+
+# check consistency of MPI I/O configuration
+if(mpi AND (SC_ENABLE_MPI AND NOT SC_ENABLE_MPIIO))
+  message(WARNING "libsc MPI configured but MPI I/O is not configured/found: DEPRECATED")
+  message(NOTICE "This configuration is DEPRECATED and will be disallowed in the future.")
+  message(NOTICE "If the MPI File API is not available, please disable MPI altogether.")
 endif()

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -418,6 +418,12 @@ dnl This macro prints messages at the end of the configure run.
 dnl
 AC_DEFUN([SC_FINAL_MESSAGES],
 [
+if test "x$HAVE_PKG_MPI" = xyes && test "x$HAVE_PKG_MPIIO" != xyes ; then
+AC_MSG_NOTICE([SC_SINGLE_LINE
+$1 has been configured --enable-mpi and --disable-mpiio.
+This configuration is DEPRECATED and will be disallowed in the future.
+If the MPI File API is not available, please configure to --disable-mpi.])
+fi
 if test "x$$1_HAVE_ZLIB" = x ; then
 AC_MSG_NOTICE([SC_SINGLE_LINE
 $1 did not find a recent zlib containing the function adler32_combine.

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -1,4 +1,4 @@
-
+dnl
 dnl sc_include.m4 - general custom macros
 dnl
 dnl This file is part of the SC Library.
@@ -7,6 +7,18 @@ dnl
 dnl Copyright (C) 2008,2009 Carsten Burstedde, Lucas Wilcox.
 
 dnl Documentation for macro names: brackets indicate optional arguments
+
+dnl SC_SINGLE_LINE
+dnl Print 72 characters '-' without any trailing newline.
+AC_DEFUN([SC_SINGLE_LINE],[dnl
+------------------------------------------------------------------------dnl
+])
+
+dnl SC_DOUBLE_LINE
+dnl Print 72 characters '=' without any trailing newline.
+AC_DEFUN([SC_DOUBLE_LINE],[dnl
+========================================================================dnl
+])
 
 dnl SC_VERSION(PREFIX)
 dnl Expose major, minor, and point version numbers as CPP defines.
@@ -407,8 +419,8 @@ dnl
 AC_DEFUN([SC_FINAL_MESSAGES],
 [
 if test "x$$1_HAVE_ZLIB" = x ; then
-AC_MSG_NOTICE([- $1 ----------------------------------------------------
-We did not find a recent zlib containing the function adler32_combine.
+AC_MSG_NOTICE([SC_SINGLE_LINE
+$1 did not find a recent zlib containing the function adler32_combine.
 This is OK if the following does not matter to you:
  - Calling some functions that rely on zlib will abort your program.
    These include sc_array_checksum and sc_vtk_write_compressed.
@@ -417,9 +429,10 @@ This is OK if the following does not matter to you:
 You can fix this by compiling a recent zlib and pointing LIBS to it.])
 fi
 if test "x$$1_HAVE_JSON" = x ; then
-AC_MSG_NOTICE([- $1 ----------------------------------------------------
-We did not find a JSON library containing json_integer and json_real.
+AC_MSG_NOTICE([SC_SINGLE_LINE
+$1 did not find a JSON library containing json_integer and json_real.
 This means that loading JSON files for option values will fail.
 You can fix this by installing the jansson development library.])
 fi
+AC_MSG_NOTICE([SC_SINGLE_LINE])
 ])

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -78,7 +78,7 @@ if test "x$enableval" = xyes ; then
     HAVE_PKG_MPIIO=yes
   fi
 elif test "x$enableval" != xno ; then
-  AC_MSG_WARN([Ignoring --enable-mpiio with unsupported argument])
+  AC_MSG_ERROR([use --enable-mpiio without an argument, or with yes or no])
 fi
 AC_MSG_CHECKING([whether we are using MPI I/O])
 AC_MSG_RESULT([$HAVE_PKG_MPIIO])

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -12,6 +12,7 @@ dnl                   on the configure command line.
 dnl                   Likewise for F77, FC and CXX if enabled in SC_MPI_CONFIG.
 dnl --disable-mpiio   Only effective if --enable-mpi is given.  In this case,
 dnl                   do not use MPI I/O in sc and skip the compile-and-link test.
+dnl                   DEPRECATED: we will disallow this combination in the future.
 dnl --disable-mpithread Only effective if --enable-mpi is given.  In this case,
 dnl                   do not use MPI_Init_thread () and skip compile-and-link test.
 dnl --disable-mpishared Only effective if --enable-mpi is given.  In this case,
@@ -71,7 +72,7 @@ dnl The shell variable SC_ENABLE_MPIIO is set if --disable-mpiio is not given.
 dnl If not disabled, MPI I/O will be verified by a compile/link test below.
 AC_ARG_ENABLE([mpiio],
               [AS_HELP_STRING([--disable-mpiio],
-               [do not use MPI I/O (even if MPI is enabled)])],,
+               [do not use MPI I/O (this option is DEPRECATED)])],,
               [enableval=yes])
 if test "x$enableval" = xyes ; then
   if test "x$HAVE_PKG_MPI" = xyes ; then
@@ -514,7 +515,7 @@ dnl  ])
   ])
   if test "x$HAVE_PKG_MPIIO" = xyes ; then
     SC_MPIIO_C_COMPILE_AND_LINK(,
-      [AC_MSG_ERROR([MPI I/O not found; you may try --disable-mpiio])])
+      [AC_MSG_ERROR([MPI I/O not found; you may --disable-mpi altogether])])
   fi
   if test "x$HAVE_PKG_MPITHREAD" = xyes ; then
     SC_MPITHREAD_C_COMPILE_AND_LINK(,

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -79,7 +79,7 @@ if test "x$enableval" = xyes ; then
     HAVE_PKG_MPIIO=yes
   fi
 elif test "x$enableval" != xno ; then
-  AC_MSG_ERROR([use --enable-mpiio without an argument, or with yes or no])
+  AC_MSG_ERROR([use --disable-mpiio without an argument (option DEPRECATED)])
 fi
 AC_MSG_CHECKING([whether we are using MPI I/O])
 AC_MSG_RESULT([$HAVE_PKG_MPIIO])


### PR DESCRIPTION
# Deprecate `--disable-mpiio` configure option

Use of MPI configuration without MPI I/O enabled now results in a warning and DEPRECATED message.
It has become increasingly expensive to maintain this case with reasonable standards conformance.
We are suggesting this PR as a first step to more drastically disable this corner case.
