### PR TITLE
Build cmake examples by default

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,11 +18,6 @@ add_executable(sc_${name} ${files})
 
 target_link_libraries(sc_${name} PRIVATE SC::SC)
 
-# it is not intended to run examples as tests in the top-level SC project
-if(NOT PROJECT_IS_TOP_LEVEL)
-  return()
-endif()
-
 if(SC_ENABLE_MPI)
   add_test(NAME sc:example:${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:sc_${name}>)
 else()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -12,49 +12,44 @@ endif()
 
 # --- build examples
 
-function(test_sc_example name files)
+function(sc_example name files)
 
 add_executable(sc_${name} ${files})
 
 target_link_libraries(sc_${name} PRIVATE SC::SC)
+set_target_properties(sc_${name}
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}"
+  LABELS sc
+)
 
-if(SC_ENABLE_MPI)
-  add_test(NAME sc:example:${name} COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${MPIEXEC_MAX_NUMPROCS} $<TARGET_FILE:sc_${name}>)
-else()
-  add_test(NAME sc:example:${name} COMMAND sc_${name})
-endif()
-
-if(WIN32)
-  set_property(TEST sc:example:${name} PROPERTY ENVIRONMENT_MODIFICATION "PATH=path_list_append:${SC_INCLUDE_DIR}/../bin")
-endif()
-
-endfunction(test_sc_example)
+endfunction(sc_example)
 
 
-test_sc_example(function function/function.c)
-test_sc_example(logging logging/logging.c)
-test_sc_example(test_shmem testing/sc_test_shmem.c)
+sc_example(function function/function.c)
+sc_example(logging logging/logging.c)
+sc_example(test_shmem testing/sc_test_shmem.c)
 
 configure_file(options/sc_options_example.ini sc_options_example.ini COPYONLY)
 configure_file(options/sc_options_example.json sc_options_example.json COPYONLY)
 configure_file(options/sc_options_preload.ini sc_options_preload.ini COPYONLY)
-test_sc_example(options options/options.c)
+sc_example(options options/options.c)
 
 # The OpenMP example is disabled
 # We are likely removing the OpenMP configuration entirely
 #
 # if(OpenMP_FOUND)
-#   test_sc_example(openmp openmp/openmp.c)
+#   sc_example(openmp openmp/openmp.c)
 #   target_link_libraries(sc_openmp PRIVATE OpenMP::OpenMP_C)
 # endif()
 
 if(CMAKE_USE_PTHREADS_INIT)
-  test_sc_example(pthread pthread/pthread.c)
+  sc_example(pthread pthread/pthread.c)
   target_link_libraries(sc_pthread PRIVATE Threads::Threads)
 endif()
 
 if(SC_ENABLE_V4L2)
-  test_sc_example(v4l2 v4l2/v4l2.c)
+  sc_example(v4l2 v4l2/v4l2.c)
 endif()
 
 if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)


### PR DESCRIPTION
This PR enables building examples by default and disables building and running them as tests.