### PR TITLE
Feature extern c

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -16,6 +16,10 @@
 
 ## Next release
 
+### Functionality
+
+ - Fix extern "C" macro for using C++ compilers with libsc .c files
+
 ### Build system
 
  - Streamline CMake configuration

--- a/src/sc.c
+++ b/src/sc.c
@@ -124,6 +124,22 @@ static int          sc_num_packages = 0;
 static int          sc_num_packages_alloc = 0;
 static sc_package_t *sc_packages = NULL;
 
+void
+sc_extern_c_hack_1 (void)
+{
+  /* Completing the hack in sc.h on providing the prototype.
+     We use the macro SC_EXTER_C_BEGIN; after including all headers
+     and before declaring functions to ensure C linkage. */
+}
+
+void
+sc_extern_c_hack_2 (void)
+{
+  /* Completing the hack in sc.h on providing the prototype.
+     We use the macro SC_EXTER_C_END; after declaring all functions,
+     just before the final include-once check, to ensure C linkage. */
+}
+
 #ifdef SC_ENABLE_PTHREAD
 
 static pthread_mutex_t sc_default_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/sc.h
+++ b/src/sc.h
@@ -197,11 +197,11 @@ typedef SSIZE_T     ssize_t;
  * and also take care of the different semantics of () / (...) */
 #ifdef __cplusplus
 #define SC_EXTERN_C_BEGIN       extern "C" { void sc_extern_c_hack_1 (void)
-#define SC_EXTERN_C_END                    } void sc_extern_c_hack_2 (void)
+#define SC_EXTERN_C_END                    } extern "C" void sc_extern_c_hack_2 (void)
 #define SC_NOARGS               ...
 #else
-#define SC_EXTERN_C_BEGIN                    void sc_extern_c_hack_3 (void)
-#define SC_EXTERN_C_END                      void sc_extern_c_hack_4 (void)
+#define SC_EXTERN_C_BEGIN                    void sc_extern_c_hack_1 (void)
+#define SC_EXTERN_C_END                      void sc_extern_c_hack_2 (void)
 /** For compatibility of varargs with C++ */
 #define SC_NOARGS
 #endif

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -563,7 +563,6 @@ sc_io_file_load (const char *filename, sc_array_t * buffer)
   /* fixed window size for reading a usually small file */
   const size_t        bwins = 1 << 14;
   size_t              bpos, bout;
-  int                 i;
 
   SC_ASSERT (filename != NULL);
   SC_ASSERT (buffer != NULL);
@@ -579,7 +578,7 @@ sc_io_file_load (const char *filename, sc_array_t * buffer)
 
   /* perform reading in a loop */
   bpos = 0;
-  for (i = 0;; ++i) {
+  for (;;) {
     /* make room in read buffer */
     sc_array_resize (buffer, bpos + bwins);
 

--- a/src/sc_notify.c
+++ b/src/sc_notify.c
@@ -2396,7 +2396,7 @@ sc_notify_payload_superset (sc_array_t * receivers, sc_array_t * senders,
                             sc_array_t * in_payload, sc_array_t * out_payload,
                             int sorted, sc_notify_t * notify)
 {
-  int                 num_receivers, num_senders = 0;
+  int                 num_receivers;
   int                 num_extra_receivers;
   int                 num_super_senders;
   int                *ireceivers, i, j;
@@ -2516,7 +2516,6 @@ sc_notify_payload_superset (sc_array_t * receivers, sc_array_t * senders,
                      comm, sc_MPI_STATUS_IGNORE);
       SC_CHECK_MPI (mpiret);
       queue--;
-      num_senders++;
       continue;
     }
     mpiret =


### PR DESCRIPTION
# Set C linkage for hack prototype 

Following up on issue #179.

Proposed changes: Make the prototype of sc_extern_c_hack_2 have C linkage, which allows to use the same names of the hack functions for both C and C++. Hopefully this avoids the warning with Clang. (Wondering why Clang would complain about declaring an unused prototype in a header, which is what headers do.)

For completeness, also implement the two dummy functions even though they are never called from the code.