### PR TITLE
CMake: Fix pkgconf install path in symbolic link

### DIFF
--- a/cmake/pkgconf.cmake
+++ b/cmake/pkgconf.cmake
@@ -19,11 +19,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${pc_filename}
         DESTINATION lib/pkgconfig)
 
 set(pc_target ${pc_filename})
-set(pc_link ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig/libsc.pc)
+set(pc_link lib/pkgconfig/libsc.pc)
 
-install(CODE "execute_process( \
-    COMMAND ${CMAKE_COMMAND} -E create_symlink \
-    ${pc_target} \
-    ${pc_link}   \
-    )"
-  )
+install(CODE "
+    file(CREATE_LINK ${pc_target} \${CMAKE_INSTALL_PREFIX}/${pc_link} SYMBOLIC)
+")


### PR DESCRIPTION
# Fix pkgconf install path in symbolic link

Closes issue #187.

Proposed changes:
The `CMAKE_INSTALL_PATH` was being set an configure time and not using the value present at install time. This change will allow all supported cmake versions to specify the install prefix when installing via `cmake --install . --prefix=/path/to/install`. 

Note that this change will cause cmake to issue a fatal error and abort install if the symbolic link is not created, instead of failing passively as before. 