### PR TITLE
CMake: fix git-version-gen path

### DIFF
--- a/cmake/git.cmake
+++ b/cmake/git.cmake
@@ -5,7 +5,7 @@ set(PROJECT_MINOR 0)
 set(PROJECT_PATCH 0)
 set(PROJECT_VERSION 0.0.0)
 find_program(GIT_VERSION_GEN NAMES git-version-gen
-             PATHS ${PROJECT_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
+             PATHS ${CMAKE_CURRENT_SOURCE_DIR}/build-aux NO_DEFAULT_PATH)
 if(GIT_VERSION_GEN)
   execute_process(COMMAND ${GIT_VERSION_GEN} .tarball-version
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}


### PR DESCRIPTION
# Fix git-version-gen path

Closes issue #188.

Proposed changes:
find_program was previously using `${PROJECT_SOURCE_DIR}/build-aux` to look for `git-version-gen`, but because we use this before `PROJECT()` is called, it evaluates to empty causing `git-version-gen` to be not found. This is corrected to `${CMAKE_CURRENT_SOURCE_DIR}/build-aux`. 

This will fix the libsc version from being 0.0.0 when building from source, and fix the name of `libsc-{git-version}.pc`

Note that you will probably want to test that this works as expected when including libsc and subproject in p4est as per #167 . 