### PR TITLE
CI: Revert breaking change to valgrind test

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -89,7 +89,7 @@ jobs:
 
   linux-valgrind:
     needs: linux-gcc14
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     name: Valgrind Linux mpi=${{ matrix.mpi }} CC=${{ matrix.cc }} shared=${{ matrix.shared }}
     timeout-minutes: 60
 


### PR DESCRIPTION
# Revert breaking change to valgrind CI test

It looks like the Valgrind test will need some updating before bumping the OS to Ubuntu 24.04. I'm not sure why but as the logs show, it's failing to successfully install the system packages.  Related to #185. Breaking Commit was 0c3a681.

Proposed changes:
I've reverted the OS to Ubuntu 22.04 for the valgrind test, until I can give it a closer look #191 .