### PR TITLE
ci:cmake: use default GCC,Clang per OS

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -18,26 +18,26 @@ env:
   CTEST_NO_TESTS_ACTION: "error"
   CMAKE_BUILD_PARALLEL_LEVEL: 4
   CTEST_PARALLEL_LEVEL: 0
+  CMAKE_INSTALL_PREFIX: ~/local
+  CMAKE_PREFIX_PATH: ~/local
 
 jobs:
 
-  linux-gcc14:
+  ubuntu-24:
     runs-on: ubuntu-24.04
     name: Linux mpi=${{ matrix.mpi }} CC=${{ matrix.cc }} shared=${{ matrix.shared }}
     timeout-minutes: 60
 
     strategy:
       matrix:
-        cc: [gcc-12, gcc-13, gcc-14]
+        cc: [gcc, clang]
         shared: [false]
-        mpi: [true]
+        mpi: [true, false]
+# we only include one "shared=true" as it's less common usage
+# but we want to be sure CMake is OK with it
         include:
         - cc: gcc
           shared: true
-          mpi: true
-        - cc: gcc
-          mpi: false
-        - cc: clang-18
           mpi: true
 
     env:
@@ -58,14 +58,14 @@ jobs:
       uses: ./.github/workflows/composite-cmake
 
 
-  linux-gcc9:
+  ubuntu-22:
     runs-on: ubuntu-22.04
     name: Linux mpi=${{ matrix.mpi }} CC=${{ matrix.cc }} shared=${{ matrix.shared }}
     timeout-minutes: 60
 
     strategy:
       matrix:
-        cc: [gcc-9, gcc-10, gcc-11]
+        cc: [gcc]
         shared: [false]
         mpi: [true]
 
@@ -88,15 +88,14 @@ jobs:
 
 
   linux-valgrind:
-    needs: linux-gcc14
+    needs: ubuntu-24
     runs-on: ubuntu-24.04
-    name: Valgrind Linux mpi=${{ matrix.mpi }} CC=${{ matrix.cc }} shared=${{ matrix.shared }}
+    name: Valgrind Linux mpi=${{ matrix.mpi }} CC=${{ matrix.cc }}
     timeout-minutes: 60
 
     strategy:
       matrix:
         cc: [gcc]
-        shared: [false]
         mpi: [true]
         valgrind: [ON]
 
@@ -114,7 +113,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: CMake configure
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} --install-prefix=${{ runner.temp }} -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }}
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }}
 
     - name: CMake build
       run: cmake --build --preset default
@@ -132,17 +131,17 @@ jobs:
           ./build/Testing/Temporary/LastTest.log
 
   mac:
-    # macos-14 is to use Apple Silicon hardware as most Apple users nowadays would have
-    # https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
     runs-on: macos-14
     name: macOS mpi=${{ matrix.mpi }} CC=${{ matrix.cc }} shared=${{ matrix.shared }}
     timeout-minutes: 60
 
     strategy:
       matrix:
-        cc: [clang, gcc-13]
+        cc: [clang]
+# gcc-13 is broken in general for macOS GItHub Actions, but works fine on real computers.
         mpi: [true]
         shared: [false]
+# shared=true is not common usage, but let's test one case of it
         include:
         - shared: true
           cc: clang
@@ -178,8 +177,12 @@ jobs:
     - uses: actions/checkout@v4
       name: Checkout source code
 
+    - run: echo "CMAKE_INSTALL_PREFIX=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - run: echo "CMAKE_PREFIX_PATH=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
     - name: CMake configure without MPI
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no --install-prefix=${{ runner.temp }} -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
     - name: CMake build
       run: cmake --build --preset default --parallel
@@ -191,7 +194,7 @@ jobs:
       run: cmake --install build
 
     - name: CMake configure examples without MPI
-      run: cmake -B example/build -S example -DCMAKE_PREFIX_PATH:PATH=${{ runner.temp }}
+      run: cmake -B example/build -S example
 
     - name: CMake build examples
       run: cmake --build example/build --parallel

--- a/.github/workflows/composite-cmake/action.yml
+++ b/.github/workflows/composite-cmake/action.yml
@@ -7,7 +7,6 @@ runs:
     run: >-
       cmake --preset default
       -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-      --install-prefix=${{ runner.temp }}
       -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
 
   - name: CMake print debug find
@@ -16,7 +15,6 @@ runs:
     run: >-
       cmake --preset default
       -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-      --install-prefix=${{ runner.temp }}
       -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
       --debug-find --fresh
 
@@ -34,7 +32,7 @@ runs:
 
   - name: CMake configure examples
     shell: bash
-    run: cmake -B example/build -S example -DCMAKE_PREFIX_PATH:PATH=${{ runner.temp }}
+    run: cmake -B example/build -S example
 
   - name: CMake build examples
     shell: bash
@@ -49,14 +47,14 @@ runs:
     if: github.event.action == 'published'
     uses: actions/upload-artifact@v4
     with:
-      name: ${{ runner.os }}-binary-archive-${{ matrix.cc }}-${{ matrix.mpi }}-shared-${{ matrix.shared }}
+      name: ${{ github.job }}-binary-archive-${{ matrix.cc }}-mpi-${{ matrix.mpi }}-shared-${{ matrix.shared }}
       path: build/package
 
   - name: Upload log files
     if: always()
     uses: actions/upload-artifact@v4
     with:
-      name: ${{ runner.os }}_cmake_log-${{ matrix.cc }}-${{ matrix.mpi }}-shared-${{ matrix.shared }}
+      name: ${{ github.job }}_cmake_log-${{ matrix.cc }}-mpi-${{ matrix.mpi }}-shared-${{ matrix.shared }}
       path: |
         ./build/CMakeFiles/CMakeConfigureLog.yaml
         ./build/Testing/Temporary/LastTest.log


### PR DESCRIPTION
per Carsten, simplify compiler fanout by using only default GCC or Clang.


