### PR TITLE
CMake: fix check for MPI_COMM_SHARED_TYPE using openMPI

### DIFF
--- a/cmake/check_mpicommshared.cmake
+++ b/cmake/check_mpicommshared.cmake
@@ -1,0 +1,18 @@
+include(CheckCSourceCompiles)
+function(check_mpicommshared)
+
+  set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_C)
+
+  check_c_source_compiles(
+    "
+        #include <mpi.h>
+        int main(void) {
+          int temp = MPI_COMM_TYPE_SHARED;
+          return 0;
+        }
+    "
+    SC_ENABLE_MPICOMMSHARED)
+
+endfunction()
+
+check_mpicommshared()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -106,7 +106,8 @@ if(NOT SC_ENABLE_MPI EQUAL CACHE{SC_ENABLE_MPI})
 endif()
 
 if( SC_ENABLE_MPI )
-  check_symbol_exists(MPI_COMM_TYPE_SHARED mpi.h SC_ENABLE_MPICOMMSHARED)
+  # perform check to set SC_ENABLE_MPICOMMSHARED
+  include(cmake/check_mpicommshared.cmake)
   # perform check to set SC_ENABLE_MPIIO
   include(cmake/check_mpiio.cmake)
   check_symbol_exists(MPI_Init_thread mpi.h SC_ENABLE_MPITHREAD)


### PR DESCRIPTION
# Fix CMake check for MPI_COMM_SHARED_TYPE

Following up on issue #195 

Proposed changes:
This PR checks the existence of the symbol `MPI_COMM_SHARED_TYPE` in the header `mpi.h` using `check_c_source_compiles` instead of `check_symbol_exists`.