### PR TITLE
scda: Write and read inline file sections

### DIFF
--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1636,12 +1636,14 @@ sc_scda_fread_inline_data (sc_scda_fcontext_t *fc, sc_array_t *data, int root,
   SC_ASSERT (root >= 0);
   SC_ASSERT (errcode != NULL);
 
-  if (fc->mpirank == root && data != NULL) {
+  if (data != NULL) {
     /* the data is not skipped */
-    sc_scda_fread_inline_data_serial_internal (fc, data, &count_err, errcode);
+    if (fc->mpirank == root) {
+      sc_scda_fread_inline_data_serial_internal (fc, data, &count_err, errcode);
+    }
+    SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
+    SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);
   }
-  SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
-  SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);
 
   /* if no error occurred, we move the internal file pointer */
   fc->accessed_bytes += SC_SCDA_INLINE_FIELD;

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1016,6 +1016,8 @@ sc_scda_fopen_write_header_internal (sc_scda_fcontext_t *fc,
   int                 invalid_user_string;
   char                file_header_data[SC_SCDA_HEADER_BYTES];
 
+  *count_err = 0;
+
   /* get scda file header section */
   /* magic */
   sc_scda_copy_bytes (file_header_data, SC_SCDA_MAGIC, SC_SCDA_MAGIC_BYTES);
@@ -1191,6 +1193,8 @@ sc_scda_fwrite_inline_header_internal (sc_scda_fcontext_t *fc,
   int                 invalid_user_string;
   char                header_data[SC_SCDA_COMMON_FIELD];
 
+  *count_err = 0;
+
   /* get inline file section header */
 
   /* section-identifying character */
@@ -1238,6 +1242,8 @@ sc_scda_fwrite_inline_data_internal (sc_scda_fcontext_t *fc,
   int                 mpiret;
   int                 count;
   int                 invalid_inline_data;
+
+  *count_err = 0;
 
   /* check inline data */
   invalid_inline_data = !(inline_data->elem_size == 32 &&
@@ -1392,6 +1398,8 @@ sc_scda_fopen_read_header_internal (sc_scda_fcontext_t * fc,
   int                 invalid_file_header;
   char                file_header_data[SC_SCDA_HEADER_BYTES];
 
+  *count_err = 0;
+
   mpiret =
     sc_io_read_at (fc->file, 0, file_header_data, SC_SCDA_HEADER_BYTES,
                    sc_MPI_BYTE, &count);
@@ -1516,6 +1524,8 @@ sc_scda_fread_section_header_common_internal (sc_scda_fcontext_t *fc,
   int                 wrong_format;
   char                common[SC_SCDA_COMMON_FIELD];
 
+  *count_err = 0;
+
   /* read common file section header */
   mpiret = sc_io_read_at (fc->file, fc->accessed_bytes, common,
                           SC_SCDA_COMMON_FIELD, sc_MPI_BYTE, &count);
@@ -1636,6 +1646,8 @@ sc_scda_fread_inline_data_serial_internal (sc_scda_fcontext_t *fc,
   int                 mpiret;
   int                 count;
   int                 invalid_array;
+
+  *count_err = 0;
 
   /* check the passed sc_array */
   invalid_array = !(data->elem_count == 1 && data->elem_size == 32);

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -163,29 +163,30 @@
 struct sc_scda_fcontext
 {
   /* *INDENT-OFF* */
-  sc_MPI_Comm         mpicomm; /**< associated MPI communicator */
-  int                 mpisize; /**< number of MPI ranks */
-  int                 mpirank; /**< MPI rank */
-  sc_MPI_File         file;    /**< file object */
-  unsigned            fuzzy_everyn; /**< In average every n-th possible error
-                                       origin returns a fuzzy error. There may
-                                       be multiple possible error origins in
-                                       one top-level scda function.
-                                       We return for each possible error origin
-                                       a random error with the empirical
-                                       probability of 1 / fuzzy_everyn but only
-                                       if the respective possible error origin
-                                       did not already cause an error without
-                                       the fuzzy error return. In such a case,
-                                       the actual error is returned. 0 means
-                                       that there are no fuzzy error returns. */
-  sc_rand_state_t     fuzzy_seed; /**< The seed for the fuzzy error return.
-                                       This value is ignored if
-                                       fuzzy_everyn == 0. It is important to
-                                       notice that fuzzy_seed is initialized by
-                                       the user-defined seed but is adjusted
-                                       to the state after each call of
-                                       \ref sc_rand. */
+  sc_MPI_Comm         mpicomm;        /**< associated MPI communicator */
+  int                 mpisize;        /**< number of MPI ranks */
+  int                 mpirank;        /**< MPI rank */
+  sc_MPI_File         file;           /**< file object */
+  sc_MPI_Offset       accessed_bytes; /**< number of written/read bytes */
+  unsigned            fuzzy_everyn;   /**< In average every n-th possible error
+                                        origin returns a fuzzy error. There may
+                                        be multiple possible error origins in
+                                        one top-level scda function.
+                                        We return for each possible error origin
+                                        a random error with the empirical
+                                        probability of 1 / fuzzy_everyn but only
+                                        if the respective possible error origin
+                                        did not already cause an error without
+                                        the fuzzy error return. In such a case,
+                                        the actual error is returned. 0 means
+                                        that there are no fuzzy error returns.*/
+  sc_rand_state_t     fuzzy_seed;     /**< The seed for the fuzzy error return.
+                                        This value is ignored if
+                                        fuzzy_everyn == 0. It is important to
+                                        notice that fuzzy_seed is initialized by
+                                        the user-defined seed but is adjusted
+                                        to the state after each call of
+                                        \ref sc_rand. */
   /* *INDENT-ON* */
 };
 
@@ -1088,6 +1089,9 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
    */
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, fc);
 
+  /* store number of written bytes */
+  fc->accessed_bytes = SC_SCDA_HEADER_BYTES;
+
   return fc;
 }
 
@@ -1277,6 +1281,9 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
   mpiret = sc_MPI_Bcast (user_string, SC_SCDA_USER_STRING_BYTES + 1,
                          sc_MPI_BYTE, 0, mpicomm);
   SC_CHECK_MPI (mpiret);
+
+  /* store the number of read bytes */
+  fc->accessed_bytes = SC_SCDA_HEADER_BYTES;
 
   return fc;
 }

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -38,7 +38,6 @@
                                                                   the file
                                                                   section
                                                                   headers */
-#define SC_SCDA_INLINE_FIELD 32 /**< byte count of inline data */
 #define SC_SCDA_PADDING_MOD 32  /**< divisor for variable length padding */
 
 /** get a random double in the range [A,B) */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1676,6 +1676,9 @@ sc_scda_fread_inline_data (sc_scda_fcontext_t *fc, sc_array_t *data, int root,
   /* if no error occurred, we move the internal file pointer */
   fc->accessed_bytes += SC_SCDA_INLINE_FIELD;
 
+  /* last function call can not be \ref sc_scda_fread_section_header anymore */
+  fc->header_before = 0;
+
   return fc;
 }
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -150,6 +150,10 @@
  * On rank root \b cerror must point to the int that was set by \ref
  * SC_SCDA_CHECK_NONCOLL_COUNT_ERR. On all other ranks \b cerror is set by this
  * macro.
+ * In case of activated fuzzy error testing it is important to notice that this
+ * macro calls \ref sc_scda_scdaret_to_errcode, which may output fuzzy errors.
+ * Hence, for activated fuzzy error testing one may observe reported count
+ * errors with an error string for an other error.
  */
 #define SC_SCDA_HANDLE_NONCOLL_COUNT_ERR(errorcode, cerror, root, fc) do{      \
                                     SC_CHECK_MPI (sc_MPI_Bcast (cerror,        \

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -156,6 +156,8 @@
  * errors with an error string for an other error.
  */
 #define SC_SCDA_HANDLE_NONCOLL_COUNT_ERR(errorcode, cerror, root, fc) do{      \
+                                    SC_ASSERT (                                \
+                                        sc_scda_ferror_is_success (*errcode)); \
                                     SC_CHECK_MPI (sc_MPI_Bcast (cerror,        \
                                                   1, sc_MPI_INT, root,         \
                                                   fc->mpicomm));               \

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1221,6 +1221,14 @@ sc_scda_fwrite_inline_data_internal (sc_scda_fcontext_t *fc,
 {
   int                 mpiret;
   int                 count;
+  int                 invalid_inline_data;
+
+  /* check inline data */
+  invalid_inline_data = !(inline_data->elem_size == 32 &&
+                          inline_data->elem_count == 1);
+  sc_scda_scdaret_to_errcode (invalid_inline_data ? SC_SCDA_FERR_ARG :
+                              SC_SCDA_FERR_SUCCESS, errcode, fc);
+  SC_SCDA_CHECK_NONCOLL_ERR (errcode, "Invalid inline data");
 
   /* write the inline data to the file section */
   mpiret = sc_io_write_at (fc->file, fc->accessed_bytes, inline_data->array,
@@ -1242,8 +1250,6 @@ sc_scda_fwrite_inline (sc_scda_fcontext_t *fc, const char *user_string,
   SC_ASSERT (root >= 0);
   /* inline_data is ignored on all ranks except of root */
   SC_ASSERT (fc->mpirank != root || inline_data != NULL);
-  SC_ASSERT (fc->mpirank != root || (inline_data->elem_count == 1 &&
-                                     inline_data->elem_size == 32));
   SC_ASSERT (errcode != NULL);
 
   /* The file header section is always written and read on rank 0. */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1263,6 +1263,8 @@ sc_scda_fwrite_inline (sc_scda_fcontext_t *fc, const char *user_string,
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, fc);
 
+  fc->accessed_bytes += SC_SCDA_INLINE_FIELD;
+
   return fc;
 }
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1006,7 +1006,7 @@ sc_scda_get_common_section_header (char section_char, const char* user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fopen_write_serial_internal (sc_scda_fcontext_t *fc,
+sc_scda_fopen_write_header_internal (sc_scda_fcontext_t *fc,
                                      const char *user_string, size_t *len,
                                      int *count_err, sc_scda_ferror_t *errcode)
 {
@@ -1126,13 +1126,13 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
   SC_SCDA_CHECK_COLL_ERR (errcode, fc, "File open write");
 
   if (fc->mpirank == 0) {
-    sc_scda_fopen_write_serial_internal (fc, user_string, len, &count_err,
+    sc_scda_fopen_write_header_internal (fc, user_string, len, &count_err,
                                          errcode);
   }
   /* This macro must be the first expression after the non-collective code part
    * since it must be the point where \ref SC_SCDA_CHECK_NONCOLL_ERR and \ref
    * SC_SCDA_CHECK_NONCOLL_COUNT_ERR can jump to, which are called in \ref
-   * sc_scda_fopen_write_serial_internal. The macro handles the non-collective
+   * sc_scda_fopen_write_header_internal. The macro handles the non-collective
    * error, i.e. it broadcasts the errcode, which may encode success, from
    * rank 0 to all other ranks and in case of an error it closes the file,
    * frees the file context and returns NULL. Hence, it is valid that errcode
@@ -1150,7 +1150,7 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
    * prints an error message using \ref SC_LERRORF. This means in particular
    * that it is valid that errcode is only initialized on rank 0 before calling
    * this macro. The macro argument count_err must point to the count error
-   * Boolean that was set on rank 0 by \ref sc_scda_fopen_write_serial_internal.
+   * Boolean that was set on rank 0 by \ref sc_scda_fopen_write_header_internal.
    */
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, 0, fc);
 
@@ -1383,7 +1383,7 @@ sc_scda_check_file_header (const char *file_header_data, char *user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fopen_read_serial_internal (sc_scda_fcontext_t * fc,
+sc_scda_fopen_read_header_internal (sc_scda_fcontext_t * fc,
                                     char *user_string, size_t *len,
                                     int *count_err, sc_scda_ferror_t *errcode)
 {
@@ -1459,7 +1459,7 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
 
   /* read file header section on rank 0 */
   if (fc->mpirank == 0) {
-    sc_scda_fopen_read_serial_internal (fc, user_string, len, &count_err,
+    sc_scda_fopen_read_header_internal (fc, user_string, len, &count_err,
                                         errcode);
   }
   /* The macro to handle a non-collective error that is associated to a

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1281,7 +1281,8 @@ sc_scda_fwrite_inline (sc_scda_fcontext_t *fc, const char *user_string,
  * \param [in] file_header_data The read file header data as a byte buffer.
  * \param [out] user_string     On output the read user string including
  *                              nul-termination. At least \ref
- *                              SC_SCDA_USER_STRING_BYTES + 1 bytes.
+ *                              SC_SCDA_USER_STRING_BYTES + 1 bytes. Must be
+ *                              initialized with '\0'.
  * \param [out] len             On output \b len is set to the number of bytes
  *                              written to \b user_string excluding the
  *                              terminating nul.
@@ -1342,7 +1343,6 @@ sc_scda_check_file_header (const char *file_header_data, char *user_string,
     return -1;
   }
   /* the user string content is not checked */
-  user_string[*len] = '\0';
 
   current_pos += SC_SCDA_USER_STRING_FIELD;
   /* check the padding of zero data bytes */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1591,6 +1591,18 @@ sc_scda_fread_section_header (sc_scda_fcontext_t *fc, char *user_string,
   return fc;
 }
 
+/** Internal function to read the inline data.
+ *
+ * \param [in] fc           The file context as in \ref
+ *                          sc_scda_fread_inline_data before running the
+ *                          serial code part.
+ * \param [out] data        As in the documentation of \ref
+ *                          sc_scda_fread_inline_data.
+ * \param [out] count_err   A Boolean indicating if a count error occurred.
+ * \param [out] errcode     An errcode that can be interpreted by \ref
+ *                          sc_scda_ferror_string or mapped to an error class
+ *                          by \ref sc_scda_ferror_class.
+ */
 static void
 sc_scda_fread_inline_data_serial_internal (sc_scda_fcontext_t *fc,
                                            sc_array_t *data, int *count_err,

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1469,6 +1469,22 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
   return fc;
 }
 
+/** Internal function to read and check the common part of file section header.
+ *
+ * \param [in] fc           The file context as in \ref
+ *                          sc_scda_fread_section_header before running the
+ *                          first serial code part.
+ * \param [out] type        As in the documentation of \ref
+ *                          sc_scda_fread_section_header.
+ * \param [out] user_string As in the documentation of \ref
+ *                          sc_scda_fread_section_header.
+ * \param [out] len         As in the documentation of \ref
+ *                          sc_scda_fread_section_header.
+ * \param [out] count_err   A Boolean indicating if a count error occurred.
+ * \param [out] errcode     An errcode that can be interpreted by \ref
+ *                          sc_scda_ferror_string or mapped to an error class
+ *                          by \ref sc_scda_ferror_class.
+ */
 static void
 sc_scda_fread_section_header_common_internal (sc_scda_fcontext_t *fc,
                                               char *type, char *user_string,

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -200,6 +200,7 @@ SC_EXTERN_C_BEGIN;
 
 #define SC_SCDA_HEADER_BYTES 128 /**< number of file header bytes */
 #define SC_SCDA_USER_STRING_BYTES 58 /**< number of user string bytes */
+#define SC_SCDA_INLINE_FIELD 32 /**< byte count of inline data */
 
 /** Opaque context for writing and reading a libsc data file, i.e. a scda file. */
 typedef struct sc_scda_fcontext sc_scda_fcontext_t;

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -801,8 +801,10 @@ sc_scda_fcontext_t *sc_scda_fread_section_header (sc_scda_fcontext_t * fc,
  * \param [in,out]  fc          File context previously opened by \ref
  *                              sc_scda_fopen_read.
  * \param [out]     data        Exactly 32 bytes on the rank \b root or NULL
- *                              on \b root to not read the bytes. The parameter
- *                              is ignored on all ranks unequal to \b root.
+ *                              on \b root to not read the bytes. In the first
+ *                              case the sc_array must have an element count
+ *                              of 1 and an element size 32. The parameter is
+ *                              ignored on all ranks unequal to \b root.
  * \param [in]      root        An integer between 0 and mpisize exclusive of
  *                              the MPI communicator that was used to create
  *                              \b fc. \b root indicates the MPI rank on that

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -134,7 +134,10 @@ main (int argc, char **argv)
   /* Create valid scda options structure. */
   /* set the options to actiavate fuzzy error testing */
   /* WARNING: Fuzzy error testing means that the code randomly produces
-   * errors.
+   * errors. Random errors mean in particular that error codes may arise from
+   * code places, which can not produce such particular error codes without
+   * fuzzy error testing. Nonetheless, our implementation is designed to be
+   * able to handle this situations properly.
    */
   scda_opt.fuzzy_everyn = (unsigned) int_everyn;
   if (int_seed < 0) {

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -211,6 +211,22 @@ main (int argc, char **argv)
   SC_INFOF ("Read file section header of type %c with user string: %s\n",
             section_type, read_user_string);
 
+  fc =
+    sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_opt,
+                        &errcode);
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "scda_fopen_read failed");
+
+  /* provoke error for invalid scda workflow */
+  SC_GLOBAL_ESSENTIAL ("We expect an error for incorrect workflow for scda"
+                       " reading function, which is triggered on purpose to"
+                       " test the error checking.\n");
+  fc = sc_scda_fread_inline_data (fc, &data, 0, &errcode);
+  SC_CHECK_ABORT (!sc_scda_ferror_is_success (errcode) &&
+                  errcode.scdaret == SC_SCDA_FERR_USAGE && fc == NULL,
+                  "sc_scda_fread_section_header failed");
+  /* fc is closed and deallocated due to the occurred error  */
+
   sc_options_destroy (opt);
 
   sc_finalize ();

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -198,6 +198,9 @@ main (int argc, char **argv)
                   || !strncmp (read_inline_data, inline_data,
                                SC_SCDA_INLINE_FIELD), "inline data mismatch");
 
+  SC_INFOF ("Read file section header of type %c with user string: %s\n",
+            section_type, read_user_string);
+
   /* skip the next inline section */
   /* reading the section header can not be skipped */
   fc = sc_scda_fread_section_header (fc, read_user_string, &len, &section_type,
@@ -215,9 +218,6 @@ main (int argc, char **argv)
   /* TODO: check errcode and return value */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fclose after read failed");
-
-  SC_INFOF ("Read file section header of type %c with user string: %s\n",
-            section_type, read_user_string);
 
   fc =
     sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_opt,

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -128,6 +128,10 @@ main (int argc, char **argv)
   }
 
   /* Create valid scda options structure. */
+  /* set the options to actiavate fuzzy error testing */
+  /* WARNING: Fuzzy error testing means that the code randomly produces
+   * errors.
+   */
   scda_opt.fuzzy_everyn = (unsigned) int_everyn;
   if (int_seed < 0) {
     scda_opt.fuzzy_seed = (sc_rand_state_t) sc_MPI_Wtime ();
@@ -157,11 +161,6 @@ main (int argc, char **argv)
   /* TODO: check errcode and return value */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fclose after write" " failed");
-
-  /* set the options to actiavate fuzzy error testing */
-  /* WARNING: Fuzzy error testing means that the code randomly produces
-   * errors.
-   */
 
   fc =
     sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_opt,

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -235,7 +235,7 @@ main (int argc, char **argv)
   fc = sc_scda_fread_inline_data (fc, &data, 0, &errcode);
   SC_CHECK_ABORT (!sc_scda_ferror_is_success (errcode) &&
                   errcode.scdaret == SC_SCDA_FERR_USAGE && fc == NULL,
-                  "sc_scda_fread_section_header failed");
+                  "sc_scda_fread_section_header error detection failed");
   /* fc is closed and deallocated due to the occurred error  */
 
   sc_options_destroy (opt);

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -199,6 +199,14 @@ main (int argc, char **argv)
                                SC_SCDA_INLINE_FIELD), "inline data mismatch");
 
   /* skip the next inline section */
+  /* reading the section header can not be skipped */
+  fc = sc_scda_fread_section_header (fc, read_user_string, &len, &section_type,
+                                     &elem_count, &elem_size, &decode,
+                                     &errcode);
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "sc_scda_fread_section_header failed");
+  SC_CHECK_ABORT (section_type == 'I' && elem_count == 0 && elem_size == 0,
+                  "Identifying section type");
   fc = sc_scda_fread_inline_data (fc, NULL, mpisize - 1, &errcode);
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "sc_scda_fread_inline_data skip failed");

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -139,7 +139,7 @@ main (int argc, char **argv)
   scda_opt.info = sc_MPI_INFO_NULL;
 
   fc = sc_scda_fopen_write (mpicomm, filename, file_user_string, NULL,
-                            NULL, &errcode);
+                            &scda_opt, &errcode);
   /* TODO: check errcode */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fopen_write failed");

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -42,6 +42,8 @@ main (int argc, char **argv)
   sc_scda_ferror_t    errcode;
   size_t              len;
   sc_options_t       *opt;
+  sc_array_t          data;
+  const char         *inline_data = "Test inline data               \n";
 
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
@@ -143,6 +145,13 @@ main (int argc, char **argv)
   /* TODO: check errcode */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fopen_write failed");
+
+  /* write an inline section to the file */
+  sc_array_init_data (&data, (void *) inline_data, 32, 1);
+  fc = sc_scda_fwrite_inline (fc, "Inline section test without user-defined "
+                              "padding", NULL, &data, mpisize - 1, &errcode);
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "scda_fwrite_inline failed");
 
   sc_scda_fclose (fc, &errcode);
   /* TODO: check errcode and return value */


### PR DESCRIPTION
# scda: Write and read inline file sections

This PR continues the implementation of the scda file format (cf. https://github.com/cburstedde/libsc/pull/197 and https://github.com/cburstedde/libsc/pull/193) by implementing `fwrite_inline`, `fread_section_header` for the case of an inline file section and `fread_inline_data`. Moreover, this PR contains in particular the following changes:
- Introduce a static function to generate the part of headers that always have the same structure,
- track the last `fread_section_header` call in the file context to be able to generate a suitable error code if the user does not follow the required reading workflow,
-  generalize the macros for non-collective errors to handle non-collective code on a fixed but arbitrary rank and
- basic tests of the new scda functions.