### PR TITLE
Fix recheck MPI features in the CMake build system

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -98,7 +98,7 @@ set(SC_ENABLE_PTHREAD ${CMAKE_USE_PTHREADS_INIT})
 set(SC_ENABLE_MEMALIGN 1)
 
 # user has requested a different MPI setting, so we need to clear these cache variables to recheck
-if(NOT SC_ENABLE_MPI EQUAL CACHE{SC_ENABLE_MPI})
+if(NOT "${SC_ENABLE_MPI}" STREQUAL "$CACHE{SC_ENABLE_MPI}")
   unset(SC_ENABLE_MPICOMMSHARED CACHE)
   unset(SC_ENABLE_MPITHREAD CACHE)
   unset(SC_ENABLE_MPIWINSHARED CACHE)


### PR DESCRIPTION
# Fix recheck MPI features in the CMake build system

This PR fixes a condition statement that would always evaluate to true due to a typo in the CMake build system. Now, when relaunching CMake, the cached variables for the MPI features are no longer discarded when the variable `SC_ENABLE_MPI` did not change. This allows the checks not to run again as intended and use the cached variables instead.

Closes #198
