### PR TITLE
scda: Write and read block sections

### DIFF
--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -410,8 +410,11 @@ sc_scda_pad_to_mod_len (size_t input_len)
 
   if (num_pad_bytes < 7) {
     /* not sufficient number of padding bytes for the padding format */
-    num_pad_bytes += SC_SCDA_PADDING_MOD;
+    num_pad_bytes += SC_SCDA_PADDING_MOD *
+      (size_t) ceil (((7. - num_pad_bytes) / ((double) SC_SCDA_PADDING_MOD)));
+    /* The factor is necessary for the case that SC_SCDA_PADDING_MOD < 7. */
   }
+  SC_ASSERT (num_pad_bytes >= 7);
 
   return num_pad_bytes;
 }

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -47,6 +47,8 @@
 #define SC_SCDA_COUNT_MAX_DIGITS 26 /**< maximal decimal digits count of a count
                                          variable in a section header */
 #define SC_SCDA_PADDING_MOD 32  /**< divisor for variable length padding */
+#define SC_SCDA_PADDING_MOD_MAX (6 + SC_SCDA_PADDING_MOD) /**< maximal count of
+                                                              mod padding bytes */
 
 /** get a random double in the range [A,B) */
 #define SC_SCDA_RAND_RANGE(A, B, state) ((A) + sc_rand (state) * ((B) - (A)))
@@ -404,8 +406,8 @@ sc_scda_pad_to_mod (const char *input_data, size_t input_len,
   /* compute the number of padding bytes */
   num_pad_bytes = sc_scda_pad_to_mod_len (input_len);
 
-  SC_ASSERT (num_pad_bytes >= 6);
-  SC_ASSERT (num_pad_bytes <= SC_SCDA_PADDING_MOD + 6);
+  SC_ASSERT (num_pad_bytes >= 7);
+  SC_ASSERT (num_pad_bytes <= SC_SCDA_PADDING_MOD_MAX);
 
   /* check for last byte to decide on padding format */
   if (input_len > 0 && input_data[input_len - 1] == '\n') {

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -33,11 +33,19 @@
 #define SC_SCDA_VENDOR_STRING_BYTES 20 /**< maximal number of vendor string bytes */
 #define SC_SCDA_USER_STRING_FIELD 62   /**< byte count for user string entry
                                             including the padding */
+#define SC_SCDA_COUNT_ENTRY 30 /**< byte count of the count variable entry in
+                                    the section header including padding */
 #define SC_SCDA_COMMON_FIELD (2 + SC_SCDA_USER_STRING_FIELD) /**< byte count for
                                                                   common part of
                                                                   the file
                                                                   section
                                                                   headers */
+#define SC_SCDA_COUNT_FIELD (2 + SC_SCDA_COUNT_ENTRY) /**< byte count of the
+                                                           complete count
+                                                           variable entry in
+                                                           the section header */
+#define SC_SCDA_COUNT_MAX_DIGITS 26 /**< maximal decimal digits count of a count
+                                         variable in a section header */
 #define SC_SCDA_PADDING_MOD 32  /**< divisor for variable length padding */
 
 /** get a random double in the range [A,B) */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1643,13 +1643,13 @@ sc_scda_fwrite_block_data_internal (sc_scda_fcontext_t *fc,
                            padding, (int) num_pad_bytes, sc_MPI_BYTE, &count);
   sc_scda_mpiret_to_errcode (mpiret, errcode, fc);
   SC_SCDA_CHECK_NONCOLL_ERR (errcode, "Writing block data padding");
-  SC_SCDA_CHECK_NONCOLL_COUNT_ERR (block_size, count, count_err);
+  SC_SCDA_CHECK_NONCOLL_COUNT_ERR (num_pad_bytes, count, count_err);
 }
 
 sc_scda_fcontext_t *
 sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
-                       size_t *len, sc_array_t * block_data, size_t block_size,
-                       int root, int encode, sc_scda_ferror_t * errcode)
+                      size_t *len, sc_array_t * block_data, size_t block_size,
+                      int root, int encode, sc_scda_ferror_t * errcode)
 {
   int                 count_err;
   size_t              num_pad_bytes;
@@ -2358,7 +2358,8 @@ sc_scda_fread_block_data (sc_scda_fcontext_t *fc, sc_array_t *block_data,
   }
 
   /* if no error occurred, we move the internal file pointer */
-  fc->accessed_bytes += (sc_MPI_Offset) block_size;
+  fc->accessed_bytes += (sc_MPI_Offset) (block_size +
+                                          sc_scda_pad_to_mod_len (block_size));
 
   /* last function call can not be \ref sc_scda_fread_section_header anymore */
   fc->header_before = 0;

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -237,6 +237,36 @@ sc_scda_copy_bytes (char *dest, const char *src, size_t n)
   (void) memcpy (dest, src, n);
 }
 
+/** Merge up to three buffers into one contiguous buffer.
+ *
+ * \param [in] d1           The first buffer. Must be not NULL.
+ * \param [in] len1         The byte count of the first buffer.
+ * \param [in] d2           The second buffer. May be NULL.
+ * \param [in] len2         The byte count of the second buffer. Must be 0 if
+ *                          \b d2 is NULL.
+ * \param [in] d3           The third buffer. May be NULL and must be NULL if
+ *                          \b d2 is NULL.
+ * \param [in] len3         The byte count of the third buffer. Must be 0 if
+ *                          \b d3 is NULL.
+ * \param [out] out         At least \b len1 + \b len2 + \b len3 bytes.
+ */
+static void
+sc_scda_merge_data_to_buf (const char *d1, size_t len1, const char *d2,
+                           size_t len2, const char *d3, size_t len3,
+                           char *out)
+{
+  SC_ASSERT (d1 != NULL);
+
+  sc_scda_copy_bytes (out, d1, len1);
+  if (d2 != NULL) {
+    sc_scda_copy_bytes (&out[len1], d2, len2);
+  }
+  if (d3 != NULL) {
+    SC_ASSERT (d2 != NULL);
+    sc_scda_copy_bytes (&out[len2], d3, len3);
+  }
+}
+
 /** Set \b n bytes in \b dest to \b c.
  * \b dest must have at least \b n bytes.
  */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1663,7 +1663,7 @@ sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
   ret = sc_scda_check_coll_params (fc, (const char*) &block_size,
                                    sizeof (size_t), NULL, 0, NULL, 0);
   sc_scda_scdaret_to_errcode (ret, errcode, fc);
-  SC_SCDA_CHECK_COLL_ERR (errcode, fc, "fwrite_block: block_size not "
+  SC_SCDA_CHECK_COLL_ERR (errcode, fc, "fwrite_block: block_size is not "
                           "collective");
 
   /* TODO: respect encode parameter */
@@ -2018,7 +2018,7 @@ sc_scda_fread_count_entry_internal (sc_scda_fcontext_t *fc, char *ident,
   int                 count;
   int                 wrong_format, wrong_ident;
   long long unsigned  read_count;
-  size_t              len;
+  size_t              len = 0;
 
   SC_ASSERT (fc != NULL);
   SC_ASSERT (ident != NULL);
@@ -2323,10 +2323,18 @@ sc_scda_fread_block_data (sc_scda_fcontext_t *fc, sc_array_t *block_data,
 {
   int                 count_err;
   int                 wrong_usage;
+  sc_scda_ret_t       ret;
 
   SC_ASSERT (fc != NULL);
   SC_ASSERT (root >= 0);
   SC_ASSERT (errcode != NULL);
+
+  /* check if block_size is collective */
+  ret = sc_scda_check_coll_params (fc, (const char*) &block_size,
+                                   sizeof (size_t), NULL, 0, NULL, 0);
+  sc_scda_scdaret_to_errcode (ret, errcode, fc);
+  SC_SCDA_CHECK_COLL_ERR (errcode, fc, "fread_block_data: block_size is not "
+                          "collective");
 
   /* It is necessary that sc_scda_fread_section_header was called as last
    * function call on fc and that it returned the block section type.

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -2027,8 +2027,9 @@ sc_scda_fread_count_entry_internal (sc_scda_fcontext_t *fc, char *ident,
   SC_ASSERT (ident != NULL);
   SC_ASSERT (count_var != NULL);
 
-  *count_err = 0;
+  *ident = ' ';
   *count_var = 0;
+  *count_err = 0;
 
   /* read a count entry */
   mpiret = sc_io_read_at (fc->file, fc->accessed_bytes, count_entry,
@@ -2113,6 +2114,9 @@ sc_scda_fread_section_header (sc_scda_fcontext_t *fc, char *user_string,
   SC_ASSERT (elem_size != NULL);
   SC_ASSERT (decode != NULL);
   SC_ASSERT (errcode != NULL);
+
+  *elem_count = 0;
+  *elem_size = 0;
 
   /* read the common section header part first */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -410,13 +410,13 @@ sc_scda_pad_to_mod (const char *input_data, size_t input_len,
   /* check for last byte to decide on padding format */
   if (input_len > 0 && input_data[input_len - 1] == '\n') {
     /* input data ends with a line break */
-    padding[input_len] = '=';
+    padding[0] = '=';
   }
   else {
     /* add a line break add the beginning of the padding */
-    padding[input_len] = '\n';
+    padding[0] = '\n';
   }
-  padding[input_len + 1] = '=';
+  padding[1] = '=';
 
   /* append the remaining padding bytes */
   sc_scda_set_bytes (&padding[2], '=', num_pad_bytes - 4);

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -830,7 +830,7 @@ sc_scda_fcontext_t *sc_scda_fread_inline_data (sc_scda_fcontext_t * fc,
  * sc_scda_fread_section_header. This preceding call gives also the required
  * \b block_size.
  * \note
- * All parameters except of \b data_block are collective.
+ * All parameters except of \b block_data are collective.
  *
  * This function returns NULL on I/O errors.
  *

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -145,6 +145,8 @@ main (int argc, char **argv)
     mpiret =
       sc_MPI_Bcast (&scda_opt.fuzzy_seed, 1, sc_MPI_UNSIGNED, 0, mpicomm);
     SC_CHECK_MPI (mpiret);
+    SC_GLOBAL_INFOF ("Fuzzy error return with time-dependent seed activated. "
+                     "The seed is %lld.\n", (long long) scda_opt.fuzzy_seed);
   }
   else {
     scda_opt.fuzzy_seed = (sc_rand_state_t) int_seed;

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -140,7 +140,7 @@ main (int argc, char **argv)
    * able to handle this situations properly.
    */
   scda_opt.fuzzy_everyn = (unsigned) int_everyn;
-  if (int_seed < 0) {
+  if (scda_opt.fuzzy_everyn > 0 && int_seed < 0) {
     scda_opt.fuzzy_seed = (sc_rand_state_t) sc_MPI_Wtime ();
     mpiret =
       sc_MPI_Bcast (&scda_opt.fuzzy_seed, 1, sc_MPI_UNSIGNED, 0, mpicomm);

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -169,6 +169,13 @@ main (int argc, char **argv)
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fwrite_inline with empty user string failed");
 
+  /* write a block section */
+  fc = sc_scda_fwrite_block (fc, "A block section", NULL, &data, 32,
+                             mpisize - 1, 0, &errcode);
+  /* TODO: check errcode */
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "scda_fwrite_block failed");
+
   sc_scda_fclose (fc, &errcode);
   /* TODO: check errcode and return value */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),


### PR DESCRIPTION
# scda: Write and read block sections

This PR continues the implementation of the scda file format (cf. https://github.com/cburstedde/libsc/pull/199) by introducing the functionalities for writing and reading block sections. The changes in this PR are in particular
- implementation of `fwrite_block` and `fread_block_data`,
- extension of  `fread_section_header` to also handle block section headers,
- internal functions to read and write count entries appearing in section headers,
- a generic internal function to check if parameters are collective,
- extension of the set of internal padding functions to support outputting the padding bytes into a separate buffer, next to the already existing inplace option. This is used in `fwrite_block` since the block data is allocated by the user and inplace padding would thus require a copy of the block data.  
- For the sake of generality:  Extension of the calculation of the number of modulo padding bytes  in `sc_scda_pad_to_mod_len` to the case `SC_SCDA_PADDING_MOD < 7`.

