### PR TITLE
scda: Write and read fixed-length array sections

### DIFF
--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -3083,7 +3083,9 @@ sc_scda_fread_block_data (sc_scda_fcontext_t *fc, sc_array_t *block_data,
   if (fc->mpirank == root) {
     const char         *last_byte;
 
-    last_byte = (block_size > 0) ? &block_data->array[block_size - 1] : NULL;
+    last_byte = (block_size > 0
+                 && block_data !=
+                 NULL) ? &block_data->array[block_size - 1] : NULL;
     sc_scda_fread_mod_padding_serial (fc, last_byte, block_size, &count_err,
                                       errcode);
   }

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1724,6 +1724,7 @@ sc_scda_fwrite_block_data_serial (sc_scda_fcontext_t *fc,
   size_t              num_pad_bytes;
   /* \ref SC_SCDA_PADDING_MOD + 6 is the maximum number of mod padding bytes */
   char                padding[SC_SCDA_PADDING_MOD + 6];
+  const char         *last_byte;
 
   *count_err = 0;
 
@@ -1743,7 +1744,8 @@ sc_scda_fwrite_block_data_serial (sc_scda_fcontext_t *fc,
 
   /* get the padding bytes */
   num_pad_bytes = sc_scda_pad_to_mod_len (block_size);
-  sc_scda_pad_to_mod (&block_data->array[block_size - 1], block_size, padding);
+  last_byte = (block_size > 0) ? &block_data->array[block_size - 1] : NULL;
+  sc_scda_pad_to_mod (last_byte, block_size, padding);
 
   /* write the padding bytes */
   mpiret = sc_io_write_at (fc->file, fc->accessed_bytes + block_size,
@@ -2073,7 +2075,7 @@ sc_scda_fwrite_array (sc_scda_fcontext_t *fc, const char *user_string,
                                array_data->array, bytes_to_write, sc_MPI_BYTE,
                                &count);
   sc_scda_mpiret_to_errcode (mpiret, errcode, fc);
-  SC_SCDA_CHECK_COLL_ERR (errcode, fc, "Writing fixed-length array padding");
+  SC_SCDA_CHECK_COLL_ERR (errcode, fc, "Writing fixed-length array data");
   /* check for count error of the collective I/O operation */
   SC_SCDA_CHECK_COLL_COUNT_ERR (bytes_to_write, count, fc, errcode);
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1812,7 +1812,8 @@ sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
  *                          sc_scda_fwrite_array.
  * \param [in] len          As in the documentation of \ref
  *                          sc_scda_fwrite_array.
- * TODO
+ * \param [in] elem_count   As in the documentation of \ref
+ *                          sc_scda_fwrite_array.
  * \param [in] elem_size    As in the documentation of \ref
  *                          sc_scda_fwrite_array.
  * \param [out] count_err   A Boolean indicating if a count error occurred.

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -2387,8 +2387,6 @@ sc_scda_fread_section_header_common_internal (sc_scda_fcontext_t *fc,
 
 /** Internal function to check a count entry in a section header.
  *
- * This code is only valid to be run in serial.
- *
  * \param [in] fc           The file context as in \ref
  *                          sc_scda_fread_section_header before running the
  *                          second serial code part.
@@ -2495,7 +2493,8 @@ sc_scda_check_count_entry_internal (const char *count_entry, char expc_ident,
  *
  * This function is only valid to be called in serial.
  * This function updates \b fc->accessed_bytes. Hence, it is crucial that
- * \b fc->accessed_bytes is set collectivley afterwards.
+ * \b fc->accessed_bytes is set on all other ranks afterwards to ensure
+ * a collective internal file pointer.
  *
  * \param [in]  fc          The file context as in \ref
  *                          sc_scda_fread_section_header before running the
@@ -2544,7 +2543,8 @@ sc_scda_fread_block_header_internal (sc_scda_fcontext_t *fc, size_t *elem_size,
  *
  * This function is only valid to be called in serial.
  * This function updates \b fc->accessed_bytes. Hence, it is crucial that
- * \b fc->accessed_bytes is set collectivley afterwards.
+ * \b fc->accessed_bytes is set on all other ranks afterwards to ensure
+ * a collective internal file pointer.
  *
  * \param [in]  fc          The file context as in \ref
  *                          sc_scda_fread_section_header before running the

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -563,7 +563,7 @@ sc_scda_pad_to_mod_inplace (const char *input_data, size_t input_len,
  * requires this byte.
  *
  * \param [in]  last_byte     Pointer to the last data byte.
- *                            This byte is required since the padding byte
+ *                            This byte is required since the padding
  *                            content depends on the trailing data byte.
  * \param [in]  data_len      The raw data length in number of bytes.
  * \param [in]  pad           The padding bytes with byte count \b pad_len.
@@ -2051,7 +2051,7 @@ sc_scda_check_array_params (sc_scda_fcontext_t *fc, sc_array_t *array_data,
 
   /* check elem_counts array */
   invalid_elem_counts = !(elem_counts->elem_size == sizeof (sc_scda_ulong) &&
-                          elem_counts->elem_count == fc->mpisize);
+                          elem_counts->elem_count == (size_t) fc->mpisize);
   /* synchronize */
   mpiret =
     sc_MPI_Allreduce (&invalid_elem_counts, &global_invalid_elem_counts, 1,

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1281,9 +1281,9 @@ sc_scda_get_common_section_header (char section_char, const char* user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fopen_write_header_internal (sc_scda_fcontext_t *fc,
-                                     const char *user_string, size_t *len,
-                                     int *count_err, sc_scda_ferror_t *errcode)
+sc_scda_fopen_write_header_serial (sc_scda_fcontext_t *fc,
+                                   const char *user_string, size_t *len,
+                                   int *count_err, sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1403,13 +1403,13 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
   SC_SCDA_CHECK_COLL_ERR (errcode, fc, "File open write");
 
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fopen_write_header_internal (fc, user_string, len, &count_err,
-                                         errcode);
+    sc_scda_fopen_write_header_serial (fc, user_string, len, &count_err,
+                                       errcode);
   }
   /* This macro must be the first expression after the non-collective code part
    * since it must be the point where \ref SC_SCDA_CHECK_NONCOLL_ERR and \ref
    * SC_SCDA_CHECK_NONCOLL_COUNT_ERR can jump to, which are called in \ref
-   * sc_scda_fopen_write_header_internal. The macro handles the non-collective
+   * sc_scda_fopen_write_header_serial. The macro handles the non-collective
    * error, i.e. it broadcasts the errcode, which may encode success, from
    * rank 0 to all other ranks and in case of an error it closes the file,
    * frees the file context and returns NULL. Hence, it is valid that errcode
@@ -1428,7 +1428,7 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
    * that it is valid that errcode is only initialized on rank 0 before calling
    * this macro. The macro argument count_err must point to the count error
    * Boolean that was set on rank SC_SCDA_HEADER_ROOT by \ref
-   * sc_scda_fopen_write_header_internal.
+   * sc_scda_fopen_write_header_serial.
    */
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, SC_SCDA_HEADER_ROOT,
                                     fc);
@@ -1459,10 +1459,9 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_inline_header_internal (sc_scda_fcontext_t *fc,
-                                       const char *user_string, size_t *len,
-                                       int *count_err,
-                                       sc_scda_ferror_t *errcode)
+sc_scda_fwrite_inline_header_serial (sc_scda_fcontext_t *fc,
+                                     const char *user_string, size_t *len,
+                                     int *count_err, sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1512,9 +1511,9 @@ sc_scda_fwrite_inline_header_internal (sc_scda_fcontext_t *fc,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_inline_data_internal (sc_scda_fcontext_t *fc,
-                                     sc_array_t * inline_data, int *count_err,
-                                     sc_scda_ferror_t * errcode)
+sc_scda_fwrite_inline_data_serial (sc_scda_fcontext_t *fc,
+                                   sc_array_t * inline_data, int *count_err,
+                                   sc_scda_ferror_t * errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1553,8 +1552,8 @@ sc_scda_fwrite_inline (sc_scda_fcontext_t *fc, const char *user_string,
 
   /* The file header section is always written and read on rank 0. */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fwrite_inline_header_internal (fc, user_string, len, &count_err,
-                                           errcode);
+    sc_scda_fwrite_inline_header_serial (fc, user_string, len, &count_err,
+                                         errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, SC_SCDA_HEADER_ROOT, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, SC_SCDA_HEADER_ROOT,
@@ -1565,8 +1564,8 @@ sc_scda_fwrite_inline (sc_scda_fcontext_t *fc, const char *user_string,
 
   /* The inline data is written on the the user-defined rank root. */
   if (fc->mpirank == root) {
-    sc_scda_fwrite_inline_data_internal (fc, inline_data, &count_err,
-                                         errcode);
+    sc_scda_fwrite_inline_data_serial (fc, inline_data, &count_err,
+                                       errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);
@@ -1650,10 +1649,10 @@ sc_scda_get_section_header_entry (char ident, size_t var, char *output)
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_block_header_internal (sc_scda_fcontext_t *fc,
-                                      const char *user_string, size_t *len,
-                                      size_t block_size, int *count_err,
-                                      sc_scda_ferror_t *errcode)
+sc_scda_fwrite_block_header_serial (sc_scda_fcontext_t *fc,
+                                    const char *user_string, size_t *len,
+                                    size_t block_size, int *count_err,
+                                    sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1715,9 +1714,9 @@ sc_scda_fwrite_block_header_internal (sc_scda_fcontext_t *fc,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_block_data_internal (sc_scda_fcontext_t *fc,
-                                     sc_array_t * block_data, size_t block_size,
-                                     int *count_err, sc_scda_ferror_t * errcode)
+sc_scda_fwrite_block_data_serial (sc_scda_fcontext_t *fc,
+                                  sc_array_t * block_data, size_t block_size,
+                                  int *count_err, sc_scda_ferror_t * errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1781,8 +1780,8 @@ sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
 
   /* section header is always written and read on rank SC_SCDA_HEADER_ROOT */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fwrite_block_header_internal (fc, user_string, len, block_size,
-                                          &count_err, errcode);
+    sc_scda_fwrite_block_header_serial (fc, user_string, len, block_size,
+                                        &count_err, errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, SC_SCDA_HEADER_ROOT, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, SC_SCDA_HEADER_ROOT,
@@ -1793,8 +1792,8 @@ sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
 
   /* The block data is written on the the user-defined rank root. */
   if (fc->mpirank == root) {
-    sc_scda_fwrite_block_data_internal (fc, block_data, block_size,
-                                        &count_err, errcode);
+    sc_scda_fwrite_block_data_serial (fc, block_data, block_size,
+                                      &count_err, errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);
@@ -1827,10 +1826,10 @@ sc_scda_fwrite_block (sc_scda_fcontext_t *fc, const char *user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_array_header_internal (sc_scda_fcontext_t *fc,
-                                      const char *user_string, size_t *len,
-                                      size_t elem_count, size_t elem_size,
-                                      int *count_err, sc_scda_ferror_t *errcode)
+sc_scda_fwrite_array_header_serial (sc_scda_fcontext_t *fc,
+                                    const char *user_string, size_t *len,
+                                    size_t elem_count, size_t elem_size,
+                                    int *count_err, sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -1904,9 +1903,9 @@ sc_scda_fwrite_array_header_internal (sc_scda_fcontext_t *fc,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fwrite_padding_internal (sc_scda_fcontext_t *fc, const char *last_byte,
-                                 size_t byte_count, int *count_err,
-                                 sc_scda_ferror_t *errcode)
+sc_scda_fwrite_padding_serial (sc_scda_fcontext_t *fc, const char *last_byte,
+                               size_t byte_count, int *count_err,
+                               sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -2028,8 +2027,8 @@ sc_scda_fwrite_array (sc_scda_fcontext_t *fc, const char *user_string,
 
   /* section header is always written and read on rank SC_SCDA_HEADER_ROOT */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fwrite_array_header_internal (fc, user_string, len, elem_count,
-                                          elem_size, &count_err, errcode);
+    sc_scda_fwrite_array_header_serial (fc, user_string, len, elem_count,
+                                        elem_size, &count_err, errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, SC_SCDA_HEADER_ROOT, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, SC_SCDA_HEADER_ROOT,
@@ -2094,8 +2093,8 @@ sc_scda_fwrite_array (sc_scda_fcontext_t *fc, const char *user_string,
     last_byte = (elem_count > 0) ?
                               &array_data->array[bytes_to_write - 1] : NULL;
     /* the padding depends on the last data byte */
-    sc_scda_fwrite_padding_internal (fc, last_byte, collective_byte_count,
-                                     &count_err, errcode);
+    sc_scda_fwrite_padding_serial (fc, last_byte, collective_byte_count,
+                                   &count_err, errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, last_byte_owner, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, last_byte_owner, fc);
@@ -2196,9 +2195,9 @@ sc_scda_check_file_header (const char *file_header_data, char *user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fopen_read_header_internal (sc_scda_fcontext_t * fc,
-                                    char *user_string, size_t *len,
-                                    int *count_err, sc_scda_ferror_t *errcode)
+sc_scda_fopen_read_header_serial (sc_scda_fcontext_t * fc,
+                                  char *user_string, size_t *len,
+                                  int *count_err, sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -2274,8 +2273,8 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
 
   /* read file header section on rank SC_SCDA_HEADER_ROOT */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fopen_read_header_internal (fc, user_string, len, &count_err,
-                                        errcode);
+    sc_scda_fopen_read_header_serial (fc, user_string, len, &count_err,
+                                      errcode);
   }
   /* The macro to handle a non-collective error that is associated to a
    * preceding call of \ref SC_SCDA_CHECK_NONCOLL_ERR.
@@ -2322,10 +2321,10 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fread_section_header_common_internal (sc_scda_fcontext_t *fc,
-                                              char *type, char *user_string,
-                                              size_t *len, int *count_err,
-                                              sc_scda_ferror_t *errcode)
+sc_scda_fread_section_header_common_serial (sc_scda_fcontext_t *fc,
+                                            char *type, char *user_string,
+                                            size_t *len, int *count_err,
+                                            sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -2506,8 +2505,8 @@ sc_scda_check_count_entry_internal (const char *count_entry, char expc_ident,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fread_block_header_internal (sc_scda_fcontext_t *fc, size_t *elem_size,
-                                     int *count_err, sc_scda_ferror_t *errcode)
+sc_scda_fread_block_header_serial (sc_scda_fcontext_t *fc, size_t *elem_size,
+                                   int *count_err, sc_scda_ferror_t *errcode)
 {
   char                count_entry[SC_SCDA_COUNT_FIELD];
   int                 mpiret;
@@ -2556,9 +2555,9 @@ sc_scda_fread_block_header_internal (sc_scda_fcontext_t *fc, size_t *elem_size,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fread_array_header_internal (sc_scda_fcontext_t *fc, size_t *elem_count,
-                                     size_t *elem_size, int *count_err,
-                                     sc_scda_ferror_t *errcode)
+sc_scda_fread_array_header_serial (sc_scda_fcontext_t *fc, size_t *elem_count,
+                                   size_t *elem_size, int *count_err,
+                                   sc_scda_ferror_t *errcode)
 {
   char                count_entry[SC_SCDA_COUNT_FIELD];
   int                 mpiret;
@@ -2632,8 +2631,8 @@ sc_scda_fread_section_header (sc_scda_fcontext_t *fc, char *user_string,
 
   /* read the common section header part first */
   if (fc->mpirank == SC_SCDA_HEADER_ROOT) {
-    sc_scda_fread_section_header_common_internal (fc, type, user_string, len,
-                                                  &count_err, errcode);
+    sc_scda_fread_section_header_common_serial (fc, type, user_string, len,
+                                                &count_err, errcode);
   }
   SC_SCDA_HANDLE_NONCOLL_ERR (errcode, SC_SCDA_HEADER_ROOT, fc);
   SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, SC_SCDA_HEADER_ROOT,
@@ -2649,11 +2648,11 @@ sc_scda_fread_section_header (sc_scda_fcontext_t *fc, char *user_string,
       /* no count entries to read */
       break;
     case 'B':
-      sc_scda_fread_block_header_internal (fc, elem_size, &count_err, errcode);
+      sc_scda_fread_block_header_serial (fc, elem_size, &count_err, errcode);
       break;
     case 'A':
-      sc_scda_fread_array_header_internal (fc, elem_count, elem_size,
-                                           &count_err, errcode);
+      sc_scda_fread_array_header_serial (fc, elem_count, elem_size,
+                                         &count_err, errcode);
       break;
     default:
       /* rank SC_SCDA_HEADER_ROOT already checked if type is valid/supported */
@@ -2732,9 +2731,8 @@ sc_scda_fread_section_header (sc_scda_fcontext_t *fc, char *user_string,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fread_inline_data_serial_internal (sc_scda_fcontext_t *fc,
-                                           sc_array_t *data, int *count_err,
-                                           sc_scda_ferror_t *errcode)
+sc_scda_fread_inline_data_serial (sc_scda_fcontext_t *fc, sc_array_t *data,
+                                  int *count_err, sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -2778,7 +2776,7 @@ sc_scda_fread_inline_data (sc_scda_fcontext_t *fc, sc_array_t *data, int root,
   if (data != NULL) {
     /* the data is not skipped */
     if (fc->mpirank == root) {
-      sc_scda_fread_inline_data_serial_internal (fc, data, &count_err, errcode);
+      sc_scda_fread_inline_data_serial (fc, data, &count_err, errcode);
     }
     SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
     SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);
@@ -2808,10 +2806,9 @@ sc_scda_fread_inline_data (sc_scda_fcontext_t *fc, sc_array_t *data, int root,
  *                          by \ref sc_scda_ferror_class.
  */
 static void
-sc_scda_fread_block_data_serial_internal (sc_scda_fcontext_t *fc,
-                                          sc_array_t *data, size_t block_size,
-                                          int *count_err,
-                                          sc_scda_ferror_t *errcode)
+sc_scda_fread_block_data_serial (sc_scda_fcontext_t *fc, sc_array_t *data,
+                                 size_t block_size, int *count_err,
+                                 sc_scda_ferror_t *errcode)
 {
   int                 mpiret;
   int                 count;
@@ -2884,8 +2881,8 @@ sc_scda_fread_block_data (sc_scda_fcontext_t *fc, sc_array_t *block_data,
   if (block_data != NULL) {
     /* the data is not skipped */
     if (fc->mpirank == root) {
-      sc_scda_fread_block_data_serial_internal (fc, block_data, block_size,
-                                                &count_err, errcode);
+      sc_scda_fread_block_data_serial(fc, block_data, block_size, &count_err,
+                                      errcode);
     }
     SC_SCDA_HANDLE_NONCOLL_ERR (errcode, root, fc);
     SC_SCDA_HANDLE_NONCOLL_COUNT_ERR (errcode, &count_err, root, fc);

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -302,7 +302,7 @@ sc_scda_merge_data_to_buf (const char *d1, size_t len1, const char *d2,
   }
   if (d3 != NULL) {
     SC_ASSERT (d2 != NULL);
-    sc_scda_copy_bytes (&out[len2], d3, len3);
+    sc_scda_copy_bytes (&out[len1 + len2], d3, len3);
   }
 }
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -2513,28 +2513,24 @@ sc_scda_fread_section_header_common_serial (sc_scda_fcontext_t *fc,
 
 /** Internal function to check a count entry in a section header.
  *
- * \param [in] fc           The file context as in \ref
- *                          sc_scda_fread_section_header before running the
- *                          second serial code part.
- * \param [out] ident       The character that identifies the count entry.
- *                          If this character is not conforming to the scda
- *                          convention, the function call is not completed and
- *                          results in \ref SC_SCDA_FERR_FORMAT as error,
- *                          cf. \b errcode.
+ * This function checks if the count entry is conforming to the scda format.
+ *
+ * \param [in] count_entry  A pointer to a count entry that was read from file.
+ *                          The count entry has exactly \ref SC_SCDA_COUNT_FIELD
+ *                          bytes.
  * \param [in] expc_ident   The expected count entry identifier. If the read
  *                          identifier is not as expected the function returns
- *                          false.
+ *                          true. Note that the function also returns true if
+ *                          the count entry identifier coincides with
+ *                          \b expc_ident but is not in the list of supported
+ *                          count identifiers (currently 'E' and 'N').
  * \param [out] count_var   The count variable read from the count entry.
- * \param [out] count_err   A Boolean indicating if a count error occurred.
- *                          For this parameter the term count refers to the
- *                          expected byte count for reading count (different
- *                          count) entry.
- * \return                  True if the count entry is valid and has the
- *                          expected identifier.
+ * \return                  False if the count entry is valid and has the
+ *                          expected identifier. True, otherwise.
  */
 static int
-sc_scda_check_count_entry_internal (const char *count_entry, char expc_ident,
-                                    size_t *count_var)
+sc_scda_check_count_entry (const char *count_entry, char expc_ident,
+                           size_t *count_var)
 {
   char                var_str[SC_SCDA_COUNT_MAX_DIGITS + 1];
   char                ident;
@@ -2654,8 +2650,8 @@ sc_scda_fread_block_header_serial (sc_scda_fcontext_t *fc, size_t *elem_size,
   SC_SCDA_CHECK_NONCOLL_COUNT_ERR (SC_SCDA_COUNT_FIELD, count, count_err);
 
   /* check read count entry */
-  invalid_count_entry = sc_scda_check_count_entry_internal (count_entry, 'E',
-                                                            elem_size);
+  invalid_count_entry = sc_scda_check_count_entry (count_entry, 'E',
+                                                   elem_size);
   sc_scda_scdaret_to_errcode (invalid_count_entry ? SC_SCDA_FERR_FORMAT :
                                                     SC_SCDA_FERR_SUCCESS,
                               errcode, fc);
@@ -2705,8 +2701,8 @@ sc_scda_fread_array_header_serial (sc_scda_fcontext_t *fc, size_t *elem_count,
   SC_SCDA_CHECK_NONCOLL_COUNT_ERR (SC_SCDA_COUNT_FIELD, count, count_err);
 
   /* check read count entry */
-  invalid_count_entry = sc_scda_check_count_entry_internal (count_entry,'N',
-                                                            elem_count);
+  invalid_count_entry = sc_scda_check_count_entry (count_entry,'N',
+                                                   elem_count);
   sc_scda_scdaret_to_errcode (invalid_count_entry ? SC_SCDA_FERR_FORMAT :
                                                     SC_SCDA_FERR_SUCCESS,
                               errcode, fc);
@@ -2724,8 +2720,8 @@ sc_scda_fread_array_header_serial (sc_scda_fcontext_t *fc, size_t *elem_count,
   SC_SCDA_CHECK_NONCOLL_COUNT_ERR (SC_SCDA_COUNT_FIELD, count, count_err);
 
   /* check read count entry */
-  invalid_count_entry = sc_scda_check_count_entry_internal (count_entry, 'E',
-                                                            elem_size);
+  invalid_count_entry = sc_scda_check_count_entry (count_entry, 'E',
+                                                   elem_size);
   sc_scda_scdaret_to_errcode (invalid_count_entry ? SC_SCDA_FERR_FORMAT :
                                                     SC_SCDA_FERR_SUCCESS,
                               errcode, fc);

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1746,14 +1746,14 @@ sc_scda_fwrite_block_data_serial (sc_scda_fcontext_t *fc,
 
 /** Internal function to write mod data padding.
  *
- * This function is only valid to be called on a rank that stores the global
+ * This function is intended to be called on a rank that stores the global
  * last data byte. For block sections, this is the root rank and for (v)array
  * sections the maximal not empty rank.
  *
  * \param [in] fc           The file context after writing the data that is
  *                          intended to be padded.
  * \param [in] last_byte    A pointer to the last global data byte. For
- *                          \b byte_count = 0 NULL is valid.
+ *                          \b byte_count = 0 \b last_byte must be NULL.
  * \param [in] byte_count   Number of (collectively) written bytes in the
  *                          preceding data writing I/O operation.
  * \param [out] count_err   A Boolean indicating if a count error occurred.
@@ -1771,6 +1771,8 @@ sc_scda_fwrite_mod_padding_serial (sc_scda_fcontext_t *fc,
   size_t              num_pad_bytes;
   /* \ref SC_SCDA_PADDING_MOD + 6 is the maximum number of mod padding bytes */
   char                padding[SC_SCDA_PADDING_MOD + 6];
+
+  SC_ASSERT (byte_count != 0 || last_byte == NULL);
 
   *count_err = 0;
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -3151,7 +3151,7 @@ sc_scda_fread_array_data (sc_scda_fcontext_t *fc, sc_array_t *array_data,
     data = NULL;
   }
 
-  if (indirect) {
+  if (indirect && array_data != NULL) {
     /* TODO: batches */
     /* read to contiguous temporary buffer */
     sc_array_init_size (&conti_arr, elem_size, elem_count);
@@ -3187,7 +3187,7 @@ sc_scda_fread_array_data (sc_scda_fcontext_t *fc, sc_array_t *array_data,
   fc->accessed_bytes +=
     (sc_MPI_Offset) sc_scda_pad_to_mod_len (collective_byte_count);
 
-  if (indirect) {
+  if (indirect && array_data != NULL) {
     sc_array_t         *curr;
     const char         *src;
     char               *dest;

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -560,10 +560,12 @@ sc_scda_pad_to_mod_inplace (const char *input_data, size_t input_len,
 /** Check if the padding bytes are correct w.r.t. \ref SC_SCDA_PADDING_MOD.
  *
  * Since the mod padding depends on the trailing data byte this function also
- * requires the raw data.
+ * requires this byte.
  *
- * \param [in]  data          The raw data with byte count \b data_len.
- * \param [in]  data_len      The length of \b data in number of bytes.
+ * \param [in]  last_byte     Pointer to the last data byte.
+ *                            This byte is required since the padding byte
+ *                            content depends on the trailing data byte.
+ * \param [in]  data_len      The raw data length in number of bytes.
  * \param [in]  pad           The padding bytes with byte count \b pad_len.
  * \param [in]  pad_len       The length of \b pad in number of bytes.
  *                            Must be at least 7.
@@ -572,8 +574,8 @@ sc_scda_pad_to_mod_inplace (const char *input_data, size_t input_len,
  *                            condition. False, otherwise.
  */
 static int
-sc_scda_check_pad_to_mod (const char* data, size_t data_len, const char *pad,
-                          size_t pad_len)
+sc_scda_check_pad_to_mod (const char* last_byte, size_t data_len,
+                          const char *pad, size_t pad_len)
 {
   size_t              si;
   size_t              num_pad_bytes;
@@ -605,7 +607,7 @@ sc_scda_check_pad_to_mod (const char* data, size_t data_len, const char *pad,
 
   /* padding depends on the trailing data byte */
   if ((!((pad[si] == '=' && data_len != 0 &&
-          data[data_len - 1] == '\n') || pad[si] == '\n'))) {
+          *last_byte == '\n') || pad[si] == '\n'))) {
     /* wrong padding start */
     return -1;
   }
@@ -644,8 +646,8 @@ sc_scda_get_pad_to_mod (const char *padded_data, size_t padded_len,
     return -1;
   }
 
-  if (sc_scda_check_pad_to_mod (padded_data, raw_len, &padded_data[raw_len],
-                                padded_len - raw_len)) {
+  if (sc_scda_check_pad_to_mod (&padded_data[raw_len - 1], raw_len,
+                                &padded_data[raw_len], padded_len - raw_len)) {
     /* invalid padding bytes */
     return -1;
   }

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -638,6 +638,8 @@ static int
 sc_scda_get_pad_to_mod (const char *padded_data, size_t padded_len,
                         size_t raw_len, char *raw_data)
 {
+  const char         *last_byte;
+
   SC_ASSERT (padded_data != NULL);
   SC_ASSERT (raw_len == 0 || raw_data != NULL);
 
@@ -646,8 +648,9 @@ sc_scda_get_pad_to_mod (const char *padded_data, size_t padded_len,
     return -1;
   }
 
-  if (sc_scda_check_pad_to_mod (&padded_data[raw_len - 1], raw_len,
-                                &padded_data[raw_len], padded_len - raw_len)) {
+  last_byte = (raw_len > 0) ? &padded_data[raw_len - 1] : NULL;
+  if (sc_scda_check_pad_to_mod (last_byte, raw_len, &padded_data[raw_len],
+                                padded_len - raw_len)) {
     /* invalid padding bytes */
     return -1;
   }

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1940,6 +1940,8 @@ sc_scda_fwrite_array_header_serial (sc_scda_fcontext_t *fc,
  * \param [in] elem_counts  As the parameter \b elem_counts in \ref
  *                          sc_scda_fwrite_array or \ref sc_scda_fwrite_varray.
  *                          This array stores the number of elements per rank.
+ *                          The element count of \b elem_counts must be equal
+ *                          to \b fc->mpisize.
  * \return                  The maximal rank that is not empty. If all ranks
  *                          are empty, 0 is returned.
  */
@@ -1951,6 +1953,8 @@ sc_scda_get_last_byte_owner (sc_scda_fcontext_t *fc, sc_array_t *elem_counts)
 
   SC_ASSERT (fc != NULL);
   SC_ASSERT (elem_counts != NULL);
+  SC_ASSERT (elem_counts->elem_size == sizeof (sc_scda_ulong));
+  SC_ASSERT ((size_t) fc->mpisize == elem_counts->elem_count);
 
   /* determine the rank that holds the last byte */
   last_byte_owner = 0;
@@ -1993,7 +1997,7 @@ sc_scda_get_local_partition_index (sc_scda_fcontext_t *fc,
   SC_ASSERT (fc != NULL);
   SC_ASSERT (elem_counts != NULL);
   SC_ASSERT (elem_counts->elem_size == sizeof (sc_scda_ulong));
-  SC_ASSERT ((int) elem_counts->elem_count == fc->mpisize);
+  SC_ASSERT ((size_t) fc->mpisize == elem_counts->elem_count);
 
   /* compute rank-dependent offset */
   *offset = 0;
@@ -2005,7 +2009,7 @@ sc_scda_get_local_partition_index (sc_scda_fcontext_t *fc,
   }
   *offset *= (sc_MPI_Offset) elem_size;
 
-  /* computer number of local array data bytes */
+  /* compute the number of local array data bytes */
   num_local_elements =
     (int) *((sc_scda_ulong *) sc_array_index_int (elem_counts, fc->mpirank));
   *num_bytes = (int) elem_size * num_local_elements;

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -3152,7 +3152,7 @@ sc_scda_fread_array_data (sc_scda_fcontext_t *fc, sc_array_t *array_data,
   }
 
   if (indirect && array_data != NULL) {
-    /* TODO: batches */
+    /* TODO: batches? */
     /* read to contiguous temporary buffer */
     sc_array_init_size (&conti_arr, elem_size, elem_count);
     data = (void *) conti_arr.array;

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -429,6 +429,10 @@ sc_scda_fcontext_t *sc_scda_fwrite_inline (sc_scda_fcontext_t * fc,
  * \param [in]      block_data  On rank \b root a sc_array with one element and
  *                              element size equals to \b block_size. On all
  *                              other ranks the parameter is ignored.
+ *                              Since \ref sc_array_init and the other \ref
+ *                              sc_array_t initialization functions do not allow
+ *                              an element size of 0, block sections can not be
+ *                              empty.
  * \param [in]      block_size  The size of the data block in bytes. Must be
  *                              less or equal than 10^{26} - 1.
  * \param [in]      root        An integer between 0 and mpisize of the MPI

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -27,6 +27,31 @@
 #define SC_SCDA_FILE_EXT "scd"
 #define SC_SCDA_TEST_FILE "sc_test_scda." SC_SCDA_FILE_EXT
 
+static void
+test_scda_write_fixed_size_array (sc_scda_fcontext_t *fc, int mpisize)
+{
+  int                 indirect = 0;
+  int                 i;
+  size_t              elem_size = 3;
+  sc_array_t          elem_counts;
+  sc_scda_ferror_t    errcode;
+
+  sc_array_init_count (&elem_counts, sizeof (sc_scda_ulong), mpisize);
+
+  /* set elem_counts */
+  for (i = 0; i < mpisize; ++i) {
+    /* partition dependent */
+    *((sc_scda_ulong *) sc_array_index_int (&elem_counts, i)) = 5;
+  }
+
+  fc = sc_scda_fwrite_array (fc, "A fixed-len array section", NULL, NULL,
+                             &elem_counts, elem_size, indirect, 0, &errcode);
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "sc_scda_fwrite_array failed");
+
+  sc_array_reset (&elem_counts);
+}
+
 int
 main (int argc, char **argv)
 {
@@ -187,6 +212,9 @@ main (int argc, char **argv)
   /* TODO: check errcode */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fwrite_block failed");
+
+  /* write a fixed-size array section */
+  test_scda_write_fixed_size_array (fc, mpisize);
 
   /* intentionally try to write with non-collective block size */
   if (mpisize > 1) {

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -45,7 +45,6 @@ test_scda_skip_through_file (sc_MPI_Comm mpicomm, const char *filename,
   sc_scda_ferror_t    errcode;
   sc_array_t          elem_counts, data;
 
-  /* TODO, also non-collective skip */
   /* open the file for reading */
   fc = sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, opt,
                            &errcode);
@@ -159,6 +158,7 @@ test_scda_skip_through_file (sc_MPI_Comm mpicomm, const char *filename,
                   && elem_size == 3, "Identifying section type");
 
   /* define reading partition */
+  /* Even if all array data is skipped, a valid reading partition is required. */
   for (i = 0; i < mpisize; ++i) {
     *((sc_scda_ulong *) sc_array_index_int (&elem_counts, i)) = 0;
   }

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -95,7 +95,9 @@ test_scda_write_fixed_size_array (sc_scda_fcontext_t *fc, int mpirank,
 static void
 test_scda_read_fixed_size_array (sc_scda_fcontext_t *fc)
 {
+#if 0
   const int           indirect = 0;
+#endif
   int                 decode;
   char                read_user_string[SC_SCDA_USER_STRING_BYTES + 1];
   char                section_type;

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -31,11 +31,11 @@ static void
 test_scda_write_fixed_size_array (sc_scda_fcontext_t *fc, int mpirank,
                                   int mpisize)
 {
-  int                 indirect = 0;
+  const int           indirect = 0;
   int                 i;
   char               *data_ptr;
   size_t              si;
-  size_t              elem_size = 3;
+  const size_t        elem_size = 3;
   size_t              local_elem_count;
   const sc_scda_ulong global_elem_count = 12;
   sc_scda_ulong       per_proc_count, remainder_count;
@@ -70,6 +70,20 @@ test_scda_write_fixed_size_array (sc_scda_fcontext_t *fc, int mpirank,
                              &elem_counts, elem_size, indirect, 0, &errcode);
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "sc_scda_fwrite_array failed");
+
+  /* write an empty array */
+
+  /* set elem_counts */
+  for (i = 0; i < mpisize; ++i) {
+    *((sc_scda_ulong *) sc_array_index_int (&elem_counts, i)) = 0;
+  }
+
+  sc_array_resize (&data, 0);
+
+  fc = sc_scda_fwrite_array (fc, "An empty array", NULL, &data,
+                             &elem_counts, elem_size, indirect, 0, &errcode);
+  SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
+                  "sc_scda_fwrite_array empty array failed");
 
   sc_array_reset (&elem_counts);
   sc_array_reset (&data);
@@ -146,7 +160,7 @@ main (int argc, char **argv)
   if (mpisize > 1) {
     SC_GLOBAL_ESSENTIAL
       ("We expect two invalid scda function parameter errors."
-       " This is just for testing purposes and do not imply"
+       " This is just for testing purposes and does not imply"
        " erroneous code behavior.\n");
   }
   /* fopen_write with non-collective fuzzy error parameters */

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -45,18 +45,20 @@ test_scda_write_fixed_size_array (sc_scda_fcontext_t *fc, int mpirank,
   sc_array_t          elem_counts, data;
   sc_scda_ferror_t    errcode;
 
-  sc_array_init_count (&elem_counts, sizeof (sc_scda_ulong), mpisize);
+  sc_array_init_count (&elem_counts, sizeof (sc_scda_ulong),
+                       (size_t) mpisize);
 
   /* get the counts per process */
   per_proc_count = global_elem_count / (sc_scda_ulong) mpisize;
   remainder_count = global_elem_count % (sc_scda_ulong) mpisize;
 
   /* set elem_counts */
-  for (i = 0; i < mpisize - 1; ++i) {
-    *((sc_scda_ulong *) sc_array_index_int (&elem_counts, i)) = per_proc_count;
+  for (i = 0; i < mpisize; ++i) {
+    *((sc_scda_ulong *) sc_array_index_int (&elem_counts, i)) =
+      per_proc_count;
   }
-  *((sc_scda_ulong *) sc_array_index_int (&elem_counts, mpisize - 1)) =
-                      (remainder_count == 0) ? per_proc_count : remainder_count;
+  *((sc_scda_ulong *) sc_array_index_int (&elem_counts, mpisize - 1)) +=
+    remainder_count;
 
   /* create local data */
   local_elem_count =


### PR DESCRIPTION
# scda: Write and read fixed-length array sections

This PR continues the implementation of the scda file format (cf. https://github.com/cburstedde/libsc/pull/202) by implementing the functionality to write and read fixed-length array sections.
Among others this PR also
- introduces a new macro to check MPI counts for collective I/O operations,
- changes the mod data padding functions to make the dependence on the last data byte explicit,
- renames all functions for serial I/O operations such that they have the common suffix `_serial`,
- adds and uses generic functions to write and read mod data padding,
- adds more internal generic functions and
- extends the tests.

Note: The indirect writing and reading of an array is currently implemented by using an internal contiguous buffer. I plan to improve this in a future PR.