### PR TITLE
Fix variable change check in CMake

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -98,11 +98,13 @@ set(SC_ENABLE_PTHREAD ${CMAKE_USE_PTHREADS_INIT})
 set(SC_ENABLE_MEMALIGN 1)
 
 # user has requested a different MPI setting, so we need to clear these cache variables to recheck
-if(NOT "${SC_ENABLE_MPI}" STREQUAL "$CACHE{SC_ENABLE_MPI}")
+if(NOT "${SC_ENABLE_MPI}" STREQUAL "${CACHED_SC_ENABLE_MPI}")
   unset(SC_ENABLE_MPICOMMSHARED CACHE)
   unset(SC_ENABLE_MPITHREAD CACHE)
   unset(SC_ENABLE_MPIWINSHARED CACHE)
   unset(SC_ENABLE_MPIIO CACHE)
+  # Update cached variable
+  set(CACHED_SC_ENABLE_MPI "${SC_ENABLE_MPI}" CACHE STRING "Cached value of SC_ENABLE_MPI")
 endif()
 
 if( SC_ENABLE_MPI )

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -24,3 +24,6 @@ endif()
 if (DEFINED mpi)
   set_property(CACHE SC_ENABLE_MPI PROPERTY VALUE "${mpi}")
 endif()
+
+# Store the MPI setting for the case the user changes the value
+set(CACHED_SC_ENABLE_MPI "${SC_ENABLE_MPI}" CACHE STRING "Cached value of SC_ENABLE_MPI")


### PR DESCRIPTION
# Fix variable change check in CMake

### Problem description
Reconfiguring with enabled MPI after starting from a CMake configuration with MPI disabled results in a setup with enabled MPI but deactivated  MPI I/O, which is deprecated. The expected behavior is that MPI I/O is enabled if MPI is enabled.

### Proposed changes
The issue arises because `$CACHE{SC_ENABLE_MPI}` reflects the current MPI setting rather than the previous one. As a result, the condition
```
NOT "${SC_ENABLE_MPI}" STREQUAL "$CACHE{SC_ENABLE_MPI}"
```
evaluates to false, preventing the check for MPI I/O when MPI was previously disabled. To address this, I introduced a new variable, `CACHED_SC_ENABLE_MPI`, to track the last MPI setting, ensuring that the last used value of `SC_ENABLE_MPI` is preserved.