### PR TITLE
scda: Custom MPI data type for indirect arrays

### DIFF
--- a/cmake/check_mpiaintdiff.cmake
+++ b/cmake/check_mpiaintdiff.cmake
@@ -1,0 +1,23 @@
+include(CheckCSourceCompiles)
+function(check_mpiaintdiff)
+
+  set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_C)
+
+  check_c_source_compiles(
+    "
+        #include <mpi.h>
+        int main(void) {
+          MPI_Aint a, b, res;
+          a = 42;
+          b = 12;
+          MPI_Init ((int *) 0, (char ***) 0);
+          res = MPI_Aint_diff (a, b);
+          MPI_Finalize ();
+          return 0;
+        }
+    "
+    SC_HAVE_AINT_DIFF)
+
+endfunction()
+
+check_mpiaintdiff()

--- a/cmake/check_mpiio.cmake
+++ b/cmake/check_mpiio.cmake
@@ -42,11 +42,6 @@ function(check_mpiio)
     "
     SC_ENABLE_MPIIO)
 
-    if( NOT SC_ENABLE_MPIIO )
-        message(WARNING "libsc MPI configured but MPI I/O is not configured/found: DEPRECATED")
-        message(NOTICE "This configuration is DEPRECATED and will be disallowed in the future.")
-        message(NOTICE "If the MPI File API is not available, please disable MPI altogether.")
-    endif()
 endfunction()
 
 check_mpiio()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -234,3 +234,12 @@ set(CMAKE_REQUIRED_DEFINITIONS)
 # libsc and current project must both be compiled with/without MPI
 check_symbol_exists("SC_ENABLE_MPI" ${PROJECT_BINARY_DIR}/include/sc_config.h SC_ENABLE_MPI)
 check_symbol_exists("SC_ENABLE_MPIIO" ${PROJECT_BINARY_DIR}/include/sc_config.h SC_ENABLE_MPIIO)
+
+# Check for deprecated MPI and MPI I/O configuration.
+# This is done at the end of config.cmake to ensure that the warning is visible
+# without scrolling.
+if (SC_ENABLE_MPI AND NOT SC_ENABLE_MPIIO)
+  message(WARNING "libsc MPI configured but MPI I/O is not configured/found: DEPRECATED")
+  message(NOTICE "This configuration is DEPRECATED and will be disallowed in the future.")
+  message(NOTICE "If the MPI File API is not available, please disable MPI altogether.")
+endif()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -102,6 +102,7 @@ if(NOT "${SC_ENABLE_MPI}" STREQUAL "$CACHE{SC_ENABLE_MPI}")
   unset(SC_ENABLE_MPICOMMSHARED CACHE)
   unset(SC_ENABLE_MPITHREAD CACHE)
   unset(SC_ENABLE_MPIWINSHARED CACHE)
+  unset (SC_HAVE_AINT_DIFF CACHE)
   unset(SC_ENABLE_MPIIO CACHE)
 endif()
 
@@ -114,6 +115,8 @@ if( SC_ENABLE_MPI )
   include(cmake/check_mpithread.cmake)
   # perform check to set SC_ENABLE_MPIWINSHARED
   include(cmake/check_mpiwinshared.cmake)
+  # perform check to set SC_HAVE_AINT_DIFF
+  include(cmake/check_mpiaintdiff.cmake)
 endif()
 
 

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -41,6 +41,9 @@
 /* Define to 1 if we are using MPI I/O */
 #cmakedefine SC_ENABLE_MPIIO 1
 
+/* Define to 1 if we have MPI_Aint_diff */
+#cmakedefine SC_HAVE_AINT_DIFF 1
+
 /* Define to 1 if we are using MPI_Init_thread */
 #cmakedefine SC_ENABLE_MPITHREAD 1
 

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -316,6 +316,30 @@ MPI_Finalize ();
  $2])
 ])
 
+dnl SC_MPI_Aint_Diff_C_COMPILE_AND_LINK([action-if-successful], [action-if-failed])
+dnl Compile and link an MPI_Aint_diff test program.
+dnl
+AC_DEFUN([SC_MPI_Aint_Diff_C_COMPILE_AND_LINK],
+[
+AC_MSG_CHECKING([compile/link for MPI_Aint_diff C program])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+#undef MPI
+#include <mpi.h>
+]], [[
+MPI_Aint a, b, res;
+a = 42;
+b = 12;
+MPI_Init ((int *) 0, (char ***) 0);
+res = MPI_Aint_diff (a, b);
+MPI_Finalize ();
+]])],
+[AC_MSG_RESULT([successful])
+ $1],
+[AC_MSG_RESULT([failed])
+ $2])
+])
+
 dnl SC_MPIIO_C_COMPILE_AND_LINK([action-if-successful], [action-if-failed])
 dnl Compile and link an MPI I/O test program
 dnl
@@ -520,6 +544,14 @@ dnl  ])
   if test "x$HAVE_PKG_MPITHREAD" = xyes ; then
     SC_MPITHREAD_C_COMPILE_AND_LINK(,
       [AC_MSG_ERROR([MPI_Init_thread not found; you may try --disable-mpithread])])
+  fi
+
+  dnl Run test to check availability of MPI_Aint_diff
+  $1_HAVE_AINT_DIFF=yes
+  SC_MPI_Aint_Diff_C_COMPILE_AND_LINK(,[$1_HAVE_AINT_DIFF=no])
+  if test "x$$1_HAVE_AINT_DIFF" = xyes ; then
+    AC_DEFINE([HAVE_AINT_DIFF], 1,
+              [Define to 1 if we have MPI_Aint_diff])
   fi
 
   dnl Run test to check availability of MPI window

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -19,12 +19,14 @@
 ### Functionality
 
  - Fix extern "C" macro for using C++ compilers with libsc .c files
+ - Add sc_MPI_Aint and sc_MPI_Aint_diff
 
 ### Build system
 
  - Streamline CMake configuration
  - Make sure to use SC_ENABLE_* CMake variables
  - Adapt CMake CI to matrix of latest compilers
+ - Check for MPI_Aint_diff in CMake and Autoconf
 
 ## 2.8.6
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ sc_allgather.c sc_reduce.c sc_notify.c
 sc_uint128.c sc_v4l2.c
 sc_puff.c
 sc_options.c sc_getopt.c sc_getopt1.c
+sc_scda.c
 )
 
 if(MSVC AND NOT SC_HAVE_GETTIMEOFDAY)

--- a/src/sc_mpi.c
+++ b/src/sc_mpi.c
@@ -24,6 +24,26 @@
 /* including sc_mpi.h does not work here since sc_mpi.h is included by sc.h */
 #include <sc.h>
 
+#if (defined(SC_ENABLE_MPI) && !defined(SC_HAVE_AINT_DIFF)) ||\
+    !defined (SC_ENABLE_MPI)
+/** This function is defined for two different configurations.
+ * For the case of MPI being enabled but MPI_Aint_diff is not available and
+ * for the case of MPI being disabled.
+ */
+sc_MPI_Aint
+sc_MPI_Aint_diff (sc_MPI_Aint a, sc_MPI_Aint b)
+{
+  /* MPI 2.0 supports MPI_Aint but does not support MPI_Aint_diff.
+   * In the MPI 2.0 standard document
+   * (https://www.mpi-forum.org/docs/mpi-2.0/mpi2-report.pdf) on page 283 is
+   * an example of calculating MPI_Aint displacements by standard subtraction.
+   * Therefore, we also use standard subtraction in the case MPI_Aint_diff is
+   * not available.
+   */
+  return a - b;
+}
+#endif
+
 #ifndef SC_ENABLE_MPI
 
 /* time.h is already included by sc.h */

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -299,6 +299,21 @@ sc_MPI_IO_Errorcode_t;
 #define sc_MPI_Pack                MPI_Pack
 #define sc_MPI_Unpack              MPI_Unpack
 #define sc_MPI_Pack_size           MPI_Pack_size
+#ifdef SC_HAVE_AINT_DIFF
+/* MPI 3.0 function */
+#define sc_MPI_Aint_diff           MPI_Aint_diff
+#else
+/* Replacement by standard subtraction.
+ *
+ * MPI 2.0 supports MPI_Aint but does not support MPI_Aint_diff.
+ * In the MPI 2.0 standard document
+ * (https://www.mpi-forum.org/docs/mpi-2.0/mpi2-report.pdf) on page 283 is
+ * an example of calculating MPI_Aint displacements by standard subtraction.
+ * Therefore, we also use standard subtraction in the case MPI_Aint_diff is
+ * not available.
+ */
+sc_MPI_Aint         sc_MPI_Aint_diff (sc_MPI_Aint a, sc_MPI_Aint b);
+#endif
 
 #else /* !SC_ENABLE_MPI */
 #include <sc3_mpi_types.h>
@@ -569,6 +584,17 @@ int                 sc_MPI_Scan (void *, void *, int, sc_MPI_Datatype,
 /** Execute the MPI_Exscan algorithm. */
 int                 sc_MPI_Exscan (void *, void *, int, sc_MPI_Datatype,
                                    sc_MPI_Op, sc_MPI_Comm);
+
+/* Replacement by standard subtraction.
+ *
+ * MPI 2.0 supports MPI_Aint but does not support MPI_Aint_diff.
+ * In the MPI 2.0 standard document
+ * (https://www.mpi-forum.org/docs/mpi-2.0/mpi2-report.pdf) on page 283 is
+ * an example of calculating MPI_Aint displacements by standard subtraction.
+ * Therefore, we also use standard subtraction in the case MPI_Aint_diff is
+ * not available.
+ */
+sc_MPI_Aint         sc_MPI_Aint_diff (sc_MPI_Aint a, sc_MPI_Aint b);
 
 /** Execute the MPI_Wtime function.
  * \return          Number of seconds since the epoch. */

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -134,6 +134,9 @@ sc_tag_t;
 
 #define sc_MPI_ERR_LASTCODE               MPI_ERR_LASTCODE
 
+/* MPI 2.0 type */
+#define sc_MPI_Aint                MPI_Aint
+
 #else /* !SC_ENABLE_MPIIO */
 
 typedef enum sc_MPI_IO_Errorcode
@@ -161,6 +164,8 @@ typedef enum sc_MPI_IO_Errorcode
   sc_MPI_ERR_LASTCODE
 }
 sc_MPI_IO_Errorcode_t;
+
+#define sc_MPI_Aint                sc3_MPI_Aint_t
 
 #endif /* !SC_ENABLE_MPIIO */
 
@@ -369,6 +374,7 @@ sc_MPI_IO_Errorcode_t;
 #define sc_MPI_DOUBLE_INT          SC3_MPI_DOUBLE_INT
 #define sc_MPI_LONG_DOUBLE         ((sc_MPI_Datatype) 0x4c000c0c)
 #define sc_MPI_PACKED              ((sc_MPI_Datatype) 0x4c001001)
+#define sc_MPI_Aint                sc3_MPI_Aint_t
 
 #define sc_MPI_OP_NULL             SC3_MPI_OP_NULL
 #define sc_MPI_MINLOC              SC3_MPI_MINLOC

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -2217,8 +2217,8 @@ sc_scda_get_indirect_type (sc_scda_fcontext_t *fc, sc_array_t *array_data,
 
   /* get displacements with respect to the base address */
   for (si = 0; si < num_blocks; ++si) {
-    /* TODO: Is this fine with the MPI 2.0 standard? */
-    displacements[si] = MPI_Aint_diff (displacements[si], base);
+    /* Without MPI 3.0 MPI_Aint_diff is replaced by standard subtraction */
+    displacements[si] = sc_MPI_Aint_diff (displacements[si], base);
   }
 
   /* Since MPI_File_write_at_all works with int for the count we can assume here

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1379,6 +1379,15 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
   sc_MPI_Info         info;
   sc_scda_fcontext_t *fc;
 
+#if defined(SC_ENABLE_MPI) && !defined(SC_ENABLE_MPIIO)
+  /* MPI without MPI I/O is not supported. */
+  SC_ABORT ("The configuration with enabled MPI but disabled MPI I/O "
+            "is deprecated. Please enable MPI I/O as well or disable MPI.\n"
+            "The scda file functions do not support the deprecated "
+            "configuration and hence we abort for this case in the scda fopen "
+            "functions.");
+#endif
+
   SC_ASSERT (filename != NULL);
   SC_ASSERT (user_string != NULL);
   SC_ASSERT (errcode != NULL);
@@ -2123,6 +2132,9 @@ sc_scda_check_array_params (sc_scda_fcontext_t *fc, sc_array_t *array_data,
  * available. Without MPI all functionalities are still available but writing
  * indirect data arrays is less optimized, i.e. we use an internal contiguous
  * buffer.
+ * Moreover, we assume that MPI I/O is available. This is equivalent to MPI 2.0
+ * being available (cf. the abort in \ref sc_scda_fopen_write and \ref
+ * sc_scda_fopen_write).
  */
 #ifdef SC_ENABLE_MPI
 /** Create a custom MPI data type for a potentially discontiguous data layout.
@@ -2159,8 +2171,8 @@ sc_scda_get_indirect_type (sc_scda_fcontext_t *fc, sc_array_t *array_data,
 #ifdef SC_ENABLE_DEBUG
   int                 size, size_cmp;
 #endif
+  /* MPI_Aint is a MPI 2.0 type */
   MPI_Aint           *displacements, base;
-  /* TODO: Use wrapper? */
   MPI_Datatype       *types;
   sc_array_t         *curr_arr;
 
@@ -2192,7 +2204,7 @@ sc_scda_get_indirect_type (sc_scda_fcontext_t *fc, sc_array_t *array_data,
   for (si = 0; si < num_blocks; ++si) {
     curr_arr = (sc_array_t *) sc_array_index (array_data, si);
 
-    /* get the address of the current data chunk */
+    /* get the address of the current data chunk; MPI 2.0 function */
     mpiret = MPI_Get_address (curr_arr->array, &displacements[si]);
     SC_CHECK_MPI (mpiret);
 
@@ -2224,6 +2236,7 @@ sc_scda_get_indirect_type (sc_scda_fcontext_t *fc, sc_array_t *array_data,
   /* Since MPI_File_write_at_all works with int for the count we can assume here
    * that casting num_blocks to int does not lead to an overflow since it is
    * smaller than the byte count of the associated I/O operation.
+   * MPI_Type_create_struct is a MPI 2.0 function.
    */
   mpiret =
     MPI_Type_create_struct ((int) num_blocks, block_lens, displacements,
@@ -2546,6 +2559,15 @@ sc_scda_fopen_read (sc_MPI_Comm mpicomm,
   int                 count_err;
   sc_MPI_Info         info;
   sc_scda_fcontext_t *fc;
+
+#if defined(SC_ENABLE_MPI) && !defined(SC_ENABLE_MPIIO)
+  /* MPI without MPI I/O is not supported. */
+  SC_ABORT ("The configuration with enabled MPI but disabled MPI I/O "
+            "is deprecated. Please enable MPI I/O as well or disable MPI.\n"
+            "The scda file functions do not support the deprecated "
+            "configuration and hence we abort for this case in the scda fopen "
+            "functions.");
+#endif
 
   SC_ASSERT (filename != NULL);
   SC_ASSERT (user_string != NULL);

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -2190,6 +2190,9 @@ sc_scda_get_indirect_type (sc_scda_fcontext_t *fc, sc_array_t *array_data,
   SC_FREE (displacements);
   SC_FREE (block_lens);
   SC_FREE (types);
+
+  mpiret = MPI_Type_commit (type);
+  SC_CHECK_MPI (mpiret);
 }
 #endif
 

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -54,7 +54,12 @@
  * The main purpose of \b scda is to enable the user to implement parallel I/O
  * for numerical appliations, e.g. simulation checkpoint/restart.
  *
- * We elaborate further on the workflow in \ref scda_workflow .
+ * We elaborate further on the workflow in \ref scda_workflow.
+ *
+ * The \b scda functions do not support the deprecated configuration case of
+ * MPI being enabled but MPI I/O being disabled. The functions \ref
+ * sc_scda_fopen_write and \ref sc_scda_fopen_read abort in this case. All other
+ * valid configurations are supported.
  *
  * ### User Strings
  *
@@ -322,6 +327,9 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  * sc_scda_fread_section_header and skipping the respective data bytes using the
  * respective read functions sc_scda_fread_*_data to parse the structure
  * of a given file and some metadata that is written by sc_scda.
+ *
+ * This function aborts on the deprecated configuration of enabled MPI and
+ * disabled MPI I/O. All other valid configurations are supported.
  *
  * This function differs from the one opening function for writing and reading
  * introduced in this \b scda
@@ -686,6 +694,9 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  * causes \ref SC_SCDA_FERR_FORMAT as \b errcode.
  * \note
  * All parameters are collective.
+ *
+ * This function aborts on the deprecated configuration of enabled MPI and
+ * disabled MPI I/O. All other valid configurations are supported.
  *
  * This function differs from the one opening function for writing and reading
  * introduced in this \b scda

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(CTest)
 
-set(sc_tests allgather arrays keyvalue notify reduce search sortb version)
+set(sc_tests allgather arrays keyvalue notify reduce search sortb version scda)
 
 if(SC_HAVE_RANDOM AND SC_HAVE_SRANDOM)
   list(APPEND sc_tests node_comm)


### PR DESCRIPTION
# scda: Custom MPI data type for indirect arrays

### scda changes
This PR continues the scda implementation (cf. https://github.com/cburstedde/libsc/pull/205) by implementing and using a custom MPI data type to write and read indirect arrays without copying the local data to a contiguous buffer. This optimization is only performed if MPI is available and enabled. Moreover, `sc_scda_fopen_{write,read}` are changed to abort on the deprecated configuration of MPI being enabled but MPI I/O being disabled. This is also explained in the documentation and the abort message.

### Build system changes
The creation of the custom MPI data type in the function `sc_scda_get_indirect_type` requires the MPI functions `MPI_Get_address` and `MPI_Type_create_struct` and the type `MPI_Aint`, which are all part of the MPI 2.0 standard.  Since the scda functions are only valid to call if MPI I/O is available or no MPI at all is activated (cf. above), we know that MPI 2.0 must be supported. Without MPI `sc_scda_get_indirect_type` is not compiled and the internal contiguous buffer is used.

The function `sc_scda_get_indirect_type` also requires the MPI function `MPI_Aint_diff`. However, this is a MPI 3.0 function. Therefore, we check in Autoconf and CMake if the function is available. If the function is not available, we use a fallback that conforms to an example from the MPI 2.0 standard document (cf. page 283 in https://www.mpi-forum.org/docs/mpi-2.0/mpi2-report.pdf), i.e. standard subtraction of MPI_Aint. The user only needs to call the new function `sc_MPI_Aint_diff` that abstracts the described logic and the function also works without MPI. The introduction of `sc_MPI_Aint_diff` includes the introduction of `sc_MPI_Aint` in the same vein as the other wrapped MPI types.