### PR TITLE
Add three newer MPI data types

### DIFF
--- a/cmake/check_mpitype.cmake
+++ b/cmake/check_mpitype.cmake
@@ -1,0 +1,24 @@
+include(CheckCSourceCompiles)
+function(check_mpitype MPI_TYPE)
+
+  set(CMAKE_REQUIRED_LIBRARIES MPI::MPI_C)
+
+  check_c_source_compiles(
+    "
+        #include <mpi.h>
+        int main(void) {
+          int size;
+          MPI_Init ((int *) 0, (char ***) 0);
+          /* check if ${MPI_TYPE} is defined */
+          MPI_Type_size (${MPI_TYPE}, &size);
+          MPI_Finalize ();
+          return 0;
+        }
+    "
+    SC_HAVE_${MPI_TYPE})
+
+endfunction()
+
+check_mpitype(MPI_UNSIGNED_LONG_LONG)
+check_mpitype(MPI_SIGNED_CHAR)
+check_mpitype(MPI_INT8_T)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -103,6 +103,9 @@ if(NOT "${SC_ENABLE_MPI}" STREQUAL "${CACHED_SC_ENABLE_MPI}")
   unset(SC_ENABLE_MPITHREAD CACHE)
   unset(SC_ENABLE_MPIWINSHARED CACHE)
   unset (SC_HAVE_AINT_DIFF CACHE)
+  unset (SC_HAVE_MPI_UNSIGNED_LONG_LONG CACHE)
+  unset (SC_HAVE_MPI_SIGNED_CHAR CACHE)
+  unset (SC_HAVE_MPI_INT8_T CACHE)
   unset(SC_ENABLE_MPIIO CACHE)
   # Update cached variable
   set(CACHED_SC_ENABLE_MPI "${SC_ENABLE_MPI}" CACHE STRING "Cached value of SC_ENABLE_MPI")
@@ -119,6 +122,8 @@ if( SC_ENABLE_MPI )
   include(cmake/check_mpiwinshared.cmake)
   # perform check to set SC_HAVE_AINT_DIFF
   include(cmake/check_mpiaintdiff.cmake)
+  # perform check of newer MPI data types
+  include(cmake/check_mpitype.cmake)
 endif()
 
 

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -44,6 +44,15 @@
 /* Define to 1 if we have MPI_Aint_diff */
 #cmakedefine SC_HAVE_AINT_DIFF 1
 
+/* Define to 1 if we have MPI_UNSIGNED_LONG_LONG */
+#cmakedefine SC_HAVE_MPI_UNSIGNED_LONG_LONG 1
+
+/* Define to 1 if we have MPI_SIGNED_CHAR */
+#cmakedefine SC_HAVE_MPI_SIGNED_CHAR 1
+
+/* Define to 1 if we have MPI_INT8_T */
+#cmakedefine SC_HAVE_MPI_INT8_T 1
+
 /* Define to 1 if we are using MPI_Init_thread */
 #cmakedefine SC_ENABLE_MPITHREAD 1
 

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -340,6 +340,30 @@ MPI_Finalize ();
  $2])
 ])
 
+dnl SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([data-type], [action-if-successful],
+dnl                                     [action-if-failed])
+dnl Compile and link an MPI data type test program.
+dnl
+AC_DEFUN([SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK],
+[
+AC_MSG_CHECKING([compile/link for the MPI data type $1])
+AC_LINK_IFELSE([AC_LANG_PROGRAM(
+[[
+#undef MPI
+#include <mpi.h>
+]], [[
+int size;
+MPI_Init ((int *) 0, (char ***) 0);
+/* check if $1 is defined */
+MPI_Type_size ($1, &size);
+MPI_Finalize ();
+]])],
+[AC_MSG_RESULT([successful])
+ $2],
+[AC_MSG_RESULT([failed])
+ $3])
+])
+
 dnl SC_MPIIO_C_COMPILE_AND_LINK([action-if-successful], [action-if-failed])
 dnl Compile and link an MPI I/O test program
 dnl
@@ -552,6 +576,33 @@ dnl  ])
   if test "x$$1_HAVE_AINT_DIFF" = xyes ; then
     AC_DEFINE([HAVE_AINT_DIFF], 1,
               [Define to 1 if we have MPI_Aint_diff])
+  fi
+
+  dnl Run test to check availability of MPI_UNSIGNED_LONG_LONG
+  $1_HAVE_MPI_UNSIGNED_LONG_LONG=yes
+  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_UNSIGNED_LONG_LONG], ,
+                                      [$1_HAVE_MPI_UNSIGNED_LONG_LONG=no])
+  if test "x$$1_HAVE_MPI_UNSIGNED_LONG_LONG" = xyes ; then
+    AC_DEFINE([HAVE_MPI_UNSIGNED_LONG_LONG], 1,
+              [Define to 1 if we have MPI_UNSIGNED_LONG_LONG])
+  fi
+
+  dnl Run test to check availability of MPI_SIGNED_CHAR
+  $1_HAVE_MPI_SIGNED_CHAR=yes
+  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_SIGNED_CHAR], ,
+                                      [$1_HAVE_MPI_SIGNED_CHAR=no])
+  if test "x$$1_HAVE_MPI_SIGNED_CHAR" = xyes ; then
+    AC_DEFINE([HAVE_MPI_SIGNED_CHAR], 1,
+              [Define to 1 if we have MPI_SIGNED_CHAR])
+  fi
+
+  dnl Run test to check availability of MPI_INT8_T
+  $1_HAVE_MPI_INT8_T=yes
+  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_INT8_T], ,
+                                      [$1_HAVE_MPI_INT8_T=no])
+  if test "x$$1_HAVE_MPI_INT8_T" = xyes ; then
+    AC_DEFINE([HAVE_MPI_INT8_T], 1,
+              [Define to 1 if we have MPI_INT8_T])
   fi
 
   dnl Run test to check availability of MPI window

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -364,6 +364,16 @@ MPI_Finalize ();
  $3])
 ])
 
+dnl SC_MPI_CHECK_TYPE([prefix], [data-type])
+dnl Checks if an MPI data type is available.
+AC_DEFUN([SC_MPI_CHECK_TYPE], [
+  $1_HAVE_$2=yes
+  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([$2], , [$1_HAVE_$2=no])
+  if test "x$$1_HAVE_$2" = xyes; then
+    AC_DEFINE([HAVE_$2], 1, [Define to 1 if we have $2])
+  fi
+])
+
 dnl SC_MPIIO_C_COMPILE_AND_LINK([action-if-successful], [action-if-failed])
 dnl Compile and link an MPI I/O test program
 dnl
@@ -578,32 +588,10 @@ dnl  ])
               [Define to 1 if we have MPI_Aint_diff])
   fi
 
-  dnl Run test to check availability of MPI_UNSIGNED_LONG_LONG
-  $1_HAVE_MPI_UNSIGNED_LONG_LONG=yes
-  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_UNSIGNED_LONG_LONG], ,
-                                      [$1_HAVE_MPI_UNSIGNED_LONG_LONG=no])
-  if test "x$$1_HAVE_MPI_UNSIGNED_LONG_LONG" = xyes ; then
-    AC_DEFINE([HAVE_MPI_UNSIGNED_LONG_LONG], 1,
-              [Define to 1 if we have MPI_UNSIGNED_LONG_LONG])
-  fi
-
-  dnl Run test to check availability of MPI_SIGNED_CHAR
-  $1_HAVE_MPI_SIGNED_CHAR=yes
-  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_SIGNED_CHAR], ,
-                                      [$1_HAVE_MPI_SIGNED_CHAR=no])
-  if test "x$$1_HAVE_MPI_SIGNED_CHAR" = xyes ; then
-    AC_DEFINE([HAVE_MPI_SIGNED_CHAR], 1,
-              [Define to 1 if we have MPI_SIGNED_CHAR])
-  fi
-
-  dnl Run test to check availability of MPI_INT8_T
-  $1_HAVE_MPI_INT8_T=yes
-  SC_MPI_DATA_TYPE_C_COMPILE_AND_LINK([MPI_INT8_T], ,
-                                      [$1_HAVE_MPI_INT8_T=no])
-  if test "x$$1_HAVE_MPI_INT8_T" = xyes ; then
-    AC_DEFINE([HAVE_MPI_INT8_T], 1,
-              [Define to 1 if we have MPI_INT8_T])
-  fi
+  dnl Run tests to check availability of newer MPI data types
+  SC_MPI_CHECK_TYPE([$1], [MPI_UNSIGNED_LONG_LONG])
+  SC_MPI_CHECK_TYPE([$1], [MPI_SIGNED_CHAR])
+  SC_MPI_CHECK_TYPE([$1], [MPI_INT8_T])
 
   dnl Run test to check availability of MPI window
   $1_ENABLE_MPIWINSHARED=yes

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -21,6 +21,7 @@
  - Fix extern "C" macro for using C++ compilers with libsc .c files
  - Add sc_MPI_Aint and sc_MPI_Aint_diff
  - Add sc_MPI_UNSIGNED_LONG_LONG, sc_MPI_SIGNED_CHAR and sc_MPI_INT8_T
+ - Implement a functional subset of the scda API for parallel I/O
 
 ### Build system
 

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -20,6 +20,7 @@
 
  - Fix extern "C" macro for using C++ compilers with libsc .c files
  - Add sc_MPI_Aint and sc_MPI_Aint_diff
+ - Add sc_MPI_UNSIGNED_LONG_LONG, sc_MPI_SIGNED_CHAR and sc_MPI_INT8_T
 
 ### Build system
 
@@ -27,6 +28,7 @@
  - Make sure to use SC_ENABLE_* CMake variables
  - Adapt CMake CI to matrix of latest compilers
  - Check for MPI_Aint_diff in CMake and Autoconf
+ - Check if MPI_UNSIGNED_LONG_LONG, MPI_SIGNED_CHAR and MPI_INT8_T are available
 
 ## 2.8.6
 

--- a/src/sc_mpi.c
+++ b/src/sc_mpi.c
@@ -817,6 +817,8 @@ sc_MPI_Error_string (int errorcode, char *string, int *resultlen)
 size_t
 sc_mpi_sizeof (sc_MPI_Datatype t)
 {
+  if (t == sc_MPI_DATATYPE_NULL)
+    SC_ABORT ("sc_mpi_sizeof was called with sc_MPI_DATATYPE_NULL");
   if (t == sc_MPI_BYTE)
     return 1;
   if (t == sc_MPI_CHAR || t == sc_MPI_UNSIGNED_CHAR)
@@ -829,6 +831,12 @@ sc_mpi_sizeof (sc_MPI_Datatype t)
     return sizeof (long);
   if (t == sc_MPI_LONG_LONG_INT)
     return sizeof (long long);
+  if (t == sc_MPI_UNSIGNED_LONG_LONG)
+    return sizeof (unsigned long long);
+  if (t == sc_MPI_INT8_T)
+    return sizeof (int8_t);
+  if (t == sc_MPI_SIGNED_CHAR)
+    return sizeof (char);
   if (t == sc_MPI_FLOAT)
     return sizeof (float);
   if (t == sc_MPI_DOUBLE)

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -199,6 +199,27 @@ sc_MPI_IO_Errorcode_t;
 #define sc_MPI_UNSIGNED            MPI_UNSIGNED
 #define sc_MPI_LONG                MPI_LONG
 #define sc_MPI_UNSIGNED_LONG       MPI_UNSIGNED_LONG
+/* Not an MPI 1.3 data type */
+#ifdef SC_HAVE_MPI_UNSIGNED_LONG_LONG
+#define sc_MPI_UNSIGNED_LONG_LONG  MPI_UNSIGNED_LONG_LONG
+#else
+/* MPI data type is not supported */
+#define sc_MPI_UNSIGNED_LONG_LONG  MPI_DATATYPE_NULL
+#endif
+/* Not an MPI 1.3 data type */
+#ifdef SC_HAVE_MPI_SIGNED_CHAR
+#define sc_MPI_SIGNED_CHAR         MPI_SIGNED_CHAR
+#else
+/* MPI data type is not supported */
+#define sc_MPI_SIGNED_CHAR         MPI_DATATYPE_NULL
+#endif
+/* Not an MPI 1.3 data type */
+#ifdef SC_HAVE_MPI_INT8_T
+#define sc_MPI_INT8_T              MPI_INT8_T
+#else
+/* MPI data type is not supported */
+#define sc_MPI_INT8_T              MPI_DATATYPE_NULL
+#endif
 #define sc_MPI_LONG_LONG_INT       MPI_LONG_LONG_INT
 #define sc_MPI_FLOAT               MPI_FLOAT
 #define sc_MPI_DOUBLE              MPI_DOUBLE
@@ -374,16 +395,19 @@ sc_MPI_Aint         sc_MPI_Aint_diff (sc_MPI_Aint a, sc_MPI_Aint b);
 #define sc_MPI_DATATYPE_NULL       SC3_MPI_DATATYPE_NULL
 
 #define sc_MPI_CHAR                ((sc_MPI_Datatype) 0x4c000101)
+#define sc_MPI_SIGNED_CHAR         ((sc_MPI_Datatype) 0x4c000118)
 #define sc_MPI_UNSIGNED_CHAR       ((sc_MPI_Datatype) 0x4c000102)
 #define sc_MPI_BYTE                SC3_MPI_BYTE
 #define sc_MPI_SHORT               ((sc_MPI_Datatype) 0x4c000203)
 #define sc_MPI_UNSIGNED_SHORT      ((sc_MPI_Datatype) 0x4c000204)
 #define sc_MPI_INT                 SC3_MPI_INT
+#define sc_MPI_INT8_T              ((sc_MPI_Datatype) 0x4c000205)
 #define sc_MPI_2INT                SC3_MPI_2INT
 #define sc_MPI_UNSIGNED            SC3_MPI_UNSIGNED
 #define sc_MPI_LONG                SC3_MPI_LONG
 #define sc_MPI_UNSIGNED_LONG       ((sc_MPI_Datatype) 0x4c000408)
 #define sc_MPI_LONG_LONG_INT       SC3_MPI_LONG_LONG
+#define sc_MPI_UNSIGNED_LONG_LONG  ((sc_MPI_Datatype) 0x4c000409)
 #define sc_MPI_FLOAT               SC3_MPI_FLOAT
 #define sc_MPI_DOUBLE              SC3_MPI_DOUBLE
 #define sc_MPI_DOUBLE_INT          SC3_MPI_DOUBLE_INT


### PR DESCRIPTION
# Add three newer MPI data types

This PR is a first step to address the issue https://github.com/cburstedde/libsc/issues/204.

Proposed changes:
- Introduce a general function in Autoconf and CMake to check for the availability of MPI data types.
- Add the following MPI data type wrappers:
    - `sc_MPI_UNSIGNED_LONG_LONG`,
    - `sc_MPI_SIGNED_CHAR` and
    - `sc_MPI_INT8_T`

- along with the corresponding preprocessor macros `SC_HAVE_{MPI_TYPE}`.
- The three added MPI data type wrappers are defined as the MPI data type if the respective MPI data type is available and MPI is activated. For the case without MPI, I added internal replacement. 
- If MPI is available but a new MPI data type is not available, it is set to `sc_MPI_DATATYPE_NULL` (cf. rationale below).

### Rationale for the case with MPI but missing new MPI data type
 If MPI is available but a new MPI data type is not available, we can not easily replace the MPI data type since using the closest available MPI data type may lead to erroneous code behavior. For example, the summation in reduction operations may cause overflows, which are unexpected to the user and difficult to trace back to the MPI data type replacement. Additionally, the MPI data type size of the replacement may differ, which could cause problems with MPI's internal buffer handling in communication calls.

Therefore, I do not replace the MPI data types in the discussed case but set them to `MPI_DATATYPE_NULL`. This means that the user can not use the new data types with MPI if the respective `SC_HAVE_*` macro is not defined. Setting unsupported MPI data types to `MPI_DATATYPE_NULL` is also the way MPICH uses (cf. https://github.com/pmodels/mpich/commit/c4125a73fdcd27f91f1d22179e666483946e1fbe).