### PR TITLE
Update cmake buildsystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if ( SC_NEED_M )
 endif()
 
 if ( WIN32 )
-  target_link_libraries(sc PUBLIC ws2_32)
+  target_link_libraries(sc PUBLIC ${WINSOCK_LIBRARIES})
 endif()
 
 # imported target, for use from parent project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(sc
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(sc PUBLIC
-  $<$<BOOL:${SC_HAVE_ZLIB}>:ZLIB::ZLIB>
   $<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
   $<$<BOOL:${SC_NEED_M}>:m>
   $<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
@@ -48,6 +47,10 @@ target_link_libraries(sc PUBLIC
 
 if ( SC_ENABLE_MPI )
   target_link_libraries(sc PUBLIC MPI::MPI_C)
+endif()
+
+if ( SC_HAVE_ZLIB )
+  target_link_libraries(sc PUBLIC ZLIB::ZLIB)
 endif()
 
 # imported target, for use from parent project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(sc
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(sc PUBLIC
-  $<$<BOOL:${SC_NEED_M}>:m>
   $<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
 )
 
@@ -55,6 +54,10 @@ endif()
 
 if( SC_HAVE_JSON )
   target_link_libraries(sc PUBLIC jansson::jansson)
+endif()
+
+if ( SC_NEED_M )
+  target_link_libraries(sc PUBLIC m)
 endif()
 
 # imported target, for use from parent project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,15 @@ target_include_directories(sc
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(sc PUBLIC
-  $<$<BOOL:${SC_ENABLE_MPI}>:MPI::MPI_C>
   $<$<BOOL:${SC_HAVE_ZLIB}>:ZLIB::ZLIB>
   $<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
   $<$<BOOL:${SC_NEED_M}>:m>
   $<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
 )
+
+if ( SC_ENABLE_MPI )
+  target_link_libraries(sc PUBLIC MPI::MPI_C)
+endif()
 
 # imported target, for use from parent project
 add_library(SC::SC INTERFACE IMPORTED GLOBAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,8 @@ target_include_directories(sc
   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
-target_link_libraries(sc PUBLIC
-  $<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
-)
 
+# optionally link with external libraries
 if ( SC_ENABLE_MPI )
   target_link_libraries(sc PUBLIC MPI::MPI_C)
 endif()
@@ -58,6 +56,10 @@ endif()
 
 if ( SC_NEED_M )
   target_link_libraries(sc PUBLIC m)
+endif()
+
+if ( WIN32 )
+  target_link_libraries(sc PUBLIC ws2_32)
 endif()
 
 # imported target, for use from parent project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ target_include_directories(sc
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(sc PUBLIC
-  $<$<BOOL:${SC_HAVE_JSON}>:jansson::jansson>
   $<$<BOOL:${SC_NEED_M}>:m>
   $<$<BOOL:${WIN32}>:${WINSOCK_LIBRARIES}>
 )
@@ -51,6 +50,11 @@ endif()
 
 if ( SC_HAVE_ZLIB )
   target_link_libraries(sc PUBLIC ZLIB::ZLIB)
+endif()
+
+
+if( SC_HAVE_JSON )
+  target_link_libraries(sc PUBLIC jansson::jansson)
 endif()
 
 # imported target, for use from parent project

--- a/doc/author_knapp.txt
+++ b/doc/author_knapp.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. David Knapp (david.knapp@dlr.de)


### PR DESCRIPTION
# Update CMake-build system.

Following up on issue #206


Proposed changes: This PR cleans the sc-targets.cmake file, if the generator expression fails to be resolved. Furthermore it improves readability. 
