### PR TITLE
Patch transient CI failures due to busy file system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
       run: |
         DIR="checkMPIdebug_shared" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug --disable-shared \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $SC_CI_CONFIG_OPT
+                     CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                     $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -60,7 +60,7 @@ jobs:
       run: |
         DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized"\
-            $SC_CI_CONFIG_OPT
+                     $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -74,7 +74,7 @@ jobs:
       run: |
         DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug CFLAGS="-O0" CC=mpicxx \
-            $SC_CI_CONFIG_OPT
+                     $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -83,7 +83,7 @@ jobs:
       run: |
         DIR="checkOpenMPMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-openmp="-fopenmp" --enable-mpi \
-            --enable-debug CFLAGS="-O0" $SC_CI_CONFIG_OPT
+                     --enable-debug CFLAGS="-O0" $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -127,8 +127,8 @@ jobs:
         DIR="checkMPIdebug_valgrind" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
                      --disable-shared --enable-valgrind \
-          CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-          $SC_CI_CONFIG_OPT
+                     CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                     $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -172,9 +172,9 @@ jobs:
       run: |
         DIR="tarball" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
-                -Wno-unused-parameter -Wno-builtin-declaration-mismatch \
-                -Wno-implicit-fallthrough" $SC_CI_CONFIG_OPT
+                     CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
+                     -Wno-unused-parameter -Wno-builtin-declaration-mismatch \
+                     -Wno-implicit-fallthrough" $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
         make -j distcheck V=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ on:
       - ".github/workflows/composite-cmake/**"
   pull_request:
 
+env:
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
+  CMAKE_CONFIGURE_OPT: --disable-file-checks
+
 jobs:
 
   linux-multi:
@@ -37,7 +42,8 @@ jobs:
       run: |
         DIR="checkMPIdebug_shared" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug --disable-shared \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+            $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -45,7 +51,7 @@ jobs:
       shell: bash
       run: |
         DIR="checkMPI" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-mpi CFLAGS="-O2"
+        ../configure --enable-mpi CFLAGS="-O2" $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -53,7 +59,8 @@ jobs:
       shell: bash
       run: |
         DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized"
+        ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized"\
+            $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -66,7 +73,8 @@ jobs:
       shell: bash
       run: |
         DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-mpi --enable-debug CFLAGS="-O0" CC=mpicxx
+        ../configure --enable-mpi --enable-debug CFLAGS="-O0" CC=mpicxx \
+            $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -75,7 +83,7 @@ jobs:
       run: |
         DIR="checkOpenMPMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-openmp="-fopenmp" --enable-mpi \
-            --enable-debug CFLAGS="-O0"
+            --enable-debug CFLAGS="-O0" $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -83,7 +91,7 @@ jobs:
       shell: bash
       run: |
         DIR="distcheck" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure
+        ../configure $CMAKE_CONFIGURE_OPT
         make -j distcheck V=0
 
     - name: Upload log files
@@ -119,7 +127,8 @@ jobs:
         DIR="checkMPIdebug_valgrind" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug \
                      --disable-shared --enable-valgrind \
-          CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+          CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+          $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
 
@@ -165,7 +174,7 @@ jobs:
         ../configure --enable-mpi --enable-debug \
             CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
                 -Wno-unused-parameter -Wno-builtin-declaration-mismatch \
-                -Wno-implicit-fallthrough"
+                -Wno-implicit-fallthrough" $CMAKE_CONFIGURE_OPT
         make -j V=0
         make -j check V=0
         make -j distcheck V=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 env:
   # Due to busy file system problems on the CI runners, we deactivate the file
   # checks in the CI.
-  CMAKE_CONFIGURE_OPT: --disable-file-checks
+  SC_CI_CONFIG_OPT: --disable-file-checks
 
 jobs:
 
@@ -43,7 +43,7 @@ jobs:
         DIR="checkMPIdebug_shared" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug --disable-shared \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -51,7 +51,7 @@ jobs:
       shell: bash
       run: |
         DIR="checkMPI" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-mpi CFLAGS="-O2" $CMAKE_CONFIGURE_OPT
+        ../configure --enable-mpi CFLAGS="-O2" $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -60,7 +60,7 @@ jobs:
       run: |
         DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized"\
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -74,7 +74,7 @@ jobs:
       run: |
         DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-mpi --enable-debug CFLAGS="-O0" CC=mpicxx \
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -83,7 +83,7 @@ jobs:
       run: |
         DIR="checkOpenMPMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
         ../configure --enable-openmp="-fopenmp" --enable-mpi \
-            --enable-debug CFLAGS="-O0" $CMAKE_CONFIGURE_OPT
+            --enable-debug CFLAGS="-O0" $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -91,7 +91,7 @@ jobs:
       shell: bash
       run: |
         DIR="distcheck" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure $CMAKE_CONFIGURE_OPT
+        ../configure $SC_CI_CONFIG_OPT
         make -j distcheck V=0
 
     - name: Upload log files
@@ -128,7 +128,7 @@ jobs:
         ../configure --enable-mpi --enable-debug \
                      --disable-shared --enable-valgrind \
           CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-          $CMAKE_CONFIGURE_OPT
+          $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
 
@@ -174,7 +174,7 @@ jobs:
         ../configure --enable-mpi --enable-debug \
             CFLAGS="-O0 -g -pedantic -Wall -Wextra -Werror \
                 -Wno-unused-parameter -Wno-builtin-declaration-mismatch \
-                -Wno-implicit-fallthrough" $CMAKE_CONFIGURE_OPT
+                -Wno-implicit-fallthrough" $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0
         make -j distcheck V=0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       shell: bash
       run: |
         DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
-        ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized"\
+        ../configure --enable-debug CFLAGS="-O0 -g -Wall -Wno-uninitialized" \
                      $SC_CI_CONFIG_OPT
         make -j V=0
         make -j check V=0

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -22,7 +22,7 @@ env:
   CMAKE_PREFIX_PATH: ~/local
   # Due to busy file system problems on the CI runners, we deactivate the file
   # checks in the CI.
-  SC_CI_CONFIG_OPT: -Ddisable-file-checks=ON
+  SC_CI_CONFIG_OPT: -DSC_ENABLE_FILE_CHECKS=OFF
 
 jobs:
 

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -116,7 +116,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: CMake configure
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }} $SC_CI_CONFIG_OPT
+      run: |
+        cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} \
+              -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }} \
+              $SC_CI_CONFIG_OPT
 
     - name: CMake build
       run: cmake --build --preset default
@@ -187,7 +190,9 @@ jobs:
     - name: CMake configure without MPI
       # We must use $env:SC_CI_CONFIG_OPT instead of $SC_CI_CONFIG_OPT
       # due to Windows PowerShell.
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} $env:SC_CI_CONFIG_OPT
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no `
+                 -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} `
+                 $env:SC_CI_CONFIG_OPT
 
     - name: CMake build
       run: cmake --build --preset default --parallel

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -20,6 +20,7 @@ env:
   CTEST_PARALLEL_LEVEL: 0
   CMAKE_INSTALL_PREFIX: ~/local
   CMAKE_PREFIX_PATH: ~/local
+  CMAKE_CONFIGURE_OPT: -Ddisable-file-checks=ON
 
 jobs:
 
@@ -113,7 +114,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: CMake configure
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }}
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }} $CMAKE_CONFIGURE_OPT
 
     - name: CMake build
       run: cmake --build --preset default
@@ -182,7 +183,9 @@ jobs:
     - run: echo "CMAKE_PREFIX_PATH=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: CMake configure without MPI
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+      # We must use $env:CMAKE_CONFIGURE_OPT instead of $CMAKE_CONFIGURE_OPT
+      # due to Windows PowerShell.
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} $env:CMAKE_CONFIGURE_OPT
 
     - name: CMake build
       run: cmake --build --preset default --parallel
@@ -194,7 +197,7 @@ jobs:
       run: cmake --install build
 
     - name: CMake configure examples without MPI
-      run: cmake -B example/build -S example
+      run: cmake -B example/build -S example $env:CMAKE_CONFIGURE_OPT
 
     - name: CMake build examples
       run: cmake --build example/build --parallel

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -22,7 +22,7 @@ env:
   CMAKE_PREFIX_PATH: ~/local
   # Due to busy file system problems on the CI runners, we deactivate the file
   # checks in the CI.
-  CMAKE_CONFIGURE_OPT: -Ddisable-file-checks=ON
+  SC_CI_CONFIG_OPT: -Ddisable-file-checks=ON
 
 jobs:
 
@@ -116,7 +116,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: CMake configure
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }} $CMAKE_CONFIGURE_OPT
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} -DSC_TEST_WITH_VALGRIND:BOOL=${{ matrix.valgrind }} $SC_CI_CONFIG_OPT
 
     - name: CMake build
       run: cmake --build --preset default
@@ -185,9 +185,9 @@ jobs:
     - run: echo "CMAKE_PREFIX_PATH=$HOME/local" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: CMake configure without MPI
-      # We must use $env:CMAKE_CONFIGURE_OPT instead of $CMAKE_CONFIGURE_OPT
+      # We must use $env:SC_CI_CONFIG_OPT instead of $SC_CI_CONFIG_OPT
       # due to Windows PowerShell.
-      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} $env:CMAKE_CONFIGURE_OPT
+      run: cmake --preset default -DSC_ENABLE_MPI:BOOL=no -DSC_BUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} $env:SC_CI_CONFIG_OPT
 
     - name: CMake build
       run: cmake --build --preset default --parallel
@@ -199,7 +199,7 @@ jobs:
       run: cmake --install build
 
     - name: CMake configure examples without MPI
-      run: cmake -B example/build -S example $env:CMAKE_CONFIGURE_OPT
+      run: cmake -B example/build -S example $env:SC_CI_CONFIG_OPT
 
     - name: CMake build examples
       run: cmake --build example/build --parallel

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -20,6 +20,8 @@ env:
   CTEST_PARALLEL_LEVEL: 0
   CMAKE_INSTALL_PREFIX: ~/local
   CMAKE_PREFIX_PATH: ~/local
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
   CMAKE_CONFIGURE_OPT: -Ddisable-file-checks=ON
 
 jobs:

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -13,6 +13,11 @@ on:
       - ".github/workflows/composite-cmake/**"
   pull_request:
 
+env:
+  # Due to busy file system problems on the CI runners, we deactivate the file
+  # checks in the CI.
+  CMAKE_CONFIGURE_OPT: --disable-file-checks
+
 jobs:
   darwin:
     runs-on: macos-latest
@@ -36,7 +41,8 @@ jobs:
        run: |
           DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+            $CMAKE_CONFIGURE_OPT
           make -j V=0
           make -j check V=0
 
@@ -44,7 +50,8 @@ jobs:
        run: |
           DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+            $CMAKE_CONFIGURE_OPT
           make -j V=0
           make -j check V=0
 
@@ -52,7 +59,8 @@ jobs:
        run: |
           DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug CC=mpicxx \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter"
+            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+            $CMAKE_CONFIGURE_OPT
           make -j V=0
           make -j check V=0
 

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -41,8 +41,8 @@ jobs:
        run: |
           DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $SC_CI_CONFIG_OPT
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -50,8 +50,8 @@ jobs:
        run: |
           DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $SC_CI_CONFIG_OPT
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -59,8 +59,8 @@ jobs:
        run: |
           DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug CC=mpicxx \
-            CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $SC_CI_CONFIG_OPT
+                       CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
+                       $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 

--- a/.github/workflows/ci_darwin.yml
+++ b/.github/workflows/ci_darwin.yml
@@ -16,7 +16,7 @@ on:
 env:
   # Due to busy file system problems on the CI runners, we deactivate the file
   # checks in the CI.
-  CMAKE_CONFIGURE_OPT: --disable-file-checks
+  SC_CI_CONFIG_OPT: --disable-file-checks
 
 jobs:
   darwin:
@@ -42,7 +42,7 @@ jobs:
           DIR="checkdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-debug \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -51,7 +51,7 @@ jobs:
           DIR="checkMPIdebug" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 
@@ -60,7 +60,7 @@ jobs:
           DIR="checkMPIdebugCXX" && mkdir -p "$DIR" && cd "$DIR"
           ../configure --enable-mpi --enable-debug CC=mpicxx \
             CFLAGS="-O0 -g -Wall -Wextra -Wno-unused-parameter" \
-            $CMAKE_CONFIGURE_OPT
+            $SC_CI_CONFIG_OPT
           make -j V=0
           make -j check V=0
 

--- a/.github/workflows/composite-cmake/action.yml
+++ b/.github/workflows/composite-cmake/action.yml
@@ -6,18 +6,19 @@ runs:
     shell: bash
     run: >-
       cmake --preset default
-      -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-      -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
-      $SC_CI_CONFIG_OPT
+            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+            $SC_CI_CONFIG_OPT
 
   - name: CMake print debug find
     shell: bash
     if: failure()
     run: >-
       cmake --preset default
-      -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-      -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
-      --debug-find --fresh
+            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+            $SC_CI_CONFIG_OPT
+            --debug-find --fresh
 
   - name: CMake build
     shell: bash

--- a/.github/workflows/composite-cmake/action.yml
+++ b/.github/workflows/composite-cmake/action.yml
@@ -4,20 +4,20 @@ runs:
   steps:
   - name: CMake configure
     shell: bash
-    run: >-
-      cmake --preset default
-            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+    run: |
+      cmake --preset default \
+            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} \
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} \
             $SC_CI_CONFIG_OPT
 
   - name: CMake print debug find
     shell: bash
     if: failure()
-    run: >-
-      cmake --preset default
-            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
-            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
-            $SC_CI_CONFIG_OPT
+    run: |
+      cmake --preset default \
+            -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }} \
+            -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }} \
+            $SC_CI_CONFIG_OPT \
             --debug-find --fresh
 
   - name: CMake build

--- a/.github/workflows/composite-cmake/action.yml
+++ b/.github/workflows/composite-cmake/action.yml
@@ -8,7 +8,7 @@ runs:
       cmake --preset default
       -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
       -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
-      $CMAKE_CONFIGURE_OPT
+      $SC_CI_CONFIG_OPT
 
   - name: CMake print debug find
     shell: bash

--- a/.github/workflows/composite-cmake/action.yml
+++ b/.github/workflows/composite-cmake/action.yml
@@ -8,6 +8,7 @@ runs:
       cmake --preset default
       -DSC_ENABLE_MPI:BOOL=${{ matrix.mpi }}
       -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shared }}
+      $CMAKE_CONFIGURE_OPT
 
   - name: CMake print debug find
     shell: bash

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -126,11 +126,6 @@ if( SC_ENABLE_MPI )
   include(cmake/check_mpitype.cmake)
 endif()
 
-if(disable-file-checks)
-    set(SC_ENABLE_FILE_CHECKS OFF)
-else()
-    set(SC_ENABLE_FILE_CHECKS ON)
-endif()
 
 check_symbol_exists(realloc stdlib.h SC_ENABLE_USE_REALLOC)
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -126,6 +126,11 @@ if( SC_ENABLE_MPI )
   include(cmake/check_mpitype.cmake)
 endif()
 
+if(disable-file-checks)
+    set(SC_ENABLE_FILE_CHECKS OFF)
+else()
+    set(SC_ENABLE_FILE_CHECKS ON)
+endif()
 
 check_symbol_exists(realloc stdlib.h SC_ENABLE_USE_REALLOC)
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,6 +1,8 @@
 option( SC_ENABLE_MPI "use MPI library" OFF )
 option( SC_ENABLE_OPENMP "use OpenMP" OFF )
 
+option( disable-file-checks "disable tests that use file functions" OFF)
+
 option( SC_USE_INTERNAL_ZLIB "build ZLIB" OFF )
 option( SC_USE_INTERNAL_JSON "build Jansson" OFF )
 

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -1,7 +1,7 @@
 option( SC_ENABLE_MPI "use MPI library" OFF )
 option( SC_ENABLE_OPENMP "use OpenMP" OFF )
 
-option( disable-file-checks "disable tests that use file functions" OFF)
+option( SC_ENABLE_FILE_CHECKS "activate tests that use file functions" ON)
 
 option( SC_USE_INTERNAL_ZLIB "build ZLIB" OFF )
 option( SC_USE_INTERNAL_JSON "build Jansson" OFF )

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -41,6 +41,9 @@
 /* Define to 1 if we are using MPI I/O */
 #cmakedefine SC_ENABLE_MPIIO 1
 
+/* Define to 1 if we compile the file checks */
+#cmakedefine SC_ENABLE_FILE_CHECKS 1
+
 /* Define to 1 if we have MPI_Aint_diff */
 #cmakedefine SC_HAVE_AINT_DIFF 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ SC_ARG_DISABLE([realloc], [replace array/dmatrix resize with malloc/copy/free],
                [USE_REALLOC])
 SC_ARG_DISABLE([counters], [disable non-thread-safe internal debug counters],
                [USE_COUNTERS])
+SC_ARG_DISABLE([file-checks], [disable tests that use file functions],
+               [FILE_CHECKS])
 SC_ARG_WITH([papi], [enable Flop counting with papi], [PAPI])
 
 echo "o---------------------------------------"

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -33,7 +33,7 @@
  - Check for MPI_Aint_diff in CMake and Autoconf
  - Check if MPI_UNSIGNED_LONG_LONG, MPI_SIGNED_CHAR and MPI_INT8_T are available
  - Fix tarball naming and add a CMake target to generate .tarball-version file
- - Add an option to disable the file checks, i.e. sc_test_scda
+ - Add an option to disable the file checks; affects sc_test_scda
 
 ## 2.8.6
 

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -23,6 +23,7 @@
  - Add sc_MPI_UNSIGNED_LONG_LONG, sc_MPI_SIGNED_CHAR and sc_MPI_INT8_T
  - Implement a functional subset of the scda API for parallel I/O
  - Intremental documentation updates
+ - Add a portable sleep function
 
 ### Build system
 
@@ -32,6 +33,7 @@
  - Check for MPI_Aint_diff in CMake and Autoconf
  - Check if MPI_UNSIGNED_LONG_LONG, MPI_SIGNED_CHAR and MPI_INT8_T are available
  - Fix tarball naming and add a CMake target to generate .tarball-version file
+ - Add an option to disable the file checks, i.e. sc_test_scda
 
 ## 2.8.6
 

--- a/src/sc.c
+++ b/src/sc.c
@@ -48,6 +48,12 @@ typedef void        (*sc_sig_t) (int);
 #include <Windows.h>
 #endif
 
+#if _POSIX_C_SOURCE >= 199309L
+#include <time.h>
+#else
+#include <unistd.h>
+#endif
+
 typedef struct sc_package
 {
   int                 is_registered;
@@ -1624,5 +1630,27 @@ sc_have_json (void)
   return 0;
 #else
   return 1;
+#endif
+}
+
+void
+sc_sleep (unsigned milliseconds){
+#if _POSIX_C_SOURCE >= 199309L
+  struct timespec ts;
+  /* full seconds */
+  ts.tv_sec = milliseconds / 1000;
+  /* nanoseconds */
+  ts.tv_nsec = (milliseconds % 1000) * 1000000;
+  nanosleep (&ts, NULL);
+#elif defined(_POSIX_C_SOURCE)
+  /* older POSIX */
+  if (milliseconds >= 1000) {
+    sleep (milliseconds / 1000);
+  }
+  usleep ((milliseconds % 1000) * 1000);
+#elif _MSC_VER
+  Sleep (milliseconds);
+#else
+  SC_ABORT ("No suitable sleep function available.");
 #endif
 }

--- a/src/sc.h
+++ b/src/sc.h
@@ -878,6 +878,12 @@ int                 sc_have_zlib (void);
  */
 int                 sc_have_json (void);
 
+/** Portable function to sleep a prescribed amount of milliseconds.
+ *
+ * \param [in] milliseconds The number of milliseconds to sleep.
+ */
+void                sc_sleep (unsigned milliseconds);
+
 SC_EXTERN_C_END;
 
 #endif /* SC_H */

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -798,7 +798,11 @@ main (int argc, char **argv)
   sc_options_destroy (opt);
 
 #else
-  SC_GLOBAL_INFO ("The file checks were deactivated during the configuration.\n");
+  SC_GLOBAL_INFO ("The file checks were deactivated during the configuration."
+                  "\n");
+  SC_GLOBAL_INFO ("The file checks can be activated by not passing\n");
+  SC_GLOBAL_INFO ("--disable-file-checks to the Autoconf configure script and"
+                  " for CMake you must set disable-file-checks to OFF.\n");
 #endif /* !SC_ENABLE_FILE_CHECKS */
 
   sc_finalize ();

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -802,7 +802,8 @@ main (int argc, char **argv)
                   "\n");
   SC_GLOBAL_INFO ("The file checks can be activated by not passing\n");
   SC_GLOBAL_INFO ("--disable-file-checks to the Autoconf configure script and"
-                  " for CMake you must set disable-file-checks to OFF.\n");
+                  " for CMake you must set the option SC_ENABLE_FILE_CHECKS to"
+                  " ON.\n");
 #endif /* !SC_ENABLE_FILE_CHECKS */
 
   sc_finalize ();

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -24,6 +24,7 @@
 #include <sc_scda.h>
 #include <sc_options.h>
 
+#ifdef SC_ENABLE_FILE_CHECKS
 #define SC_SCDA_FILE_EXT "scd"
 #define SC_SCDA_TEST_FILE "sc_test_scda." SC_SCDA_FILE_EXT
 
@@ -482,12 +483,15 @@ test_scda_read_indirect_fixed_size_array (sc_scda_fcontext_t *fc, int mpirank,
   sc_array_reset (&array_data);
   sc_array_reset (&elem_counts);
 }
+#endif /* SC_ENABLE_FILE_CHECKS */
 
 int
 main (int argc, char **argv)
 {
   sc_MPI_Comm         mpicomm = sc_MPI_COMM_WORLD;
-  int                 mpiret, mpirank, mpisize;
+  int                 mpiret;
+#ifdef SC_ENABLE_FILE_CHECKS
+  int                 mpirank, mpisize;
   int                 first_argc;
   int                 int_everyn, int_seed;
   int                 decode;
@@ -506,10 +510,13 @@ main (int argc, char **argv)
   const char         *inline_data = "Test inline data               \n";
   const char         *block_data = "Test block data";
   char                read_data[SC_SCDA_INLINE_FIELD];
+#endif /* SC_ENABLE_FILE_CHECKS */
 
   mpiret = sc_MPI_Init (&argc, &argv);
   SC_CHECK_MPI (mpiret);
   sc_init (mpicomm, 1, 1, NULL, SC_LP_INFO);
+
+#ifdef SC_ENABLE_FILE_CHECKS
 
   /* parse command line options */
   opt = sc_options_new (argv[0]);
@@ -789,6 +796,10 @@ main (int argc, char **argv)
                                mpisize);
 
   sc_options_destroy (opt);
+
+#else
+  SC_GLOBAL_INFO ("The file checks were deactivated during the configuration.\n");
+#endif /* !SC_ENABLE_FILE_CHECKS */
 
   sc_finalize ();
 


### PR DESCRIPTION
# Patch transient CI failures due to busy file system

Following up on issue https://github.com/cburstedde/libsc/issues/213.

As discussed in the referenced issue, we observed transient CI failures due to `test_scda.c`. The failures appear due to I/O operations that are according to MPI I/O's error code successful but have an unexpected MPI count of 0, indicating that no actual I/O operation was performed. During the investigation of this issue, I observed that calling a sleep between I/O operations reduces the frequency of the transient failures or even seems to overcome them, suggesting that the underlying cause may be a busy file system on the CI runners.

This PR applies a patch in the CI to wait 5 milliseconds if a successful I/O operation unexpectedly resulted in count 0 and then retry the I/O operation once. The sleeping time can be adjusted in the CI by adjusting the variable `IO_SLEEP_TIME` (cf. eb190eb072c0c95222898412e596d5aff6cedffa). In my tests 5 milliseconds ensured a reliable CI. However, past experiences indicate that the extent of the issue can vary significantly over time. Hence, it may be necessary to adjust the choice of the sleeping time in the future.

Edit: This PR contains now a different approach of avoiding the described issue (cf. https://github.com/cburstedde/libsc/pull/214#issuecomment-2639344963).
