### PR TITLE
remove need for winsock_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,6 @@ if ( SC_NEED_M )
   target_link_libraries(sc PUBLIC m)
 endif()
 
-if ( WIN32 )
-  target_link_libraries(sc PUBLIC ${WINSOCK_LIBRARIES})
-endif()
-
 # imported target, for use from parent project
 add_library(SC::SC INTERFACE IMPORTED GLOBAL)
 target_link_libraries(SC::SC INTERFACE sc)

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -183,10 +183,6 @@ check_include_file(time.h SC_HAVE_TIME_H)
 
 check_symbol_exists(gettimeofday sys/time.h SC_HAVE_GETTIMEOFDAY)
 
-if(WIN32)
-  set(WINSOCK_LIBRARIES wsock32 ws2_32 Iphlpapi)
-endif()
-
 check_include_file(libgen.h SC_HAVE_LIBGEN_H)
 check_include_file(unistd.h SC_HAVE_UNISTD_H)
 if(SC_HAVE_UNISTD_H)

--- a/src/sc.h
+++ b/src/sc.h
@@ -172,7 +172,11 @@
 #include <sys/time.h>
 #elif defined(_MSC_VER) && !defined(SC_HAVE_GETTIMEOFDAY)
 #define WIN32_LEAN_AND_MEAN
-#include <Winsock2.h>
+struct timeval {
+        long    tv_sec;
+        long    tv_usec;
+};
+
 struct timezone
 {
   int                 tz_minuteswest;


### PR DESCRIPTION
This removes the need for winsock on Windows by just defining the timeval struct.