### PR TITLE
Feature distro

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -70,30 +70,11 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_REQUIRED_INCLUDES)
 set(CMAKE_REQUIRED_LIBRARIES)
 
-set(SC_CC \"${CMAKE_C_COMPILER}\")
-set(SC_CPP ${CMAKE_C_COMPILER})
-
 check_symbol_exists(sqrt math.h SC_NONEED_M)
 
 if(NOT SC_NONEED_M)
   set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} m)
   check_symbol_exists(sqrt math.h SC_NEED_M)
-endif()
-
-string(APPEND SC_CPP " -E")
-set(SC_CPP \"${SC_CPP}\")
-
-set(SC_CFLAGS "${CMAKE_C_FLAGS}\ ${MPI_C_COMPILE_OPTIONS}")
-set(SC_CFLAGS \"${SC_CFLAGS}\")
-
-set(SC_CPPFLAGS \"\")
-
-set(SC_LDFLAGS \"${MPI_C_LINK_FLAGS}\")
-
-if(SC_HAVE_ZLIB)
-  set(SC_LIBS \"${ZLIB_LIBRARIES}\ m\")
-else()
-  set(SC_LIBS \"m\")
 endif()
 
 set(SC_ENABLE_PTHREAD ${CMAKE_USE_PTHREADS_INIT})

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -212,13 +212,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   endif()
 endif()
 
-check_type_size(int SC_SIZEOF_INT BUILTIN_TYPES_ONLY)
-check_type_size("unsigned int" SC_SIZEOF_UNSIGNED_INT BUILTIN_TYPES_ONLY)
-check_type_size(long SC_SIZEOF_LONG BUILTIN_TYPES_ONLY)
-check_type_size("unsigned long" SC_SIZEOF_UNSIGNED_LONG BUILTIN_TYPES_ONLY)
-check_type_size("long long" SC_SIZEOF_LONG_LONG BUILTIN_TYPES_ONLY)
-set(SC_SIZEOF_VOID_P ${CMAKE_SIZEOF_VOID_P})
-
 if(CMAKE_BUILD_TYPE MATCHES "Debug")
   set(SC_ENABLE_DEBUG 1)
 else()

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -5,6 +5,7 @@ include(CheckPrototypeDefinition)
 include(CheckCSourceCompiles)
 
 # --- retrieve library interface version from configuration file
+
 file(STRINGS config/sc_soversion.in SC_SOVERSION_READ
              REGEX "^[ \t]*SC_SOVERSION *= *[0-9:]+")
 string(REGEX REPLACE ".*([0-9]+):([0-9]+):([0-9]+)" "\\1.\\2.\\3"
@@ -55,6 +56,7 @@ else()
     set(SC_HAVE_JSON OFF CACHE BOOL "JSON features disabled")
   endif()
 endif()
+
 # --- set global compile environment
 
 # Build all targets with -fPIC so that libsc itself can be linked as a
@@ -102,10 +104,10 @@ if(NOT "${SC_ENABLE_MPI}" STREQUAL "${CACHED_SC_ENABLE_MPI}")
   unset(SC_ENABLE_MPICOMMSHARED CACHE)
   unset(SC_ENABLE_MPITHREAD CACHE)
   unset(SC_ENABLE_MPIWINSHARED CACHE)
-  unset (SC_HAVE_AINT_DIFF CACHE)
-  unset (SC_HAVE_MPI_UNSIGNED_LONG_LONG CACHE)
-  unset (SC_HAVE_MPI_SIGNED_CHAR CACHE)
-  unset (SC_HAVE_MPI_INT8_T CACHE)
+  unset(SC_HAVE_AINT_DIFF CACHE)
+  unset(SC_HAVE_MPI_UNSIGNED_LONG_LONG CACHE)
+  unset(SC_HAVE_MPI_SIGNED_CHAR CACHE)
+  unset(SC_HAVE_MPI_INT8_T CACHE)
   unset(SC_ENABLE_MPIIO CACHE)
   # Update cached variable
   set(CACHED_SC_ENABLE_MPI "${SC_ENABLE_MPI}" CACHE STRING "Cached value of SC_ENABLE_MPI")
@@ -125,7 +127,6 @@ if( SC_ENABLE_MPI )
   # perform check of newer MPI data types
   include(cmake/check_mpitype.cmake)
 endif()
-
 
 check_symbol_exists(realloc stdlib.h SC_ENABLE_USE_REALLOC)
 

--- a/cmake/pkgconf.pc.in
+++ b/cmake/pkgconf.pc.in
@@ -4,14 +4,6 @@ exec_prefix=${prefix}
 libdir=${prefix}/lib
 includedir=${prefix}/include
 
-libsc_CC=@SC_CC@
-libsc_CFLAGS=@SC_CPPFLAGS@ @SC_CFLAGS@
-
-have_mpi=@mpi_pc@
-have_json=@sc_have_json_pc@
-build_zlib=@zlib_pc@
-debug_build=@debug_build_pc@
-
 Name: libsc
 Description: @CMAKE_PROJECT_DESCRIPTION@
 Version: @git_version@

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -161,8 +161,8 @@
 /* Define to 1 'gettimeofday' is available */
 #cmakedefine SC_HAVE_GETTIMEOFDAY 1
 
-/* desired alignment of allocations in bytes */
-#define SC_MEMALIGN_BYTES (SC_SIZEOF_VOID_P)
+/* Desired alignment of allocations in bytes */
+#define SC_MEMALIGN_BYTES (8)
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #cmakedefine SC_HAVE_UNISTD_H 1
@@ -216,28 +216,6 @@
 /* Define to the version of this package. */
 #ifndef SC_PACKAGE_VERSION
 #define SC_PACKAGE_VERSION "@PROJECT_VERSION@"
-#endif
-
-/* Byte sizes of standard types */
-#ifndef SC_SIZEOF_INT
-#define SC_SIZEOF_INT @SC_SIZEOF_INT@
-#endif
-#ifndef SC_SIZEOF_UNSIGNED_INT
-#define SC_SIZEOF_UNSIGNED_INT @SC_SIZEOF_UNSIGNED_INT@
-#endif
-#ifndef SC_SIZEOF_LONG
-#define SC_SIZEOF_LONG @SC_SIZEOF_LONG@
-#endif
-#ifndef SC_SIZEOF_UNSIGNED_LONG
-#define SC_SIZEOF_UNSIGNED_LONG @SC_SIZEOF_UNSIGNED_LONG@
-#endif
-#ifndef SC_SIZEOF_LONG_LONG
-#define SC_SIZEOF_LONG_LONG @SC_SIZEOF_LONG_LONG@
-#endif
-
-/* The size of `void *', as computed by sizeof. */
-#ifndef SC_SIZEOF_VOID_P
-#define SC_SIZEOF_VOID_P @SC_SIZEOF_VOID_P@
 #endif
 
 /* Version number of package */

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -42,6 +42,11 @@
 /* Define to 1 if we can use MPI_Win_allocate_shared */
 #cmakedefine SC_ENABLE_MPIWINSHARED 1
 
+/* This definition is a convenience */
+#if defined SC_ENABLE_MPIWINSHARED && defined SC_ENABLE_MPICOMMSHARED
+#define SC_ENABLE_MPISHARED 1
+#endif
+
 /* Undefine if: disable non-thread-safe internal debug counters */
 #define SC_ENABLE_USE_COUNTERS 1
 

--- a/cmake/sc_config.h.in
+++ b/cmake/sc_config.h.in
@@ -1,26 +1,6 @@
 #ifndef _SRC_SC_CONFIG_H
 #define _SRC_SC_CONFIG_H 1
 
-/* C compiler */
-#ifndef SC_CC
-#define SC_CC @SC_CC@
-#endif
-
-/* C compiler flags */
-#ifndef SC_CFLAGS
-#define SC_CFLAGS @SC_CFLAGS@
-#endif
-
-/* C preprocessor */
-#ifndef SC_CPP
-#define SC_CPP @SC_CPP@
-#endif
-
-/* C preprocessor flags */
-#ifndef SC_CPPFLAGS
-#define SC_CPPFLAGS @SC_CPPFLAGS@
-#endif
-
 #cmakedefine SC_HAVE_ZLIB 1
 
 /* Define to 1 if we are using threads */
@@ -172,16 +152,6 @@
 
 /* Use builtin getopt */
 #cmakedefine SC_PROVIDE_GETOPT 1
-
-/* Linker flags */
-#ifndef SC_LDFLAGS
-#define SC_LDFLAGS @SC_LDFLAGS@
-#endif
-
-/* Libraries */
-#ifndef SC_LIBS
-#define SC_LIBS @SC_LIBS@
-#endif
 
 /* Name of package */
 #ifndef SC_PACKAGE

--- a/config/sc_autotools.pc.in
+++ b/config/sc_autotools.pc.in
@@ -4,14 +4,6 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-libsc_CC=@CC@
-libsc_CFLAGS=@CPPFLAGS@ @CFLAGS@
-
-have_mpi=@HAVE_PKG_MPI@
-have_json=@SC_HAVE_JSON@
-debug_build=@SC_ENABLE_DEBUG@
-build_zlib=no
-
 Name: libsc
 Description: The SC library supports parallel scientific applications.
 Version: @VERSION@

--- a/config/sc_memalign.m4
+++ b/config/sc_memalign.m4
@@ -15,9 +15,6 @@ dnl use the aligned version, relying on posix_memalign if it exists.
 dnl
 AC_DEFUN([SC_CHECK_MEMALIGN], [
 
-dnl check for size of types
-AC_CHECK_SIZEOF([void *])
-
 dnl check for presence of functions
 AC_CHECK_FUNCS([aligned_alloc posix_memalign])
 
@@ -35,13 +32,11 @@ if test "x$$1_ENABLE_MEMALIGN" != xno ; then
 
     dnl make sure the alignment is a number
     $1_MEMALIGN_BYTES=`echo "$$1_ENABLE_MEMALIGN" | tr -c -d '[[:digit:]]'`
-    $1_MEMALIGN_BYTES_LINK="$$1_MEMALIGN_BYTES"
     if test "x$$1_MEMALIGN_BYTES" = x ; then
       AC_MSG_ERROR([please provide --enable-memalign with a numeric value or nothing])
     fi
   else
-    $1_MEMALIGN_BYTES_LINK="SIZEOF_VOID_P"
-    $1_MEMALIGN_BYTES="$1_$$1_MEMALIGN_BYTES_LINK"
+    $1_MEMALIGN_BYTES=8
   fi
   AC_DEFINE_UNQUOTED([MEMALIGN_BYTES], [($$1_MEMALIGN_BYTES)],
                      [desired alignment of allocations in bytes])
@@ -57,7 +52,7 @@ extern "C" void* aligned_alloc(size_t, size_t);
 #endif
 ]],
 [[
-int *a = (int *) aligned_alloc ($$1_MEMALIGN_BYTES_LINK, 3 * sizeof(*a));
+int *a = (int *) aligned_alloc ($$1_MEMALIGN_BYTES, 3 * sizeof(*a));
 free(a);
 ]])],
                    [], [AC_MSG_ERROR([linking aligned_alloc failed])])
@@ -72,7 +67,7 @@ dnl verify that posix_memalign can be linked against
 ]],
 [[
 int *a;
-posix_memalign((void **) &a, $$1_MEMALIGN_BYTES_LINK, 3 * sizeof(*a));
+posix_memalign((void **) &a, $$1_MEMALIGN_BYTES, 3 * sizeof(*a));
 free(a);
 ]])],
                    [], [AC_MSG_ERROR([linking posix_memalign failed])])

--- a/configure.ac
+++ b/configure.ac
@@ -64,12 +64,6 @@ echo "o---------------------------------------"
 AC_C_CONST
 AC_C_INLINE
 AC_C_RESTRICT
-AC_CHECK_SIZEOF([int])
-AC_CHECK_SIZEOF([unsigned int])
-AC_CHECK_SIZEOF([long])
-AC_CHECK_SIZEOF([unsigned long])
-AC_CHECK_SIZEOF([long long])
-AC_CHECK_SIZEOF([void *])
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
 

--- a/configure.ac
+++ b/configure.ac
@@ -61,7 +61,6 @@ echo "o---------------------------------------"
 echo "| Checking keywords and types"
 echo "o---------------------------------------"
 
-AC_C_BIGENDIAN([AC_DEFINE([IS_BIGENDIAN], 1, [Define to 1 on a bigendian machine])])
 AC_C_CONST
 AC_C_INLINE
 AC_C_RESTRICT

--- a/configure.ac
+++ b/configure.ac
@@ -93,30 +93,6 @@ echo "o---------------------------------------"
 SC_CHECK_LIBRARIES([SC])
 
 # Print summary.
-
-m4_ifset([SC_CHECK_MPI_F77], [
-AC_DEFINE_UNQUOTED(F77,         ["${F77}"],         [F77 compiler])
-AC_DEFINE_UNQUOTED(FFLAGS,      ["${FFLAGS}"],      [F77 compiler flags])
-])
-m4_ifset([SC_CHECK_MPI_FC], [
-AC_DEFINE_UNQUOTED(FC,          ["${FC}"],          [FC compiler])
-AC_DEFINE_UNQUOTED(FCFLAGS,     ["${FCFLAGS}"],     [FC compiler flags])
-])
-AC_DEFINE_UNQUOTED(CPP,         ["${CPP}"],         [C preprocessor])
-AC_DEFINE_UNQUOTED(CPPFLAGS,    ["${CPPFLAGS}"],    [C preprocessor flags])
-AC_DEFINE_UNQUOTED(CC,          ["${CC}"],          [C compiler])
-dnl AC_DEFINE_UNQUOTED(C_VERSION,   ["${C_VERSION}"],   [C compiler version])
-AC_DEFINE_UNQUOTED(CFLAGS,      ["${CFLAGS}"],      [C compiler flags])
-m4_ifset([SC_CHECK_MPI_CXX], [
-AC_DEFINE_UNQUOTED(CXX,         ["${CXX}"],         [CXX compiler])
-AC_DEFINE_UNQUOTED(CXXFLAGS,    ["${CXXFLAGS}"],    [CXX compiler flags])
-])
-AC_DEFINE_UNQUOTED(LDFLAGS,     ["${LDFLAGS}"],     [Linker flags])
-AC_DEFINE_UNQUOTED(LIBS,        ["${LIBS}"],        [Libraries])
-dnl AC_DEFINE_UNQUOTED(BLAS_LIBS,   ["${BLAS_LIBS}"],   [BLAS libraries])
-dnl AC_DEFINE_UNQUOTED(LAPACK_LIBS, ["${LAPACK_LIBS}"], [LAPACK libraries])
-dnl AC_DEFINE_UNQUOTED(FLIBS,       ["${FLIBS}"],       [Fortran libraries])
-
 echo "o----------------------------------"
 echo "| Results for libsc are"
 echo "o----------------------------------"

--- a/src/sc.c
+++ b/src/sc.c
@@ -1293,9 +1293,6 @@ sc_init (sc_MPI_Comm mpicomm,
          int catch_signals, int print_backtrace,
          sc_log_handler_t log_handler, int log_threshold)
 {
-#if 0
-  const int           w = 24;
-#endif
   const char         *trace_file_name;
   const char         *trace_file_prio;
 
@@ -1361,22 +1358,8 @@ sc_init (sc_MPI_Comm mpicomm,
     }
   }
 
+  /* one line of logging if the threshold is not SC_LP_SILENT */
   SC_GLOBAL_ESSENTIALF ("This is %s\n", SC_PACKAGE_STRING);
-#if 0
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "F77", SC_F77);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "FFLAGS", SC_FFLAGS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CPP", SC_CPP);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CPPFLAGS", SC_CPPFLAGS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CC", SC_CC);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "C_VERSION", SC_C_VERSION);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CFLAGS", SC_CFLAGS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LDFLAGS", SC_LDFLAGS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LIBS", SC_LIBS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "BLAS_LIBS", SC_BLAS_LIBS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LAPACK_LIBS", SC_LAPACK_LIBS);
-  SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "FLIBS", SC_FLIBS);
-#endif
-
   sc_initialized = 1;
 }
 

--- a/src/sc.c
+++ b/src/sc.c
@@ -1611,6 +1611,13 @@ sc_version_point (void)
 #endif
 
 int
+sc_is_littleendian (void)
+{
+  const uint32_t      uint = 1;
+  return *(char *) &uint == 1;
+}
+
+int
 sc_have_zlib (void)
 {
 #ifndef SC_HAVE_ZLIB

--- a/src/sc.c
+++ b/src/sc.c
@@ -1613,7 +1613,10 @@ sc_version_point (void)
 int
 sc_is_littleendian (void)
 {
-  const uint32_t      uint = 1;
+  /* We use the volatile keyword to deactivate compiler optimizations related
+   * to the variable uint.
+   */
+  const volatile uint32_t uint = 1;
   return *(char *) &uint == 1;
 }
 

--- a/src/sc.c
+++ b/src/sc.c
@@ -1293,7 +1293,9 @@ sc_init (sc_MPI_Comm mpicomm,
          int catch_signals, int print_backtrace,
          sc_log_handler_t log_handler, int log_threshold)
 {
-  int                 w;
+#if 0
+  const int           w = 24;
+#endif
   const char         *trace_file_name;
   const char         *trace_file_prio;
 
@@ -1359,22 +1361,17 @@ sc_init (sc_MPI_Comm mpicomm,
     }
   }
 
-  w = 24;
   SC_GLOBAL_ESSENTIALF ("This is %s\n", SC_PACKAGE_STRING);
 #if 0
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "F77", SC_F77);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "FFLAGS", SC_FFLAGS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CPP", SC_CPP);
-#endif
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CPPFLAGS", SC_CPPFLAGS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CC", SC_CC);
-#if 0
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "C_VERSION", SC_C_VERSION);
-#endif
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "CFLAGS", SC_CFLAGS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LDFLAGS", SC_LDFLAGS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LIBS", SC_LIBS);
-#if 0
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "BLAS_LIBS", SC_BLAS_LIBS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "LAPACK_LIBS", SC_LAPACK_LIBS);
   SC_GLOBAL_PRODUCTIONF ("%-*s %s\n", w, "FLIBS", SC_FLIBS);

--- a/src/sc.h
+++ b/src/sc.h
@@ -857,6 +857,11 @@ int                 sc_version_major (void);
  */
 int                 sc_version_minor (void);
 
+/** Perform a runtime check for the integer endian convention.
+ * \return          True if byte order is little endian, false otherwise.
+ */
+int                 sc_is_littleendian (void);
+
 #if 0
 /* Sadly, the point version macro by autoconf doesn't work with vX and vX.Y.
    The remaining option is to use sc_version and parse its return string. */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,15 +6,11 @@ if(SC_HAVE_RANDOM AND SC_HAVE_SRANDOM)
   list(APPEND sc_tests node_comm)
 endif()
 
-if(SC_SIZEOF_LONG GREATER_EQUAL 8)
-  list(APPEND sc_tests helpers)
-endif()
-
 if(SC_HAVE_UNISTD_H)
   list(APPEND sc_tests sort)
 endif()
 
-list(APPEND sc_tests builtin io_sink)
+list(APPEND sc_tests builtin io_sink helpers)
 
 set(MPI_WRAPPER)
 if(MPIEXEC_EXECUTABLE)

--- a/test/test_helpers.c
+++ b/test/test_helpers.c
@@ -339,7 +339,7 @@ main (int argc, char **argv)
   /* test integer conversion functions */
   num_failed_tests = 0;
   num_failed_tests += TH (SC_TEST_TOOLONG, "too long", 0, 0);
-  num_failed_tests += TH (SC_TEST_LONG, "long", 0, 1);
+  num_failed_tests += TH (SC_TEST_LONG, "long", 0, sizeof (long) >= 8);
   num_failed_tests += TH (SC_TEST_INT, "int", 1, 1);
 
   /* test encode and decode functions */


### PR DESCRIPTION
# Meet requirements for distribution

For some Linux distributions, sc_config.h must not include arch dependencies.

## Proposed changes

Since we really did not need most of these compiler and flag variables, remove them.
Any comments? Especially on the pkgconfig setup. @tamiko