### PR TITLE
scda: Rename options to params and add logging level

### DIFF
--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -770,7 +770,8 @@ sc_scda_examine_params (sc_scda_params_t * params, sc_scda_fcontext_t *fc,
     ret = sc_scda_check_coll_params (fc, (const char *) &params->fuzzy_everyn,
                                      sizeof (unsigned),
                                      (const char *) &params->fuzzy_seed,
-                                     sizeof (sc_rand_state_t), NULL, 0);
+                                     sizeof (sc_rand_state_t),
+                                     (const char *) &params->log_level, sizeof (int));
     SC_ASSERT (ret == SC_SCDA_FERR_SUCCESS || ret == SC_SCDA_FERR_ARG);
 
     if (ret == SC_SCDA_FERR_ARG) {

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -257,6 +257,9 @@ struct sc_scda_fcontext
                                         the user-defined seed but is adjusted
                                         to the state after each call of
                                         \ref sc_rand. */
+  int                 log_level;      /**< The log level for the scda functions.
+                                        The possible values are documented in
+                                        \ref sc.h; cf. SC_LP_* macros. */
   /* *INDENT-ON* */
 };
 
@@ -771,18 +774,32 @@ sc_scda_examine_params (sc_scda_params_t * params, sc_scda_fcontext_t *fc,
       /* no fuzzy error testing in case of an error */
       fc->fuzzy_everyn = 0;
       fc->fuzzy_seed = 0;
+      /* in case of an error we use the default log level */
+#ifdef SC_ENABLE_DEBUG
+      fc->log_level = SC_LP_ERROR;
+#else
+      fc->log_level = SC_LP_SILENT;
+#endif
       return SC_SCDA_FERR_ARG;
     }
 
     *info = params->info;
     fc->fuzzy_everyn = params->fuzzy_everyn;
     fc->fuzzy_seed = params->fuzzy_seed;
+
+    fc->log_level = params->log_level;
   }
   else {
     *info = sc_MPI_INFO_NULL;
     /* no fuzzy error return by default */
     fc->fuzzy_everyn = 0;
     fc->fuzzy_seed = 0;
+    /* set default log level */
+#ifdef SC_ENABLE_DEBUG
+    fc->log_level = SC_LP_ERROR;
+#else
+    fc->log_level = SC_LP_SILENT;
+#endif
   }
 
   return SC_SCDA_FERR_SUCCESS;
@@ -1174,6 +1191,22 @@ sc_scda_file_error_cleanup (sc_MPI_File * file)
   SC_FREE (*file);
 #endif
   return -1;
+}
+
+void
+sc_scda_params_init (sc_scda_params_t *params)
+{
+  SC_ASSERT (params != NULL);
+
+  /* set the defaults for the scda parameters/options */
+  params->info = sc_MPI_INFO_NULL;
+  params->fuzzy_everyn = 0;
+  params->fuzzy_seed = 0;
+#ifdef SC_ENABLE_DEBUG
+  params->log_level = SC_LP_ERROR;
+#else
+  params->log_level = SC_LP_SILENT;
+#endif
 }
 
 /** This function peforms the start up for both scda fopen functions.

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1178,7 +1178,7 @@ sc_scda_file_error_cleanup (sc_MPI_File * file)
 
 /** This function peforms the start up for both scda fopen functions.
  *
- * \param [in]   params        The sc_scda_params_t structure that is
+ * \param [in]   params     The sc_scda_params_t structure that is
  *                          passed to the scda fopen function. \b params may be
  *                          NULL.
  * \param [in]   mpicomm    The MPI communicator of the scda fopen function.

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -39,7 +39,7 @@
  * and reading.
  *
  * In addition, we add in this file the options structure \ref
- * sc_scda_fopen_options as parameter for opening files.
+ * sc_scda_params as parameter for opening files.
  *
  * The file format includes
  * metadata in ASCII and therefore enables the human eye to parse the
@@ -281,14 +281,14 @@ typedef struct sc_scda_ferror
 }
 sc_scda_ferror_t;
 
-/** An options struct for the functions \ref sc_scda_fopen_write and
+/** A parameter struct for the functions \ref sc_scda_fopen_write and
  * \ref sc_scda_fopen_read. The struct may be extended in the future.
  *
  * The option struct is a collective structure. If the options structure that
  * is passed to a function is not the same on all processes, the whole
  * following scda workflow has undefined behavior.
  */
-typedef struct sc_scda_fopen_options
+typedef struct sc_scda_params
 {
   sc_MPI_Info         info; /**< info that is passed to MPI_File_open */
   unsigned            fuzzy_everyn; /**< In average every n-th possible error
@@ -308,7 +308,7 @@ typedef struct sc_scda_fopen_options
                                        fuzzy_everyn == 0. When in doubt use
                                        fuzzy_seed = 0. */
 }
-sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
+sc_scda_params_t; /**< type for \ref sc_scda_params */
 
 /** Open a file for writing and write the file header to the file.
  *
@@ -349,10 +349,10 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
  *                           terminating nul.
  *                           On NULL as input \b user_string is expected to be a
  *                           nul-terminated C string.
- * \param [in]     opt       An options structure that provides the possibility
+ * \param [in]     params    A parameter structure that provides the possibility
  *                           to pass further options. See \ref
- *                           sc_scda_fopen_options for more details.
- *                           It is valid to pass NULL for \b opt.
+ *                           sc_scda_params for more details.
+ *                           It is valid to pass NULL for \b params.
  * \param [out]    errcode   An errcode that can be interpreted by \ref
  *                           sc_scda_ferror_string or mapped to an error class
  *                           by \ref sc_scda_ferror_class.
@@ -364,7 +364,7 @@ sc_scda_fopen_options_t; /**< type for \ref sc_scda_fopen_options */
 sc_scda_fcontext_t *sc_scda_fopen_write (sc_MPI_Comm mpicomm,
                                          const char *filename,
                                          const char *user_string, size_t *len,
-                                         sc_scda_fopen_options_t * opt,
+                                         sc_scda_params_t * params,
                                          sc_scda_ferror_t * errcode);
 
 /** Write an inline data section.
@@ -714,10 +714,10 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  * \param [out]    len       On output \b len is set to the number of bytes
  *                           written to \b user_string excluding the terminating
  *                           nul.
- * \param [in]     opt       An options structure that provides the possibility
+ * \param [in]     params    A parameter structure that provides the possibility
  *                           to pass further options. See \ref
- *                           sc_scda_fopen_options for more details.
- *                           It is valid to pass NULL for \b opt.
+ *                           sc_scda_params for more details.
+ *                           It is valid to pass NULL for \b params.
  * \param [out]    errcode   An errcode that can be interpreted by \ref
  *                           sc_scda_ferror_string or mapped to an error class
  *                           by \ref sc_scda_ferror_class.
@@ -729,7 +729,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
 sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
                                         const char *filename,
                                         char *user_string, size_t *len,
-                                        sc_scda_fopen_options_t * opt,
+                                        sc_scda_params_t * params,
                                         sc_scda_ferror_t * errcode);
 
 /** Read the next file section header.

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -368,7 +368,9 @@ void sc_scda_params_init (sc_scda_params_t *params);
  *                           It is valid to pass NULL for \b params.
  * \param [out]    errcode   An errcode that can be interpreted by \ref
  *                           sc_scda_ferror_string or mapped to an error class
- *                           by \ref sc_scda_ferror_class.
+ *                           by \ref sc_scda_ferror_class. \b errcode encodes
+ *                           success if and only if the function does not
+ *                           return NULL.
  * \return                   Newly allocated context to continue writing
  *                           and eventually closing the file. NULL in
  *                           case of error, i.e. errcode != \ref
@@ -412,7 +414,9 @@ sc_scda_fcontext_t *sc_scda_fopen_write (sc_MPI_Comm mpicomm,
  *                              \b inline_data is written to the file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -474,7 +478,9 @@ sc_scda_fcontext_t *sc_scda_fwrite_inline (sc_scda_fcontext_t * fc,
  *                              description in this file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -555,7 +561,9 @@ sc_scda_fcontext_t *sc_scda_fwrite_block (sc_scda_fcontext_t * fc,
  *                              description in this file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -594,7 +602,9 @@ sc_scda_fcontext_t *sc_scda_fwrite_array (sc_scda_fcontext_t * fc,
  *                              filled with the number bytes per process.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      0 in case of success and -1 otherwise.
  */
 int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
@@ -679,7 +689,9 @@ int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
  *                              description in this file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -733,7 +745,9 @@ sc_scda_fcontext_t *sc_scda_fwrite_varray (sc_scda_fcontext_t * fc,
  *                           It is valid to pass NULL for \b params.
  * \param [out]    errcode   An errcode that can be interpreted by \ref
  *                           sc_scda_ferror_string or mapped to an error class
- *                           by \ref sc_scda_ferror_class.
+ *                           by \ref sc_scda_ferror_class. \b errcode encodes
+ *                           success if and only if the function does not
+ *                           return NULL.
  * \return                   Newly allocated context to continue reading
  *                           and eventually closing the file. NULL in
  *                           case of error, i.e. errcode != \ref
@@ -800,7 +814,9 @@ sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  *                              description in this file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -839,7 +855,9 @@ sc_scda_fcontext_t *sc_scda_fread_section_header (sc_scda_fcontext_t * fc,
  *                              \b data is read from the file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -877,7 +895,9 @@ sc_scda_fcontext_t *sc_scda_fread_inline_data (sc_scda_fcontext_t * fc,
  *                              \b block_data is read from the file.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -937,7 +957,9 @@ sc_scda_fcontext_t *sc_scda_fread_block_data (sc_scda_fcontext_t * fc,
  *                              the parameter \b array_data for more information.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -987,7 +1009,9 @@ sc_scda_fcontext_t *sc_scda_fread_array_data (sc_scda_fcontext_t * fc,
  *                              \ref sc_scda_fread_section_header.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -1062,7 +1086,9 @@ sc_scda_fcontext_t *sc_scda_fread_varray_sizes (sc_scda_fcontext_t * fc,
  *                              the parameter \b array_data for more information.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
- *                              by \ref sc_scda_ferror_class.
+ *                              by \ref sc_scda_ferror_class. \b errcode encodes
+ *                              success if and only if the function does not
+ *                              return NULL.
  * \return                      Return a pointer to the input
  *                              context \b fc on success.
  *                              The context is used to continue
@@ -1139,7 +1165,9 @@ int                 sc_scda_ferror_string (sc_scda_ferror_t errcode,
  *                            after a call of this function.
  * \param [out]     errcode   An errcode that can be interpreted by \ref
  *                            sc_scda_ferror_string or mapped to an error class
- *                            by \ref sc_scda_ferror_class.
+ *                            by \ref sc_scda_ferror_class. \b errcode encodes
+ *                            success if and only if the function returns
+ *                            return 0.
  * \return                    \ref SC_SCDA_FERR_SUCCESS for a successful call
  *                            and -1 in case a of an error.
  *                            See also \b errcode argument.

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -258,8 +258,11 @@ sc_scda_ret_t;
 /** Error values for the scda functions.
  * An error value is a struct since the error can be related to the scda
  * file format or to (MPI) I/O operations. The error code can be converted to a
- * string by \ref sc_scda_ferror_string and mapped to an error class by \ref
- * sc_scda_ferror_class.
+ * string by \ref sc_scda_ferror_string, mapped to an error class by \ref
+ * sc_scda_ferror_class and checked for success by \ref
+ * sc_scda_ferror_is_success. The user can rely on these functions to
+ * parse sc_scda_ferror and does not need to access the members of this
+ * structure.
  *
  * The parsing logic of \ref sc_scda_ferror_t is that first \b scdaret is examined
  * and if \b scdaret != \ref SC_SCDA_FERR_MPI, we know that \b mpiret = 0.

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -310,8 +310,18 @@ typedef struct sc_scda_params
                                        This value is ignored if
                                        fuzzy_everyn == 0. When in doubt use
                                        fuzzy_seed = 0. */
+  int                 log_level;  /**< The log level for the scda functions.
+                                       The possible values are documented in
+                                       \ref sc.h; cf. SC_LP_* macros. */
 }
 sc_scda_params_t; /**< type for \ref sc_scda_params */
+
+/** Initialize a scda parameter structure to the defaults.
+ *
+ * \param [out]    params    \ref sc_scda_params structure that is filled with
+ *                            the default parameters.
+ */
+void sc_scda_params_init (sc_scda_params_t *params);
 
 /** Open a file for writing and write the file header to the file.
  *

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -549,6 +549,7 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
   mpiret = sc_MPI_Comm_size (mpicomm, &mpisize);
   SC_CHECK_MPI (mpiret);
+  sc_scda_params_init (&scda_params_err);
   scda_params_err.info = sc_MPI_INFO_NULL;
   if (mpirank == 0) {
     scda_params_err.fuzzy_everyn = 0;
@@ -604,6 +605,7 @@ main (int argc, char **argv)
    * fuzzy error testing. Nonetheless, our implementation is designed to be
    * able to handle this situations properly.
    */
+  sc_scda_params_init (&scda_params);
   scda_params.fuzzy_everyn = (unsigned) int_everyn;
   if (scda_params.fuzzy_everyn > 0 && int_seed < 0) {
     scda_params.fuzzy_seed = (sc_rand_state_t) sc_MPI_Wtime ();

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -33,7 +33,7 @@
 
 static void
 test_scda_skip_through_file (sc_MPI_Comm mpicomm, const char *filename,
-                             sc_scda_fopen_options_t *opt, int mpirank,
+                             sc_scda_params_t *params, int mpirank,
                              int mpisize)
 {
   sc_scda_fcontext_t *fc;
@@ -47,7 +47,7 @@ test_scda_skip_through_file (sc_MPI_Comm mpicomm, const char *filename,
   sc_array_t          elem_counts, data;
 
   /* open the file for reading */
-  fc = sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, opt,
+  fc = sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, params,
                            &errcode);
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode), "sc_scda_fopen_read "
                   "failed");
@@ -500,7 +500,7 @@ main (int argc, char **argv)
   char                read_user_string[SC_SCDA_USER_STRING_BYTES + 1];
   char                section_type;
   sc_scda_fcontext_t *fc;
-  sc_scda_fopen_options_t scda_opt, scda_opt_err;
+  sc_scda_params_t    scda_params, scda_params_err;
   sc_scda_ferror_t    errcode;
   size_t              len;
   size_t              elem_count, elem_size;
@@ -549,14 +549,14 @@ main (int argc, char **argv)
   SC_CHECK_MPI (mpiret);
   mpiret = sc_MPI_Comm_size (mpicomm, &mpisize);
   SC_CHECK_MPI (mpiret);
-  scda_opt_err.info = sc_MPI_INFO_NULL;
+  scda_params_err.info = sc_MPI_INFO_NULL;
   if (mpirank == 0) {
-    scda_opt_err.fuzzy_everyn = 0;
-    scda_opt_err.fuzzy_seed = 0;
+    scda_params_err.fuzzy_everyn = 0;
+    scda_params_err.fuzzy_seed = 0;
   }
   else {
-    scda_opt_err.fuzzy_everyn = 1;
-    scda_opt_err.fuzzy_seed = 0;
+    scda_params_err.fuzzy_everyn = 1;
+    scda_params_err.fuzzy_seed = 0;
   }
   if (mpisize > 1) {
     SC_GLOBAL_ESSENTIAL
@@ -566,7 +566,7 @@ main (int argc, char **argv)
   }
   /* fopen_write with non-collective fuzzy error parameters */
   fc = sc_scda_fopen_write (mpicomm, filename, file_user_string, NULL,
-                            &scda_opt_err, &errcode);
+                            &scda_params_err, &errcode);
   if (mpisize > 1) {
     SC_CHECK_ABORT (fc == NULL && errcode.scdaret == SC_SCDA_FERR_ARG,
                     "Test fuzzy error parameters check");
@@ -582,7 +582,7 @@ main (int argc, char **argv)
   /* fopen_read with non-collective fuzzy error parameters */
   fc =
     sc_scda_fopen_read (mpicomm, filename, read_user_string, &len,
-                        &scda_opt_err, &errcode);
+                        &scda_params_err, &errcode);
   if (mpisize > 1) {
     SC_CHECK_ABORT (fc == NULL && errcode.scdaret == SC_SCDA_FERR_ARG,
                     "Test fuzzy error parameters check");
@@ -596,30 +596,30 @@ main (int argc, char **argv)
                     "scda_fclose after read failed");
   }
 
-  /* Create valid scda options structure. */
-  /* set the options to actiavate fuzzy error testing */
+  /* Create valid scda parameters structure. */
+  /* set the parameters to actiavate fuzzy error testing */
   /* WARNING: Fuzzy error testing means that the code randomly produces
    * errors. Random errors mean in particular that error codes may arise from
    * code places, which can not produce such particular error codes without
    * fuzzy error testing. Nonetheless, our implementation is designed to be
    * able to handle this situations properly.
    */
-  scda_opt.fuzzy_everyn = (unsigned) int_everyn;
-  if (scda_opt.fuzzy_everyn > 0 && int_seed < 0) {
-    scda_opt.fuzzy_seed = (sc_rand_state_t) sc_MPI_Wtime ();
+  scda_params.fuzzy_everyn = (unsigned) int_everyn;
+  if (scda_params.fuzzy_everyn > 0 && int_seed < 0) {
+    scda_params.fuzzy_seed = (sc_rand_state_t) sc_MPI_Wtime ();
     mpiret =
-      sc_MPI_Bcast (&scda_opt.fuzzy_seed, 1, sc_MPI_UNSIGNED, 0, mpicomm);
+      sc_MPI_Bcast (&scda_params.fuzzy_seed, 1, sc_MPI_UNSIGNED, 0, mpicomm);
     SC_CHECK_MPI (mpiret);
     SC_GLOBAL_INFOF ("Fuzzy error return with time-dependent seed activated. "
-                     "The seed is %lld.\n", (long long) scda_opt.fuzzy_seed);
+                     "The seed is %lld.\n", (long long) scda_params.fuzzy_seed);
   }
   else {
-    scda_opt.fuzzy_seed = (sc_rand_state_t) int_seed;
+    scda_params.fuzzy_seed = (sc_rand_state_t) int_seed;
   }
-  scda_opt.info = sc_MPI_INFO_NULL;
+  scda_params.info = sc_MPI_INFO_NULL;
 
   fc = sc_scda_fopen_write (mpicomm, filename, file_user_string, NULL,
-                            &scda_opt, &errcode);
+                            &scda_params, &errcode);
   /* TODO: check errcode */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fopen_write failed");
@@ -683,7 +683,7 @@ main (int argc, char **argv)
   }
 
   fc =
-    sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_opt,
+    sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_params,
                         &errcode);
   /* TODO: check errcode */
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
@@ -775,7 +775,7 @@ main (int argc, char **argv)
                   "scda_fclose after read failed");
 
   fc =
-    sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_opt,
+    sc_scda_fopen_read (mpicomm, filename, read_user_string, &len, &scda_params,
                         &errcode);
   SC_CHECK_ABORT (sc_scda_ferror_is_success (errcode),
                   "scda_fopen_read failed");
@@ -792,7 +792,7 @@ main (int argc, char **argv)
   SC_GLOBAL_ESSENTIAL ("End of expected error path: test successful\n");
 
   /* skip through file and test non-collective skipping */
-  test_scda_skip_through_file (mpicomm, filename, &scda_opt, mpirank,
+  test_scda_skip_through_file (mpicomm, filename, &scda_params, mpirank,
                                mpisize);
 
   sc_options_destroy (opt);

--- a/test/test_scda.c
+++ b/test/test_scda.c
@@ -560,10 +560,10 @@ main (int argc, char **argv)
     scda_params_err.fuzzy_seed = 0;
   }
   if (mpisize > 1) {
-    SC_GLOBAL_ESSENTIAL
-      ("We expect two invalid scda function parameter errors."
-       " This is just for testing purposes and does not imply"
-       " erroneous code behavior.\n");
+    SC_GLOBAL_LOG
+      (scda_params_err.log_level, "We expect two invalid scda function"
+       " parameter errors. This is just for testing purposes and does not"
+       " imply erroneous code behavior.\n");
   }
   /* fopen_write with non-collective fuzzy error parameters */
   fc = sc_scda_fopen_write (mpicomm, filename, file_user_string, NULL,
@@ -661,9 +661,9 @@ main (int argc, char **argv)
 
   /* intentionally try to write with non-collective block size */
   if (mpisize > 1) {
-    SC_GLOBAL_ESSENTIAL
-      ("We expect an invalid scda function parameter error."
-       " This is just for testing purposes and do not imply"
+    SC_GLOBAL_LOG
+      (scda_params.log_level, "We expect an invalid scda function parameter"
+       " error. This is just for testing purposes and does not imply"
        " erroneous code behavior.\n");
     fc = sc_scda_fwrite_block (fc, "A block section", NULL, &data,
                                (mpirank == 0) ? 32 : 33, mpisize - 1, 0,
@@ -783,15 +783,16 @@ main (int argc, char **argv)
                   "scda_fopen_read failed");
 
   /* provoke error for invalid scda workflow */
-  SC_GLOBAL_ESSENTIAL ("We expect an error for incorrect workflow for scda"
-                       " reading function, which is triggered on purpose to"
-                       " test the error checking\n");
+  SC_GLOBAL_LOG (scda_params.log_level, "We expect an error for incorrect"
+                 " workflow for scda reading function, which is"
+                 " triggered on purpose to test the error checking\n");
   fc = sc_scda_fread_inline_data (fc, &data, 0, &errcode);
   SC_CHECK_ABORT (!sc_scda_ferror_is_success (errcode) &&
                   errcode.scdaret == SC_SCDA_FERR_USAGE && fc == NULL,
                   "sc_scda_fread_section_header error detection failed");
   /* fc is closed and deallocated due to the occurred error  */
-  SC_GLOBAL_ESSENTIAL ("End of expected error path: test successful\n");
+  SC_GLOBAL_LOG (scda_params.log_level, "End of expected error path: test"
+                                        " successful\n");
 
   /* skip through file and test non-collective skipping */
   test_scda_skip_through_file (mpicomm, filename, &scda_params, mpirank,


### PR DESCRIPTION
# scda: Rename options to params and add logging level

This PR renames the scda options structure to `sc_scda_params_t` following the same semantics as the params structures in `p4est_wrap.h` and `p4est_mesh.h`. This includes introducing a new function to initialize the parameters, namely `sc_scda_params_init`. Additionally, this PR adds the logging level to the scda parameter structure and the scda file context to enable the user to control the logging of I/O errors.