### PR TITLE
Feature visibility

### DIFF
--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -26,6 +26,7 @@
  - Flag the scda API to be changed in the next release
  - Intremental documentation updates
  - Add a portable sleep function
+ - Remove unused sc_handler_t
 
 ### Build system
 

--- a/doc/release_notes.txt
+++ b/doc/release_notes.txt
@@ -19,6 +19,7 @@
 ### Functionality
 
  - Fix extern "C" macro for using C++ compilers with libsc .c files
+ - Add compiler argument for visibility of extern variables
  - Add sc_MPI_Aint and sc_MPI_Aint_diff
  - Add sc_MPI_UNSIGNED_LONG_LONG, sc_MPI_SIGNED_CHAR and sc_MPI_INT8_T
  - Implement a functional subset of the scda API for parallel I/O

--- a/src/sc.h
+++ b/src/sc.h
@@ -86,6 +86,36 @@
 #define SC_NOCOUNT_LOGINDENT
 #endif
 
+/* implement the default visibility attribute */
+
+#if defined _WIN32 || defined __CYGWIN__
+#if 0
+  /* this is currently not properly tested */
+  #ifdef BUILDING_DLL
+    #ifdef __GNUC__
+      #define SC_DLL_PUBLIC __attribute__ ((dllexport))
+    #else
+      #define SC_DLL_PUBLIC __declspec(dllexport)
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define SC_DLL_PUBLIC __attribute__ ((dllimport))
+    #else
+      #define SC_DLL_PUBLIC __declspec(dllimport)
+    #endif
+  #endif
+#else
+  /* while disabling the above definitions */
+  #define SC_DLL_PUBLIC
+#endif
+#else
+  #if __GNUC__ >= 4
+    #define SC_DLL_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+    #define SC_DLL_PUBLIC
+  #endif
+#endif
+
 /* use this in case mpi.h includes stdint.h */
 
 #ifndef __STDC_LIMIT_MACROS
@@ -221,14 +251,14 @@ extern const int    sc_log2_lookup_table[256];
  * It starts out with a value of -1, which is fine by itself.
  * It is set to a non-negative value by the (optional) \ref sc_init.
  */
-extern int          sc_package_id;
+extern SC_DLL_PUBLIC int sc_package_id;
 
 /** Optional trace file for logging (see \ref sc_init).
  * Initialized to NULL. */
-extern FILE        *sc_trace_file;
+extern SC_DLL_PUBLIC FILE *sc_trace_file;
 
 /** Optional minimum log priority for messages that go into the trace file. */
-extern int          sc_trace_prio;
+extern SC_DLL_PUBLIC int sc_trace_prio;
 
 /** Define machine epsilon for the double type. */
 #define SC_EPS               2.220446049250313e-16

--- a/src/sc.h
+++ b/src/sc.h
@@ -590,7 +590,6 @@ void                SC_LERRORF (const char *fmt, ...)
 
 /* callback typedefs */
 
-typedef void        (*sc_handler_t) (void *data);
 typedef void        (*sc_log_handler_t) (FILE * log_stream,
                                          const char *filename, int lineno,
                                          int package, int category,


### PR DESCRIPTION
# Add visibility attribute for GCC >= 4

## Proposed changes

Using p4est from a certain python library turned up multiple instances of the same extern variable, namely the package id (used internally for registering log priorities and debug memory counters). Add some defines to use the visibility attribute.

The attribute is placed only in the .h file for now. To make it work on windows, we may have to add it in front of the definition in the .c file, which I find a bit annoying. Shall we do it anyway or is the current approach sufficient?

Curious on feedback. @tamiko @sloede @lukasdreyer