### PR TITLE
Fixed Windows compilation issues with clang-cl and Visual Studio

### DIFF
--- a/doc/author_zhbhfut.txt
+++ b/doc/author_zhbhfut.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. Bing Zhang (zhangbing@hfut.edu.cn)

--- a/src/sc.c
+++ b/src/sc.c
@@ -51,7 +51,11 @@ typedef void        (*sc_sig_t) (int);
 #if _POSIX_C_SOURCE >= 199309L
 #include <time.h>
 #else
-#include <unistd.h>
+#ifdef _WIN32
+#   include <io.h>
+#else
+#   include <unistd.h>
+#endif
 #endif
 
 typedef struct sc_package

--- a/src/sc_camera.h
+++ b/src/sc_camera.h
@@ -105,6 +105,13 @@
 
 #include <sc_containers.h>
 
+#ifdef near
+#undef near
+#endif
+#ifdef far
+#undef far
+#endif
+
 /** The data type of the coordinates for sc_camera
  */
 /* p4est uses double, most computer graphic applications float on GPU. */

--- a/src/sc_camera.h
+++ b/src/sc_camera.h
@@ -105,13 +105,6 @@
 
 #include <sc_containers.h>
 
-#ifdef near
-#undef near
-#endif
-#ifdef far
-#undef far
-#endif
-
 /** The data type of the coordinates for sc_camera
  */
 /* p4est uses double, most computer graphic applications float on GPU. */


### PR DESCRIPTION
# Fixed Windows compilation issues with clang-cl and Visual Studio

Proposed changes:
+ On Windows, replace the missing  <unistd.h>  include with  <io.h>  in  sc.c .
+ Work around the  near / far  macros defined by  <windows.h>  so that the  near  and  far  members of  sc_camera_t  remain valid in sc_camera.h.
