### PR TITLE
Fix minor typos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+---
+exclude: doc/attic/|doc/author_*|AUTHORS|COPYING|example/linksc/COPYING|iniparser/LICENSE|libb64/README|config/ax_prefix_config_h.m4
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.36.2
+    hooks:
+      - id: typos

--- a/AUTHORS
+++ b/AUTHORS
@@ -58,7 +58,7 @@
   Advanced Computing Center (TACC) for providing them with access to the Ranger
   supercomputer under NSF TeraGrid award MCA04N026, and the National Center for
   Computational Science (NCCS) for early-user access to the Jaguar Cray XT5
-  supercomputer.  Any opinions, findings and conclusions or recomendations
+  supercomputer.  Any opinions, findings and conclusions or recommendations
   expressed in the source code and documentation are those of the authors and
   do not necessarily reflect the views of the National Science Foundation
   (NSF).
@@ -85,7 +85,7 @@
   domain software, see the LICENSE and AUTHORS files in that directory.
 
   The files under iniparser are derived from iniparser3.0b.  iniparser is
-  licensed unter the MIT license, see the LICENSE and AUTHORS files in
+  licensed under the MIT license, see the LICENSE and AUTHORS files in
   that directory.
 
   Several scripts under config are released under GNU GPL versions.

--- a/INSTALL
+++ b/INSTALL
@@ -288,4 +288,3 @@ operates.
 
 `configure' also accepts some other, not widely useful, options.  Run
 `configure --help' for more details.
-

--- a/NEWS
+++ b/NEWS
@@ -3,7 +3,7 @@ NEWS
 
  * The current stable version 2 of the libsc code is maintained in branches
    v2.2--v2.5.  It will be backwards compatible as much as possible.
-   The code will remain usable and bugfixed for the forseeable future.
+   The code will remain usable and bugfixed for the foreseeable future.
    The branches master (official) and develop (fairly stable) live here.
  * We have introduced a new development branch leading up to v3.0.
    The initial version is v2.8.  The branch is called prev3-develop.  On

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,8 @@
+#[default.extend-words]
+
+[default.extend-identifiers]
+sc_MPI_MODE_WRONLY = "sc_MPI_MODE_WRONLY"
+MPI_MODE_WRONLY = "MPI_MODE_WRONLY"
+PNGs = "PNGs"
+asend = "asend"
+nce = "nce"

--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -127,7 +127,7 @@ dnl its INVOCATION is one valid statement of a C/C++ program.
 dnl It may require INCLUDE statements to compile and link ok.
 dnl On the inside we call AC_LANG_PROGRAM(INCLUDE, INVOCATION).
 dnl The SEARCH_LIBS are a white-space separated list or empty.
-dnl The OTHER_LIBS may be empty or a list of depency libraries.
+dnl The OTHER_LIBS may be empty or a list of dependency libraries.
 dnl
 dnl This macro is modified from AC_SEARCH_LIBS.  In particular,
 dnl we use a separate cache variable ac_cv_sc_search_FUNCTION.

--- a/config/sc_mpi.m4
+++ b/config/sc_mpi.m4
@@ -495,7 +495,7 @@ dnl This was only used for our lint code, which needs to be replaced.
 dnl
 dnl dnl SC_MPI_INCLUDES
 dnl dnl Call the compiler with various --show* options
-dnl dnl to figure out the MPI_INCLUDES and MPI_INCLUDE_PATH varables
+dnl dnl to figure out the MPI_INCLUDES and MPI_INCLUDE_PATH variables
 dnl dnl
 dnl AC_DEFUN([SC_MPI_INCLUDES],
 dnl [

--- a/config/sc_package.m4
+++ b/config/sc_package.m4
@@ -107,7 +107,7 @@ $1_$3_RPATH=
 $1_DISTCLEAN="$$1_DISTCLEAN $1_$3_SOURCE.log"
 
 SC_ARG_WITH_PREFIX([$4],
-  [specifiy how to depend on package $4 (optional).
+  [specify how to depend on package $4 (optional).
    If the option value is literal no or the option is not present, use the
    source subdirectory.  If the option value is the literal external, expect
    all necessary environment variables to be set to compile and link against

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -457,7 +457,7 @@ LOOKUP_CACHE_SIZE      = 0
 # than 0 to get more control over the balance between CPU load and processing
 # speed. At this moment only the input processing can be done using multiple
 # threads. Since this is still an experimental feature the default is set to 1,
-# which efficively disables parallel processing. Please report any issues you
+# which effectively disables parallel processing. Please report any issues you
 # encounter. Generating dot graphs in parallel is controlled by the
 # DOT_NUM_THREADS setting.
 # Minimum value: 0, maximum value: 32, default value: 1.

--- a/doc/coding_standards.txt
+++ b/doc/coding_standards.txt
@@ -62,7 +62,7 @@ tries to adhere to.
 
        printf ("%jd %ju", (intmax_t) i, (uintmax_t) u);
 
-   since that would be a nice way to accomodate 128 bit integers without
+   since that would be a nice way to accommodate 128 bit integers without
    changing the `printf` code.
    This also holds for `size_t` since support for the following is still
    incomplete:

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -100,7 +100,7 @@
  *
  * This file contains routines for parallel I/O format.
  * In particular there are functions to write and read data in parallel according
- * to a user prescribed partition of contigously indexed potentially
+ * to a user prescribed partition of contiguously indexed potentially
  * variable-sized elements. In addition, the user can also write and read
  * data in serial and the data can be stored element-wise compressed.
  *

--- a/doc/portability/portitm4.sh
+++ b/doc/portability/portitm4.sh
@@ -18,4 +18,3 @@ perl -p -i \
 	-e 's,test\s+"\$,test "x\$,;' \
 	-e 's,=\s+"?x?(yes|no|unknown|disable)"?,= x\1,;' \
 	"$FILE"
-

--- a/example/camera/camera.c
+++ b/example/camera/camera.c
@@ -28,7 +28,7 @@ main(int argc, char **argv)
 {
     sc_camera_t *camera = sc_camera_new();
 
-    
+
 
     sc_camera_destroy(camera);
 

--- a/example/openmp/juqueen_job.js
+++ b/example/openmp/juqueen_job.js
@@ -1,6 +1,6 @@
-# This jobscript can be submitted to the juqueen 
+# This jobscript can be submitted to the juqueen
 # job queue via llsubmit [script]
-# Do not forget to put your email adress in the 
+# Do not forget to put your email address in the
 # notify_user field.
 #
 # This script has to be executed within the folder of

--- a/iniparser/dictionary.c
+++ b/iniparser/dictionary.c
@@ -6,7 +6,7 @@
 
    This module implements a simple dictionary object, i.e. a list
    of string/string associations. This object is useful to store e.g.
-   informations retrieved from a configuration file (ini files).
+   information retrieved from a configuration file (ini files).
 */
 /*--------------------------------------------------------------------------*/
 
@@ -107,7 +107,7 @@ unsigned dictionary_hash(const char * key)
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/iniparser/dictionary.h
+++ b/iniparser/dictionary.h
@@ -7,7 +7,7 @@
 
    This module implements a simple dictionary object, i.e. a list
    of string/string associations. This object is useful to store e.g.
-   informations retrieved from a configuration file (ini files).
+   information retrieved from a configuration file (ini files).
 */
 /*--------------------------------------------------------------------------*/
 
@@ -89,7 +89,7 @@ unsigned dictionary_hash(const char * key);
 /**
   @brief    Create a new dictionary object.
   @param    size    Optional initial size of the dictionary.
-  @return   1 newly allocated dictionary objet.
+  @return   1 newly allocated dictionary object.
 
   This function allocates a new dictionary object of given size and returns
   it. If you do not know in advance (roughly) the number of entries in the

--- a/iniparser/iniexample.c
+++ b/iniparser/iniexample.c
@@ -79,18 +79,16 @@ static int parse_ini_file(const char * ini_name)
     printf("Wine:\n");
     s = iniparser_getstring(ini, "wine:grape", NULL);
     printf("Grape:     [%s]\n", s ? s : "UNDEF");
-    
+
     i = iniparser_getint(ini, "wine:year", -1);
     printf("Year:      [%d]\n", i);
 
     s = iniparser_getstring(ini, "wine:country", NULL);
     printf("Country:   [%s]\n", s ? s : "UNDEF");
-    
+
     d = iniparser_getdouble(ini, "wine:alcohol", -1.0);
     printf("Alcohol:   [%g]\n", d);
 
     iniparser_freedict(ini);
     return 0 ;
 }
-
-

--- a/iniparser/iniparser.c
+++ b/iniparser/iniparser.c
@@ -78,9 +78,9 @@ static char * strstrip(const char * s)
 {
     static char l[ASCIILINESZ+1];
     char * last ;
-    
+
     if (s==NULL) return NULL ;
-    
+
     while (isspace((int)*s) && *s) s++;
     memset(l, 0, ASCIILINESZ+1);
     sc3_strcopy (l, ASCIILINESZ + 1, s);
@@ -295,7 +295,7 @@ int iniparser_getsecnkeys(dictionary * d, char * s)
     for (j=0 ; j<d->size ; j++) {
         if (d->key[j]==NULL)
             continue ;
-        if (!strncmp(d->key[j], keym, seclen+1)) 
+        if (!strncmp(d->key[j], keym, seclen+1))
             nkeys++;
     }
 
@@ -313,7 +313,7 @@ int iniparser_getsecnkeys(dictionary * d, char * s)
   This function queries a dictionary and finds all keys in a given section.
   Each pointer in the returned char pointer-to-pointer is pointing to
   a string allocated in the dictionary; do not free or modify them.
-  
+
   This function returns NULL in case of error.
  */
 /*--------------------------------------------------------------------------*/
@@ -337,7 +337,7 @@ char ** iniparser_getseckeys(dictionary * d, char * s)
 
     seclen  = (int)strlen(s);
     sc3_snprintf (keym, ASCIILINESZ + 1, "%s:", s);
-    
+
     i = 0;
 
     for (j=0 ; j<d->size ; j++) {
@@ -563,7 +563,7 @@ static line_status iniparser_line(
     char * section,
     char * key,
     char * value)
-{   
+{
     line_status sta ;
     char        line[ASCIILINESZ+1];
     int         len ;
@@ -577,7 +577,7 @@ static line_status iniparser_line(
         sta = LINE_EMPTY ;
     } else if (line[0]=='#' || line[0]==';') {
         /* Comment line */
-        sta = LINE_COMMENT ; 
+        sta = LINE_COMMENT ;
     } else if (line[0]=='[' && line[len-1]==']') {
         /* Section name */
         sscanf(line, "[%[^]]", section);

--- a/src/sc.c
+++ b/src/sc.c
@@ -1034,7 +1034,7 @@ void
 sc_abort (void)
 {
   sc_default_abort_handler ();
-  abort ();                     /* if the user supplied callback incorrecty returns, abort */
+  abort ();                     /* if the user supplied callback incorrectly returns, abort */
 }
 
 static void

--- a/src/sc.h
+++ b/src/sc.h
@@ -455,7 +455,7 @@ void                SC_CHECK_ABORTF (int success, const char *fmt, ...)
 #define SC_LP_SILENT      9     /**< Never log anything.  Instead suggesting \ref SC_LP_ERROR. */
 /** @} */
 
-/* The default log priority may be overridded by this preprocessor define. */
+/* The default log priority may be overridden by this preprocessor define. */
 #ifdef SC_LOG_PRIORITY
 #define SC_LP_THRESHOLD SC_LOG_PRIORITY
 #define SC_LP_APPLICATION SC_LOG_PRIORITY

--- a/src/sc_builtin/getopt_int.h
+++ b/src/sc_builtin/getopt_int.h
@@ -26,7 +26,7 @@ extern int _getopt_internal (int ___argc, char *const *___argv,
 		             const struct option *__longopts, int *__longind,
 			     int __long_only);
 
-
+
 /* Reentrant versions which can handle parsing multiple argument
    vectors at the same time.  */
 

--- a/src/sc_camera.h
+++ b/src/sc_camera.h
@@ -24,9 +24,9 @@
 #ifndef SC_CAMERA_H
 #define SC_CAMERA_H
 
-/** \file sc_camera.h 
+/** \file sc_camera.h
  * \ingroup sc_camera
- * 
+ *
  *  Camera data structure for computer graphic applications.
  *
  *  The [camera module page](\ref sc_camera) provides a detailed example of
@@ -35,53 +35,53 @@
 
 /** \defgroup sc_camera Camera
  * \ingroup sc
- * 
+ *
  * A camera data structure for maintaining the position, orientation and
  * view frustum of the camera.
- * 
+ *
  * ## Example Workflow: Rendering a point p with sc_camera
- * 
- * 1. **World Space:**  
+ *
+ * 1. **World Space:**
  *    Initially, \b p lies in the right-handed world coordinate system.
- * 
- * 2. **View Transformation:**  
+ *
+ * 2. **View Transformation:**
  *    \b p is transformed into the right-handed view coordinate system.
  *    In this system:
  *    - The camera is at the origin, looking down the negative z-axis.
  *    - The x-axis points to the right, and the y-axis points upwards.
- * 
+ *
  *    Transformation steps:
  *    - Translate p by the camera position.
  *    - Rotate \b p by the camera rotation.
- * 
+ *
  *    The camera rotation is stored as a unit quaternion q = (q_x, q_y, q_z, q_w),
- *    where (q_x, q_y, q_z) are the imaginary parts (i, j, k) and q_w is the 
+ *    where (q_x, q_y, q_z) are the imaginary parts (i, j, k) and q_w is the
  *    real part.
  *
- *    To rotate a point \b p = (p_x, p_y, p_z), treat it as a pure quaternion 
+ *    To rotate a point \b p = (p_x, p_y, p_z), treat it as a pure quaternion
  *    (p_x i + p_y j + p_z k), and compute the conjugation:
  *      p' = q * p * q^{-1}
- * 
+ *
  *    Explicitly:
  *      p' = (q_x i + q_y j + q_z k + q_w) * (p_x i + p_y j + p_z k) * (-q_x i - q_y j - q_z k + q_w)
  *    where quaternion multiplication rules apply (i.e., i^2 = j^2 = k^2 = ijk = -1).
- *    The camera rotation is defined such that it rotates the world space so 
- *    that the camera looks along the negative z-axis. It is the \b inverse of 
- *    the rotation that would align the default camera orientation with the 
+ *    The camera rotation is defined such that it rotates the world space so
+ *    that the camera looks along the negative z-axis. It is the \b inverse of
+ *    the rotation that would align the default camera orientation with the
  *    preferred camera direction.
- * 
+ *
  *    In summary, the view transformation is:
- *    
+ *
  *      p_view = q * (\b p - camera->position) * q^-1
- * 
- * 3. **Projection to Normalized Device Coordinates (NDC):**  
- *    After the view transformation, \b p is projected into normalized device 
+ *
+ * 3. **Projection to Normalized Device Coordinates (NDC):**
+ *    After the view transformation, \b p is projected into normalized device
  *    coordinates (NDC):
- *    - The x- and y-coordinates represent the 2D position of the point in the 
+ *    - The x- and y-coordinates represent the 2D position of the point in the
  *      image.
  *    - The z-coordinate represents depth information, which is used for
  *      visibility and rendering order.
- * 
+ *
  *    The NDC space is left-handed, as in OpenGL:
  *    - The visible region is the cube [-1, 1]^3.
  *    - (x, y) = (-1, -1) is the bottom-left corner of the image.
@@ -90,16 +90,16 @@
  *    - For the z-axis:
  *        - z = -1  corresponds to the near clipping plane (closest to the camera),
  *        - z = 1 corresponds to the far clipping plane (farthest from the camera).
- * 
+ *
  *    The projection is defined by:
- *    - The **horizontal field of view (FOV)**: the opening angle in radians in 
+ *    - The **horizontal field of view (FOV)**: the opening angle in radians in
  *      the x-direction.
- *    - The **aspect ratio**: the ratio of image width to height, which 
+ *    - The **aspect ratio**: the ratio of image width to height, which
  *      determines the vertical field of view.
- *    - The **near** and **far** values: the positive distances from the camera 
+ *    - The **near** and **far** values: the positive distances from the camera
  *      to the near and far clipping planes.
- * 
- *    Points closer than the near plane or farther than the far plane are clipped, 
+ *
+ *    Points closer than the near plane or farther than the far plane are clipped,
  *    meaning they are not mapped inside the visible cube [-1, 1]^3.
  */
 
@@ -129,10 +129,10 @@ typedef sc_camera_coords_t sc_camera_mat4x4_t[16];
 typedef sc_camera_coords_t sc_camera_mat3x3_t[9];
 
 /** Represents a camera with parameters for rendering a 3D scene.
- * 
+ *
  * The sc_camera object stores essential properties of a camera,
- * including its position, rotation, field of view, viewport dimensions, 
- * and clipping planes. These parameters define how the camera projects 
+ * including its position, rotation, field of view, viewport dimensions,
+ * and clipping planes. These parameters define how the camera projects
  * the 3D world onto the 2D image plane.
  *
  */
@@ -142,7 +142,7 @@ typedef struct sc_camera
                              /**< The position of the camera in world coordinates. */
 
   sc_camera_vec4_t    rotation;
-                              /**< Rotation from world space to view space, 
+                              /**< Rotation from world space to view space,
                                *   represented as a unit quaternion. */
 
   double              FOV;
@@ -166,19 +166,19 @@ typedef struct sc_camera
 sc_camera_t        *sc_camera_new ();
 
 /** Initializes a camera with the default parameters.
- * 
- * As default the camera is positioned at (0, 0, 1) and looking at (0, 0, 0) 
+ *
+ * As default the camera is positioned at (0, 0, 1) and looking at (0, 0, 0)
  * with the upwards direction (0, 1, 0). The default horizontal field of view is
  * Pi/2, the image has aspect ratio 1 (width = height) and near is set at 1/100
  * far at 100. The default is realised by the following values.
  * - position : (0, 0, 1)
- * - rotation : (0, 0, 0, 1) 
+ * - rotation : (0, 0, 0, 1)
  * - FOV : Pi / 2 = 1.57079632679
  * - width : 1000
  * - height : 1000
  * - near : 0.01
  * - far : 100.0.
- * 
+ *
  * \param [out] camera Camera that is initialized.
  */
 void                sc_camera_init (sc_camera_t * camera);

--- a/src/sc_io.c
+++ b/src/sc_io.c
@@ -1485,7 +1485,7 @@ sc_io_error_class (int errorcode, int *errorclass)
 
   if (errorcode == 0) {
     /* This is the errno for no error or
-     * possibly also the sc_MPI_SUCESS value.
+     * possibly also the sc_MPI_SUCCESS value.
      * In both cases, we want to set errorclass to
      * sc_MPI_SUCCESS.
      */

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -93,9 +93,9 @@
 #define SC_SCDA_CHECK_VERBOSE_NONCOLL(lp, errcode, msg) SC_SCDA_CHECK_VERBOSE_GEN (\
                                     errcode, msg, SC_LOGF, lp)
 
-/** Collectivly check a given errorcode.
+/** Collectively check a given errorcode.
  * This macro assumes that errcode is a collective
- * variable and that the macro is called collectivly.
+ * variable and that the macro is called collectively.
  * The calling function must return NULL in case of an error.
  */
 #define SC_SCDA_CHECK_COLL_ERR(errcode, fc, user_msg) do {                   \
@@ -395,7 +395,7 @@ sc_scda_pad_to_fix_len_inplace (const char *input_data, size_t input_len,
  * \param [out] raw_len       The length of \b raw_data in number of bytes.
  *                            Undefined if the function returns true.
  * \return                    True if \b padded_data does not satisfy the
- *                            scda padding convention for fixed-length paddding.
+ *                            scda padding convention for fixed-length padding.
  *                            False, otherwise.
  */
 static int
@@ -449,7 +449,7 @@ sc_scda_check_pad_to_fix_len (const char *padded_data, size_t pad_len,
  * \param [out] raw_len       The length of \b raw_data in number of bytes.
  *                            Undefined if the function returns true.
  * \return                    True if \b padded_data does not satisfy the
- *                            scda padding convention for fixed-length paddding.
+ *                            scda padding convention for fixed-length padding.
  *                            False, otherwise.
  */
 static int
@@ -1214,7 +1214,7 @@ sc_scda_params_init (sc_scda_params_t *params)
 #endif
 }
 
-/** This function peforms the start up for both scda fopen functions.
+/** This function performs the start up for both scda fopen functions.
  *
  * \param [in]   params     The sc_scda_params_t structure that is
  *                          passed to the scda fopen function. \b params may be
@@ -1452,7 +1452,7 @@ sc_scda_fopen_write (sc_MPI_Comm mpicomm,
   mpiret =
     sc_io_open (mpicomm, filename, SC_IO_WRITE_CREATE, info, &fc->file);
   sc_scda_mpiret_to_errcode (mpiret, errcode, fc);
-  /* We call a macro for checking an error that occurs collectivly.
+  /* We call a macro for checking an error that occurs collectively.
    * In case of an error the macro prints an error message using \ref
    * SC_GLOBAL_LERRORF, closes the file and frees fc.
    */

--- a/src/sc_scda.h
+++ b/src/sc_scda.h
@@ -54,7 +54,7 @@
  * the process count can differ between writing and reading.
  *
  * The main purpose of \b scda is to enable the user to implement parallel I/O
- * for numerical appliations, e.g. simulation checkpoint/restart.
+ * for numerical applications, e.g. simulation checkpoint/restart.
  *
  * We elaborate further on the workflow in \ref scda_workflow.
  *
@@ -271,7 +271,7 @@ sc_scda_ret_t;
  * The parsing logic of \ref sc_scda_ferror_t is that first \b scdaret is examined
  * and if \b scdaret != \ref SC_SCDA_FERR_MPI, we know that \b mpiret = 0.
  * If \b scdaret = \ref SC_SCDA_FERR_MPI, we know that an MPI error occurred and
- * we can examine \b mpiret for more informartion.
+ * we can examine \b mpiret for more information.
  *
  * Moreover, a valid sc_scda_ferror always satisfy that if \b scdaret = 0 then
  * \b mpiret = 0 and if \b scdaret = \ref SC_SCDA_FERR_MPI then \b mpiret !=0.
@@ -550,7 +550,7 @@ sc_scda_fcontext_t *sc_scda_fwrite_block (sc_scda_fcontext_t * fc,
  * \param [in]      indirect    A Boolean to determine whether \b array_data
  *                              must be a sc_array of sc_arrays to write
  *                              indirectly and in particular from potentially
- *                              non-contigous memory. In the remaining case of
+ *                              non-contiguous memory. In the remaining case of
  *                              \b indirect being false \b array_data must be
  *                              a sc_array with element size equals to
  *                              \b elem_size that contains the actual array
@@ -682,7 +682,7 @@ int                 sc_scda_proc_sizes (sc_array_t * elem_sizes,
  * \param [in]      indirect    A Boolean to determine whether \b array_data
  *                              must be a sc_array of sc_arrays to write
  *                              indirectly and in particular from potentially
- *                              non-contigous memory. In the remaining case of
+ *                              non-contiguous memory. In the remaining case of
  *                              \b indirect being false \b array_data must be
  *                              a sc_array with the actual array elements as
  *                              data as further explained in the documentation
@@ -810,7 +810,7 @@ sc_scda_fcontext_t *sc_scda_fopen_read (sc_MPI_Comm mpicomm,
  *                              true. For \b decode true as input the file
  *                              section is interpreted as a compressed file
  *                              section if the type and user string of the first
- *                              raw file section satisfiy the compression
+ *                              raw file section satisfy the compression
  *                              convention. If the compression convention is not
  *                              satisfied the data is read raw. For false as
  *                              input the data will be read raw by the
@@ -969,7 +969,7 @@ sc_scda_fcontext_t *sc_scda_fread_block_data (sc_scda_fcontext_t * fc,
  * \param [in]      indirect    A Boolean to determine whether \b array_data
  *                              must be a sc_array of sc_arrays to read
  *                              indirectly and in particular to potentially
- *                              non-contigous memory. See the documentation of
+ *                              non-contiguous memory. See the documentation of
  *                              the parameter \b array_data for more information.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class
@@ -1102,7 +1102,7 @@ sc_scda_fcontext_t *sc_scda_fread_varray_sizes (sc_scda_fcontext_t * fc,
  * \param [in]      indirect    A Boolean to determine whether \b array_data
  *                              must be a sc_array of sc_arrays to read
  *                              indirectly and in particular to potentially
- *                              non-contigous memory. See the documentation of
+ *                              non-contiguous memory. See the documentation of
  *                              the parameter \b array_data for more information.
  * \param [out]     errcode     An errcode that can be interpreted by \ref
  *                              sc_scda_ferror_string or mapped to an error class


### PR DESCRIPTION
# Add pre-commit hooks config and fix reported typos

This PR adds configuration files for using `pre-commit`, e.g.
- remove trailing white space, 
- end of file fixer,
- spell checker (typos).

It can be run in command line terminal with `pre-commit run --all-files` (`pre-commit` is available either as a system package in Debian/Ubuntu or from a python package manager) . It could in principle be placed in a CI script, but it sometimes detects false positives (e.g. abbreviated variable names), so it is better to have a human eyes to cross-check.