### PR TITLE
libsc: detect and link libm explicitly for math-using examples

### DIFF
--- a/config/sc_include.m4
+++ b/config/sc_include.m4
@@ -175,7 +175,8 @@ AC_DEFUN([SC_CHECK_MATH],
 [[
 /* make this so complex that the compiler cannot predict the result */
 double a = 3.14149;
-for (; sqrt (a) < a; a *= 1.000023) { putc ('1', stdout); }
+double (*volatile fp)(double) = sqrt;
+for (; fp (a) < a; a *= 1.000023) { putc ('1', stdout); }
 ]], [m],
   [AC_DEFINE([HAVE_MATH], [1], [Define to 1 if sqrt links successfully])],
   [AC_MSG_ERROR([unable to link with sqrt, cos, sin, both as is and with -lm])])

--- a/configure.ac
+++ b/configure.ac
@@ -90,6 +90,12 @@ echo "o---------------------------------------"
 echo "| Checking libraries"
 echo "o---------------------------------------"
 
+dnl Some libsc example programs (e.g. the v4l2 example) use math functions
+dnl such as sin().  On many systems these reside in libm, while on others
+dnl they are provided by libc.  Detect and add the required math library
+dnl explicitly to avoid relying on transitive or toolchain-specific linking.
+AC_SEARCH_LIBS([sin], [m])
+
 SC_CHECK_LIBRARIES([SC])
 
 # Print summary.

--- a/configure.ac
+++ b/configure.ac
@@ -90,12 +90,6 @@ echo "o---------------------------------------"
 echo "| Checking libraries"
 echo "o---------------------------------------"
 
-dnl Some libsc example programs (e.g. the v4l2 example) use math functions
-dnl such as sin().  On many systems these reside in libm, while on others
-dnl they are provided by libc.  Detect and add the required math library
-dnl explicitly to avoid relying on transitive or toolchain-specific linking.
-AC_SEARCH_LIBS([sin], [m])
-
 SC_CHECK_LIBRARIES([SC])
 
 # Print summary.

--- a/doc/author_anselmann.txt
+++ b/doc/author_anselmann.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. Mathias Anselmann


### PR DESCRIPTION
Some libsc example programs (notably the v4l2 example) use math functions such as sin(). On many platforms these reside in libm, but the build system previously relied on implicit or transitive linkage, which is no longer reliable with newer toolchains and linkers.

Problems are reported downstream e.g. [here](https://github.com/spack/spack-packages/issues/1942) and one can see workarounds like adding globally `"-lm" `e.g. [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=p4est-deal-ii#n34).