### PR TITLE
Fix MSVC-specific syntax issues

### DIFF
--- a/example/pthread/pthread.c
+++ b/example/pthread/pthread.c
@@ -21,6 +21,12 @@
   02110-1301, USA.
 */
 
+#ifdef _MSC_VER
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#define sleep Sleep
+#endif
+
 #include <pthread.h>
 #include <sc_options.h>
 

--- a/iniparser/inistring.h
+++ b/iniparser/inistring.h
@@ -36,6 +36,19 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE             /**< Enable additional functionality. */
 #endif
+
+/* ​Platform-specific printf format string checks​​ */
+#ifndef SC_PRINTF_LIKE
+#ifdef _MSC_VER
+#include <sal.h> /* _Printf_format_string_ */
+#define SC_PRINTF_LIKE(fmt_idx, first_arg)
+#define SC_PRINTF_FMT _Printf_format_string_
+#else
+#define SC_PRINTF_LIKE(fmt_idx, first_arg) __attribute__((format(printf, fmt_idx, first_arg)))
+#define SC_PRINTF_FMT
+#endif
+#endif
+
 #include <stdio.h>
 
 #ifdef __cplusplus
@@ -67,8 +80,8 @@ void                ini_strcopy (char *dest, size_t size, const char *src);
  * \param [in] format   Format string as in man (3) snprintf.
  */
 void                ini_snprintf (char *str, size_t size,
-                                  const char *format, ...)
-  __attribute__((format (printf, 3, 4)));
+                                  SC_PRINTF_FMT const char *format, ...)
+  SC_PRINTF_LIKE(3, 4);
 
 #ifdef __cplusplus
 #if 0

--- a/src/sc.h
+++ b/src/sc.h
@@ -127,6 +127,18 @@
 #define __STDC_CONSTANT_MACROS
 #endif
 
+/** ​Platform-specific noreturn and printf format string checks​​ */
+#ifdef _MSC_VER
+#include <sal.h> /* _Printf_format_string_ */
+#define SC_NORETURN __declspec(noreturn)
+#define SC_PRINTF_LIKE(fmt_idx, first_arg)
+#define SC_PRINTF_FMT _Printf_format_string_
+#else
+#define SC_NORETURN __attribute__((noreturn))
+#define SC_PRINTF_LIKE(fmt_idx, first_arg) __attribute__((format(printf, fmt_idx, first_arg)))
+#define SC_PRINTF_FMT
+#endif
+
 /* include MPI before stdio.h */
 
 #ifdef SC_ENABLE_MPI
@@ -286,11 +298,11 @@ extern SC_DLL_PUBLIC int sc_trace_prio;
  * 2. Use macros in C instead of the function
  * This loses __FILE__ and __LINE__ in the C++ ..F log functions
  */
-void                SC_ABORTF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)))
-  __attribute__ ((noreturn));
-void                SC_CHECK_ABORTF (int success, const char *fmt, ...)
-  __attribute__ ((format (printf, 2, 3)));
+SC_NORETURN
+void                SC_ABORTF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_CHECK_ABORTF (int success, SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(2, 3);
 #ifndef __cplusplus
 #define SC_ABORTF(fmt,...)                                      \
   sc_abort_verbosef (__FILE__, __LINE__, (fmt), __VA_ARGS__)
@@ -478,12 +490,12 @@ void                SC_CHECK_ABORTF (int success, const char *fmt, ...)
 #define SC_GLOBAL_LOG(p,s) SC_GEN_LOG (sc_package_id, SC_LC_GLOBAL, (p), (s))
 #define SC_LOG(p,s) SC_GEN_LOG (sc_package_id, SC_LC_NORMAL, (p), (s))
 void                SC_GEN_LOGF (int package, int category, int priority,
-                                 const char *fmt, ...)
-  __attribute__ ((format (printf, 4, 5)));
-void                SC_GLOBAL_LOGF (int priority, const char *fmt, ...)
-  __attribute__ ((format (printf, 2, 3)));
-void                SC_LOGF (int priority, const char *fmt, ...)
-  __attribute__ ((format (printf, 2, 3)));
+                                 SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(4, 5);
+void                SC_GLOBAL_LOGF (int priority, SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(2, 3);
+void                SC_LOGF (int priority, SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(2, 3);
 #ifndef __cplusplus
 #define SC_GEN_LOGF(package,category,priority,fmt,...)                  \
   ((priority) < SC_LP_THRESHOLD ? (void) 0 :                            \
@@ -504,22 +516,22 @@ void                SC_LOGF (int priority, const char *fmt, ...)
 #define SC_GLOBAL_PRODUCTION(s) SC_GLOBAL_LOG (SC_LP_PRODUCTION, (s))
 #define SC_GLOBAL_ESSENTIAL(s) SC_GLOBAL_LOG (SC_LP_ESSENTIAL, (s))
 #define SC_GLOBAL_LERROR(s) SC_GLOBAL_LOG (SC_LP_ERROR, (s))
-void                SC_GLOBAL_TRACEF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_LDEBUGF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_VERBOSEF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_INFOF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_STATISTICSF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
+void                SC_GLOBAL_TRACEF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_LDEBUGF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_VERBOSEF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_INFOF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_STATISTICSF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
 void                SC_GLOBAL_PRODUCTIONF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_ESSENTIALF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_GLOBAL_LERRORF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_ESSENTIALF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_GLOBAL_LERRORF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
 #ifndef __cplusplus
 #define SC_GLOBAL_TRACEF(fmt,...)                       \
   SC_GLOBAL_LOGF (SC_LP_TRACE, (fmt), __VA_ARGS__)
@@ -548,22 +560,22 @@ void                SC_GLOBAL_LERRORF (const char *fmt, ...)
 #define SC_PRODUCTION(s) SC_LOG (SC_LP_PRODUCTION, (s))
 #define SC_ESSENTIAL(s) SC_LOG (SC_LP_ESSENTIAL, (s))
 #define SC_LERROR(s) SC_LOG (SC_LP_ERROR, (s))
-void                SC_TRACEF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_LDEBUGF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_VERBOSEF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_INFOF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_STATISTICSF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_PRODUCTIONF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_ESSENTIALF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
-void                SC_LERRORF (const char *fmt, ...)
-  __attribute__ ((format (printf, 1, 2)));
+void                SC_TRACEF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_LDEBUGF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_VERBOSEF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_INFOF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_STATISTICSF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_PRODUCTIONF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_ESSENTIALF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
+void                SC_LERRORF (SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(1, 2);
 #ifndef __cplusplus
 #define SC_TRACEF(fmt,...)                      \
   SC_LOGF (SC_LP_TRACE, (fmt), __VA_ARGS__)
@@ -676,8 +688,8 @@ void                sc_log (const char *filename, int lineno,
  */
 void                sc_logf (const char *filename, int lineno,
                              int package, int category, int priority,
-                             const char *fmt, ...)
-  __attribute__ ((format (printf, 6, 7)));
+                             SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(6, 7);
 
 /** The vprintf-style log function to be called by all packages.
  * Dispatches the log calls by package and filters by category and priority.
@@ -706,28 +718,28 @@ void                sc_log_indent_push (void);
 void                sc_log_indent_pop (void);
 
 /** Print a stack trace, call the abort handler and then call abort (). */
-void                sc_abort (void)
-  __attribute__ ((noreturn));
+SC_NORETURN
+void                sc_abort (void);
 
 /** Print a message to stderr and then call sc_abort (). */
+SC_NORETURN
 void                sc_abort_verbose (const char *filename, int lineno,
-                                      const char *msg)
-  __attribute__ ((noreturn));
+                                      const char *msg);
 
 /** Print a message to stderr and then call sc_abort (). */
+SC_NORETURN
 void                sc_abort_verbosef (const char *filename, int lineno,
-                                       const char *fmt, ...)
-  __attribute__ ((format (printf, 3, 4)))
-  __attribute__ ((noreturn));
+                                       SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(3, 4);
 
 /** Print a message to stderr and then call sc_abort (). */
+SC_NORETURN
 void                sc_abort_verbosev (const char *filename, int lineno,
-                                       const char *fmt, va_list ap)
-  __attribute__ ((noreturn));
+                                       const char *fmt, va_list ap);
 
 /** Collective abort where only root prints a message */
-void                sc_abort_collective (const char *msg)
-  __attribute__ ((noreturn));
+SC_NORETURN
+void                sc_abort_collective (const char *msg);
 
 /** Register a software package with SC.
  * This function must only be called before additional threads are created.
@@ -888,8 +900,8 @@ void                sc_strcopy (char *dest, size_t size, const char *src);
  * \param [in] format   Format string as in man (3) snprintf.
  */
 void                sc_snprintf (char *str, size_t size,
-                                 const char *format, ...)
-  __attribute__ ((format (printf, 3, 4)));
+                                 SC_PRINTF_FMT const char *format, ...)
+  SC_PRINTF_LIKE(3, 4);
 
 /** Return the full version of libsc.
  *

--- a/src/sc_getopt.c
+++ b/src/sc_getopt.c
@@ -93,7 +93,7 @@ int optopt = '?';
 static struct _getopt_data getopt_data;
 
 
-#ifndef __GNU_LIBRARY__
+#if !defined(__GNU_LIBRARY__) && !defined(_MSC_VER)
 
 /* Avoid depending on library functions or files
    whose names are inconsistent.  */

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -66,6 +66,15 @@
 #ifndef SC_MPI_H
 #define SC_MPI_H
 
+/** ​Platform-specific noreturn */
+#ifndef SC_NORETURN
+#ifdef _MSC_VER
+#define SC_NORETURN __declspec(noreturn)
+#else
+#define SC_NORETURN __attribute__((noreturn))
+#endif
+#endif
+
 /* this works both standalone and when included from sc.h */
 #include <sc_config.h>
 #ifdef SC_ENABLE_MPI
@@ -482,8 +491,8 @@ int                 sc_MPI_Finalize (void);
  * \param [in] mpicomm      Communicator across which to abort.
  * \param [in] ecode        Error code returned to the system.
  */
-int                 sc_MPI_Abort (sc_MPI_Comm mpicomm, int ecode)
-  __attribute__ ((noreturn));
+SC_NORETURN
+int                 sc_MPI_Abort (sc_MPI_Comm mpicomm, int ecode);
 
 /** Duplicate an MPI communicator.
  * \param [in] mpicomm      Communicator to duplicate.

--- a/src/sc_string.h
+++ b/src/sc_string.h
@@ -83,8 +83,8 @@ int                 sc_string_puts (sc_string_t * scs, const char *s);
  * \return                      Zero if everything has been appended and a
  *                              negative value when the input was truncated.
  */
-int                 sc_string_putf (sc_string_t * scs, const char *fmt, ...)
-  __attribute__ ((format (printf, 2, 3)));
+int                 sc_string_putf (sc_string_t * scs, SC_PRINTF_FMT const char *fmt, ...)
+  SC_PRINTF_LIKE(2, 3);
 
 /** Append to the string object using a format string and a vararg pointer.
  * The maximum length will not be exceeded.


### PR DESCRIPTION
# Fix MSVC-specific syntax issues

Following up on issue #232 .

This PR refines the previously proposed platform-independent annotation macros and updates the affected declarations to better cooperate with the existing `scindent` workflow.

Changes since the previous revision:
- Adjusted the placement and formatting of the new macros to avoid confusing GNU indent.
- Verified that `scindent` runs cleanly on the touched headers without warnings or errors.
- No functional changes compared to the earlier version; this update is strictly about formatting robustness and tool compatibility.

The goal remains to provide a unified, portable way to express attributes such as `noreturn` and `printf`-like annotations across compilers, while keeping the resulting code friendly to the current formatting infrastructure.

Please let me know if you would prefer a different placement or style for any of the annotations.