### PR TITLE
Add MPI_Sendrecv

### DIFF
--- a/doc/author_elsweijer.txt
+++ b/doc/author_elsweijer.txt
@@ -1,0 +1,1 @@
+I place my contributions to libsc under the FreeBSD license. Sandro Elsweijer <sandro.elsweijer@dlr.de>

--- a/src/sc_mpi.c
+++ b/src/sc_mpi.c
@@ -461,6 +461,16 @@ sc_MPI_Isend (void *buf, int count, sc_MPI_Datatype datatype, int dest,
 }
 
 int
+sc_MPI_Sendrecv (const void *sendbuf, int sendcount, sc_MPI_Datatype sendtype,
+                 int dest, int sendtag,
+                 void *recvbuf, int recvcount, sc_MPI_Datatype recvtype,
+                 int source, int recvtag, sc_MPI_Comm comm, sc_MPI_Status * status)
+{
+  SC_ABORT ("non-MPI MPI_Sendrecv is not implemented");
+  return sc_MPI_SUCCESS;
+}
+
+int
 sc_MPI_Probe (int source, int tag, sc_MPI_Comm comm, sc_MPI_Status *status)
 {
   SC_ABORT ("non-MPI MPI_Probe is not implemented");

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -318,6 +318,7 @@ sc_MPI_IO_Errorcode_t;
 #define sc_MPI_Irecv               MPI_Irecv
 #define sc_MPI_Send                MPI_Send
 #define sc_MPI_Isend               MPI_Isend
+#define sc_MPI_Sendrecv            MPI_Sendrecv
 #define sc_MPI_Probe               MPI_Probe
 #define sc_MPI_Iprobe              MPI_Iprobe
 #define sc_MPI_Get_count           MPI_Get_count
@@ -673,6 +674,9 @@ int                 sc_MPI_Send (void *, int, sc_MPI_Datatype, int, int,
                                  sc_MPI_Comm);
 int                 sc_MPI_Isend (void *, int, sc_MPI_Datatype, int, int,
                                   sc_MPI_Comm, sc_MPI_Request *);
+int                 sc_MPI_Sendrecv (const void *, int, sc_MPI_Datatype, int,
+                                     int, void *, int, sc_MPI_Datatype, int,
+                                     int, sc_MPI_Comm, sc_MPI_Status *)
 int                 sc_MPI_Probe (int, int, sc_MPI_Comm, sc_MPI_Status *);
 int                 sc_MPI_Iprobe (int, int, sc_MPI_Comm, int *,
                                    sc_MPI_Status *);

--- a/src/sc_mpi.h
+++ b/src/sc_mpi.h
@@ -676,7 +676,7 @@ int                 sc_MPI_Isend (void *, int, sc_MPI_Datatype, int, int,
                                   sc_MPI_Comm, sc_MPI_Request *);
 int                 sc_MPI_Sendrecv (const void *, int, sc_MPI_Datatype, int,
                                      int, void *, int, sc_MPI_Datatype, int,
-                                     int, sc_MPI_Comm, sc_MPI_Status *)
+                                     int, sc_MPI_Comm, sc_MPI_Status *);
 int                 sc_MPI_Probe (int, int, sc_MPI_Comm, sc_MPI_Status *);
 int                 sc_MPI_Iprobe (int, int, sc_MPI_Comm, int *,
                                    sc_MPI_Status *);


### PR DESCRIPTION
# Add MPI_Sendrecv

Proposed changes:
Adds the wrapper functionality around `MPI_Sendrecv`.
Basically, I just copied the structure of `MPI_Send` and `MPI_Recv`.
I don't know if I should create this PR into master or develop, but develop more fitting.
