### PR TITLE
Fix set-but-unused-variable warnings

### DIFF
--- a/src/sc_containers.c
+++ b/src/sc_containers.c
@@ -380,7 +380,10 @@ sc_array_is_equal (sc_array_t * array, sc_array_t * other)
 void
 sc_array_uniq (sc_array_t * array, int (*compar) (const void *, const void *))
 {
-  size_t              incount, dupcount;
+  size_t              incount;
+#ifdef SC_ENABLE_DEBUG
+  size_t              dupcount;
+#endif
   size_t              i, j;
   void               *elem1, *elem2, *temp;
 
@@ -391,14 +394,18 @@ sc_array_uniq (sc_array_t * array, int (*compar) (const void *, const void *))
     return;
   }
 
+#ifdef SC_ENABLE_DEBUG
   dupcount = 0;                 /* count duplicates */
+#endif
   i = 0;                        /* read counter */
   j = 0;                        /* write counter */
   elem1 = sc_array_index (array, 0);
   while (i < incount) {
     elem2 = ((i < incount - 1) ? sc_array_index (array, i + 1) : NULL);
     if (i < incount - 1 && compar (elem1, elem2) == 0) {
+#ifdef SC_ENABLE_DEBUG
       ++dupcount;
+#endif
       ++i;
     }
     else {
@@ -1214,7 +1221,10 @@ static void
 sc_hash_maybe_resize (sc_hash_t * hash)
 {
   size_t              i, j;
-  size_t              new_size, new_count;
+  size_t              new_size;
+#ifdef SC_ENABLE_DEBUG
+  size_t              new_count;
+#endif
   sc_list_t          *old_list, *new_list;
   sc_link_t          *lynk, *temp;
   sc_array_t         *new_slots;
@@ -1246,7 +1256,9 @@ sc_hash_maybe_resize (sc_hash_t * hash)
   }
 
   /* go through the old slots and move data to the new slots */
+#ifdef SC_ENABLE_DEBUG
   new_count = 0;
+#endif
   for (i = 0; i < old_slots->elem_count; ++i) {
     old_list = (sc_list_t *) sc_array_index (old_slots, i);
     lynk = old_list->first;
@@ -1255,7 +1267,9 @@ sc_hash_maybe_resize (sc_hash_t * hash)
       j = hash->hash_fn (lynk->data, hash->user_data) % new_size;
       new_list = (sc_list_t *) sc_array_index (new_slots, j);
       (void) sc_list_prepend (new_list, lynk->data);
+#ifdef SC_ENABLE_DEBUG
       ++new_count;
+#endif
 
       /* remove old list element */
       temp = lynk->next;
@@ -1341,7 +1355,9 @@ void
 sc_hash_truncate (sc_hash_t * hash)
 {
   size_t              i;
+#ifdef SC_ENABLE_DEBUG
   size_t              count;
+#endif
   sc_list_t          *list;
   sc_array_t         *slots = hash->slots;
 
@@ -1356,9 +1372,14 @@ sc_hash_truncate (sc_hash_t * hash)
   }
 
   /* return all list elements to the outside memory allocator */
-  for (i = 0, count = 0; i < slots->elem_count; ++i) {
+#ifdef SC_ENABLE_DEBUG
+  count = 0;
+#endif
+  for (i = 0; i < slots->elem_count; ++i) {
     list = (sc_list_t *) sc_array_index (slots, i);
+#ifdef SC_ENABLE_DEBUG
     count += list->elem_count;
+#endif
     sc_list_reset (list);
   }
   SC_ASSERT (count == hash->elem_count);
@@ -1369,13 +1390,21 @@ sc_hash_truncate (sc_hash_t * hash)
 void
 sc_hash_unlink (sc_hash_t * hash)
 {
-  size_t              i, count;
+  size_t              i;
+#ifdef SC_ENABLE_DEBUG
+  size_t              count;
+#endif
   sc_list_t          *list;
   sc_array_t         *slots = hash->slots;
 
-  for (i = 0, count = 0; i < slots->elem_count; ++i) {
+#ifdef SC_ENABLE_DEBUG
+  count = 0;
+#endif
+  for (i = 0; i < slots->elem_count; ++i) {
     list = (sc_list_t *) sc_array_index (slots, i);
+#ifdef SC_ENABLE_DEBUG
     count += list->elem_count;
+#endif
     sc_list_unlink (list);
   }
   SC_ASSERT (count == hash->elem_count);

--- a/src/sc_notify.c
+++ b/src/sc_notify.c
@@ -1209,7 +1209,10 @@ sc_notify_recursive_nary (const sc_notify_nary_t * nary, int level,
   int                 lengthn;
   int                 mypart, topart, hipart;
   int                 remaining;
-  int                 nsent, nrecv;
+#ifdef SC_ENABLE_DEBUG
+  int                 nsent;
+#endif
+  int                 nrecv;
   int                 expon, power;
   int                 itemlen;
   sc_array_t          sendbufs, recvbufs;
@@ -1272,7 +1275,9 @@ sc_notify_recursive_nary (const sc_notify_nary_t * nary, int level,
     sc_array_init_count (&recvbufs, sizeof (sc_array_t), nrecv + 1);
 
     /* prepare send buffers */
+#ifdef SC_ENABLE_DEBUG
     nsent = 0;
+#endif
     sc_array_init_count (&sendbufs, sizeof (sc_array_t), divn);
     sc_array_init_count (&sendreqs, sizeof (sc_MPI_Request), divn);
     for (j = 0; j < divn; ++j) {
@@ -1304,7 +1309,9 @@ sc_notify_recursive_nary (const sc_notify_nary_t * nary, int level,
         continue;
       }
 
+#ifdef SC_ENABLE_DEBUG
       ++nsent;
+#endif
     }
     SC_ASSERT (nsent < divn);
 

--- a/src/sc_scda.c
+++ b/src/sc_scda.c
@@ -1521,7 +1521,9 @@ sc_scda_fwrite_inline_header_serial (sc_scda_fcontext_t *fc,
 {
   int                 mpiret;
   int                 count;
+#ifdef SC_ENABLE_DEBUG
   int                 current_len;
+#endif
   int                 invalid_user_string;
   char                header_data[SC_SCDA_COMMON_FIELD];
 
@@ -1530,7 +1532,9 @@ sc_scda_fwrite_inline_header_serial (sc_scda_fcontext_t *fc,
   /* get inline file section header */
 
   /* section-identifying character */
+#ifdef SC_ENABLE_DEBUG
   current_len = 0;
+#endif
 
   invalid_user_string =
     sc_scda_get_common_section_header ('I', user_string, len, header_data);
@@ -1541,7 +1545,9 @@ sc_scda_fwrite_inline_header_serial (sc_scda_fcontext_t *fc,
                               SC_SCDA_FERR_SUCCESS, errcode, fc);
   SC_SCDA_CHECK_NONCOLL_ERR (fc->log_level, errcode, "Invalid user string");
 
+#ifdef SC_ENABLE_DEBUG
   current_len += SC_SCDA_COMMON_FIELD;
+#endif
 
   SC_ASSERT (current_len == SC_SCDA_COMMON_FIELD);
 


### PR DESCRIPTION
# Fix set-but-unused-variable warnings

Proposed changes:
This PR addresses a recent issue in the p4est CI (https://github.com/cburstedde/p4est/actions/runs/26040411092/job/76567611984). There were some set-but-unused-variable warnings for variables that are only used in assertions. This PR removes the warnings by enclosing the variables in an `#ifdef P4EST_ENABLE_DEBUG`.